### PR TITLE
Remove defunct V8 external startup data stuff

### DIFF
--- a/NativeScript/v8runtime/V8Runtime.h
+++ b/NativeScript/v8runtime/V8Runtime.h
@@ -205,7 +205,6 @@ class V8Runtime : public facebook::jsi::Runtime {
 
  private:
   std::unique_ptr<v8::ArrayBuffer::Allocator> arrayBufferAllocator_;
-  std::unique_ptr<v8::StartupData> snapshotBlob_;
   v8::Isolate *isolate_;
   v8::Global<v8::Context> context_;
   bool isSharedRuntime_ = false;

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ git submodule update --init
 # Ensure that you have the required llvm binaries for building the metadata generator
 ./download_llvm.sh
 
+sudo gem install xcodeproj
+sudo gem install cocoapods
+
 # Open the runtime in Xcode
 open v8ios.xcodeproj
 ```

--- a/v8ios.xcodeproj/project.pbxproj
+++ b/v8ios.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		2B7EA6AF2353477000E5184E /* NativeScriptException.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EA6AD2353476F00E5184E /* NativeScriptException.mm */; };
 		2B7EA6B02353477000E5184E /* NativeScriptException.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7EA6AE2353477000E5184E /* NativeScriptException.h */; };
-		2C998AC1290FB501002BBFA9 /* SnapshotBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C998AC0290FB500002BBFA9 /* SnapshotBlob.h */; };
 		3CA6E53529A78C6000D30F8B /* IsolateWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */; };
 		3CBFF7442971C1C200C5DE36 /* ArcMacro.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CBFF7432971C1C200C5DE36 /* ArcMacro.h */; };
 		3CD1D9C129AA2C14004C1C21 /* DisposerPHV.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CD1D9BF29AA2C14004C1C21 /* DisposerPHV.mm */; };
@@ -418,7 +417,6 @@
 /* Begin PBXFileReference section */
 		2B7EA6AD2353476F00E5184E /* NativeScriptException.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NativeScriptException.mm; sourceTree = "<group>"; };
 		2B7EA6AE2353477000E5184E /* NativeScriptException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeScriptException.h; sourceTree = "<group>"; };
-		2C998AC0290FB500002BBFA9 /* SnapshotBlob.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SnapshotBlob.h; sourceTree = "<group>"; };
 		3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolateWrapper.h; sourceTree = "<group>"; };
 		3CBFF7432971C1C200C5DE36 /* ArcMacro.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArcMacro.h; sourceTree = "<group>"; };
 		3CD1D9BF29AA2C14004C1C21 /* DisposerPHV.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisposerPHV.mm; sourceTree = "<group>"; };
@@ -1407,7 +1405,6 @@
 				C275F475253B37AB00A997D5 /* UnmanagedType.mm */,
 				3CEF9CCC28F896B70056BA45 /* SpinLock.h */,
 				3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */,
-				2C998AC0290FB500002BBFA9 /* SnapshotBlob.h */,
 			);
 			path = runtime;
 			sourceTree = "<group>";
@@ -1498,7 +1495,6 @@
 				C2D7E9D523F42C1100DB289C /* PromiseProxy.h in Headers */,
 				C2A5F86B2359AEB600074AFA /* ExtVector.h in Headers */,
 				C2DDEBB0229EAC8300345BFE /* StringHasher.h in Headers */,
-				2C998AC1290FB501002BBFA9 /* SnapshotBlob.h in Headers */,
 				C247C16A22F82842001D2CA2 /* v8-profiler.h in Headers */,
 				C2DDEB8E229EAC8300345BFE /* Interop.h in Headers */,
 				C2DDEBA2229EAC8300345BFE /* Console.h in Headers */,


### PR DESCRIPTION
- Removes a couple of leftovers from using external startup data, which is no longer supported as per NativeScript/NativeScript#8926. No need to update V8 libraries as they are already built for iOS with `v8_use_external_startup_data=false`.
- Readme improvement that I had sitting around on my local checkout.