### PR TITLE
feat: use node logic for globals and modules

### DIFF
--- a/NativeScript/runtime/Caches.h
+++ b/NativeScript/runtime/Caches.h
@@ -48,6 +48,8 @@ public:
 
     Caches(v8::Isolate* isolate, const int& isolateId_ = -1);
     ~Caches();
+    
+    bool isWorker = false;
 
     static std::shared_ptr<ConcurrentMap<std::string, const Meta*>> Metadata;
     static std::shared_ptr<ConcurrentMap<int, std::shared_ptr<Caches::WorkerState>>> Workers;

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -243,6 +243,7 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
 v8::Local<v8::FunctionTemplate> NewFunctionTemplate(
                                                     v8::Isolate* isolate,
                                                     v8::FunctionCallback callback,
+                                                    v8::Local<v8::Value> data = v8::Local<v8::Value>(),
                                                     v8::Local<v8::Signature> signature = v8::Local<v8::Signature>(),
                                                     v8::ConstructorBehavior behavior = v8::ConstructorBehavior::kAllow,
                                                     v8::SideEffectType side_effect = v8::SideEffectType::kHasSideEffect,
@@ -251,53 +252,64 @@ v8::Local<v8::FunctionTemplate> NewFunctionTemplate(
 void SetMethod(v8::Local<v8::Context> context,
                v8::Local<v8::Object> that,
                const char* name,
-               v8::FunctionCallback callback);
+               v8::FunctionCallback callback,
+               v8::Local<v8::Value> data = v8::Local<v8::Value>());
 // Similar to SetProtoMethod but without receiver signature checks.
 void SetMethod(v8::Isolate* isolate,
                v8::Local<v8::Template> that,
                const char* name,
-               v8::FunctionCallback callback);
+               v8::FunctionCallback callback,
+               v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetFastMethod(v8::Isolate* isolate,
                    v8::Local<v8::Template> that,
                    const char* name,
                    v8::FunctionCallback slow_callback,
-                   const v8::CFunction* c_function);
+                   const v8::CFunction* c_function,
+                   v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetFastMethod(v8::Local<v8::Context> context,
                    v8::Local<v8::Object> that,
                    const char* name,
                    v8::FunctionCallback slow_callback,
-                   const v8::CFunction* c_function);
+                   const v8::CFunction* c_function,
+                   v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetFastMethodNoSideEffect(v8::Isolate* isolate,
                                v8::Local<v8::Template> that,
                                const char* name,
                                v8::FunctionCallback slow_callback,
-                               const v8::CFunction* c_function);
+                               const v8::CFunction* c_function,
+                               v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetFastMethodNoSideEffect(v8::Local<v8::Context> context,
                                v8::Local<v8::Object> that,
                                const char* name,
                                v8::FunctionCallback slow_callback,
-                               const v8::CFunction* c_function);
+                               const v8::CFunction* c_function,
+                               v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetProtoMethod(v8::Isolate* isolate,
                     v8::Local<v8::FunctionTemplate> that,
                     const char* name,
-                    v8::FunctionCallback callback);
+                    v8::FunctionCallback callback,
+                    v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetInstanceMethod(v8::Isolate* isolate,
                        v8::Local<v8::FunctionTemplate> that,
                        const char* name,
-                       v8::FunctionCallback callback);
+                       v8::FunctionCallback callback,
+                       v8::Local<v8::Value> data = v8::Local<v8::Value>());
 // Safe variants denote the function has no side effects.
 void SetMethodNoSideEffect(v8::Local<v8::Context> context,
                            v8::Local<v8::Object> that,
                            const char* name,
-                           v8::FunctionCallback callback);
+                           v8::FunctionCallback callback,
+                           v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetProtoMethodNoSideEffect(v8::Isolate* isolate,
                                 v8::Local<v8::FunctionTemplate> that,
                                 const char* name,
-                                v8::FunctionCallback callback);
+                                v8::FunctionCallback callback,
+                                v8::Local<v8::Value> data = v8::Local<v8::Value>());
 void SetMethodNoSideEffect(v8::Isolate* isolate,
                            v8::Local<v8::Template> that,
                            const char* name,
-                           v8::FunctionCallback callback);
+                           v8::FunctionCallback callback,
+                           v8::Local<v8::Value> data = v8::Local<v8::Value>());
 enum class SetConstructorFunctionFlag {
     NONE,
     SET_CLASS_NAME,

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -198,6 +198,136 @@ void Assert(bool condition, v8::Isolate* isolate = nullptr, std::string const &r
 
 void StopExecutionAndLogStackTrace(v8::Isolate* isolate);
 
+
+
+
+// Helpers from Node
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const char* data,
+                                           int length) {
+    return v8::String::NewFromOneByte(isolate,
+                                      reinterpret_cast<const uint8_t*>(data),
+                                      v8::NewStringType::kNormal,
+                                      length).ToLocalChecked();
+}
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const signed char* data,
+                                           int length) {
+    return v8::String::NewFromOneByte(isolate,
+                                      reinterpret_cast<const uint8_t*>(data),
+                                      v8::NewStringType::kNormal,
+                                      length).ToLocalChecked();
+}
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const unsigned char* data,
+                                           int length) {
+    return v8::String::NewFromOneByte(
+                                      isolate, data, v8::NewStringType::kNormal, length)
+    .ToLocalChecked();
+}
+
+// Convenience wrapper around v8::String::NewFromOneByte().
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const char* data,
+                                           int length = -1);
+// For the people that compile with -funsigned-char.
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const signed char* data,
+                                           int length = -1);
+inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
+                                           const unsigned char* data,
+                                           int length = -1);
+
+
+
+v8::Local<v8::FunctionTemplate> NewFunctionTemplate(
+                                                    v8::Isolate* isolate,
+                                                    v8::FunctionCallback callback,
+                                                    v8::Local<v8::Signature> signature = v8::Local<v8::Signature>(),
+                                                    v8::ConstructorBehavior behavior = v8::ConstructorBehavior::kAllow,
+                                                    v8::SideEffectType side_effect = v8::SideEffectType::kHasSideEffect,
+                                                    const v8::CFunction* c_function = nullptr);
+// Convenience methods for NewFunctionTemplate().
+void SetMethod(v8::Local<v8::Context> context,
+               v8::Local<v8::Object> that,
+               const char* name,
+               v8::FunctionCallback callback);
+// Similar to SetProtoMethod but without receiver signature checks.
+void SetMethod(v8::Isolate* isolate,
+               v8::Local<v8::Template> that,
+               const char* name,
+               v8::FunctionCallback callback);
+void SetFastMethod(v8::Isolate* isolate,
+                   v8::Local<v8::Template> that,
+                   const char* name,
+                   v8::FunctionCallback slow_callback,
+                   const v8::CFunction* c_function);
+void SetFastMethod(v8::Local<v8::Context> context,
+                   v8::Local<v8::Object> that,
+                   const char* name,
+                   v8::FunctionCallback slow_callback,
+                   const v8::CFunction* c_function);
+void SetFastMethodNoSideEffect(v8::Isolate* isolate,
+                               v8::Local<v8::Template> that,
+                               const char* name,
+                               v8::FunctionCallback slow_callback,
+                               const v8::CFunction* c_function);
+void SetFastMethodNoSideEffect(v8::Local<v8::Context> context,
+                               v8::Local<v8::Object> that,
+                               const char* name,
+                               v8::FunctionCallback slow_callback,
+                               const v8::CFunction* c_function);
+void SetProtoMethod(v8::Isolate* isolate,
+                    v8::Local<v8::FunctionTemplate> that,
+                    const char* name,
+                    v8::FunctionCallback callback);
+void SetInstanceMethod(v8::Isolate* isolate,
+                       v8::Local<v8::FunctionTemplate> that,
+                       const char* name,
+                       v8::FunctionCallback callback);
+// Safe variants denote the function has no side effects.
+void SetMethodNoSideEffect(v8::Local<v8::Context> context,
+                           v8::Local<v8::Object> that,
+                           const char* name,
+                           v8::FunctionCallback callback);
+void SetProtoMethodNoSideEffect(v8::Isolate* isolate,
+                                v8::Local<v8::FunctionTemplate> that,
+                                const char* name,
+                                v8::FunctionCallback callback);
+void SetMethodNoSideEffect(v8::Isolate* isolate,
+                           v8::Local<v8::Template> that,
+                           const char* name,
+                           v8::FunctionCallback callback);
+enum class SetConstructorFunctionFlag {
+    NONE,
+    SET_CLASS_NAME,
+};
+void SetConstructorFunction(v8::Local<v8::Context> context,
+                            v8::Local<v8::Object> that,
+                            const char* name,
+                            v8::Local<v8::FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag =
+                            SetConstructorFunctionFlag::SET_CLASS_NAME);
+void SetConstructorFunction(v8::Local<v8::Context> context,
+                            v8::Local<v8::Object> that,
+                            v8::Local<v8::String> name,
+                            v8::Local<v8::FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag =
+                            SetConstructorFunctionFlag::SET_CLASS_NAME);
+void SetConstructorFunction(v8::Isolate* isolate,
+                            v8::Local<v8::Template> that,
+                            const char* name,
+                            v8::Local<v8::FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag =
+                            SetConstructorFunctionFlag::SET_CLASS_NAME);
+void SetConstructorFunction(v8::Isolate* isolate,
+                            v8::Local<v8::Template> that,
+                            v8::Local<v8::String> name,
+                            v8::Local<v8::FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag =
+                            SetConstructorFunctionFlag::SET_CLASS_NAME);
+
+
 }
 
 #endif /* Helpers_h */

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -679,3 +679,260 @@ void tns::Assert(bool condition, Isolate* isolate, std::string const &reason) {
 void tns::StopExecutionAndLogStackTrace(v8::Isolate* isolate) {
     Assert(false, isolate);
 }
+
+
+namespace tns {
+Local<v8::FunctionTemplate> NewFunctionTemplate(
+                                                v8::Isolate* isolate,
+                                                v8::FunctionCallback callback,
+                                                Local<v8::Signature> signature,
+                                                v8::ConstructorBehavior behavior,
+                                                v8::SideEffectType side_effect_type,
+                                                const v8::CFunction* c_function) {
+    return v8::FunctionTemplate::New(isolate,
+                                     callback,
+                                     Local<v8::Value>(),
+                                     signature,
+                                     0,
+                                     behavior,
+                                     side_effect_type,
+                                     c_function);
+}
+void SetMethod(Local<v8::Context> context,
+               Local<v8::Object> that,
+               const char* name,
+               v8::FunctionCallback callback) {
+    Isolate* isolate = context->GetIsolate();
+    Local<v8::Function> function =
+    NewFunctionTemplate(isolate,
+                        callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasSideEffect)
+    ->GetFunction(context)
+        .ToLocalChecked();
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(context, name_string, function).Check();
+    function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
+}
+void SetMethod(v8::Isolate* isolate,
+               v8::Local<v8::Template> that,
+               const char* name,
+               v8::FunctionCallback callback) {
+    Local<v8::FunctionTemplate> t =
+    NewFunctionTemplate(isolate,
+                        callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasSideEffect);
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(name_string, t);
+}
+void SetFastMethod(Isolate* isolate,
+                   Local<Template> that,
+                   const char* name,
+                   v8::FunctionCallback slow_callback,
+                   const v8::CFunction* c_function) {
+    Local<v8::FunctionTemplate> t =
+    NewFunctionTemplate(isolate,
+                        slow_callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasSideEffect,
+                        c_function);
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(name_string, t);
+}
+void SetFastMethod(Local<v8::Context> context,
+                   Local<v8::Object> that,
+                   const char* name,
+                   v8::FunctionCallback slow_callback,
+                   const v8::CFunction* c_function) {
+    Isolate* isolate = context->GetIsolate();
+    Local<v8::Function> function =
+    NewFunctionTemplate(isolate,
+                        slow_callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasSideEffect,
+                        c_function)
+    ->GetFunction(context)
+        .ToLocalChecked();
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(context, name_string, function).Check();
+}
+void SetFastMethodNoSideEffect(Local<v8::Context> context,
+                               Local<v8::Object> that,
+                               const char* name,
+                               v8::FunctionCallback slow_callback,
+                               const v8::CFunction* c_function) {
+    Isolate* isolate = context->GetIsolate();
+    Local<v8::Function> function =
+    NewFunctionTemplate(isolate,
+                        slow_callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasNoSideEffect,
+                        c_function)
+    ->GetFunction(context)
+        .ToLocalChecked();
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(context, name_string, function).Check();
+}
+void SetFastMethodNoSideEffect(Isolate* isolate,
+                               Local<Template> that,
+                               const char* name,
+                               v8::FunctionCallback slow_callback,
+                               const v8::CFunction* c_function) {
+    Local<v8::FunctionTemplate> t =
+    NewFunctionTemplate(isolate,
+                        slow_callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasNoSideEffect,
+                        c_function);
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(name_string, t);
+}
+void SetMethodNoSideEffect(Local<v8::Context> context,
+                           Local<v8::Object> that,
+                           const char* name,
+                           v8::FunctionCallback callback) {
+    Isolate* isolate = context->GetIsolate();
+    Local<v8::Function> function =
+    NewFunctionTemplate(isolate,
+                        callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasNoSideEffect)
+    ->GetFunction(context)
+        .ToLocalChecked();
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(context, name_string, function).Check();
+    function->SetName(name_string);  // NODE_SET_METHOD() compatibility.
+}
+void SetMethodNoSideEffect(Isolate* isolate,
+                           Local<v8::Template> that,
+                           const char* name,
+                           v8::FunctionCallback callback) {
+    Local<v8::FunctionTemplate> t =
+    NewFunctionTemplate(isolate,
+                        callback,
+                        Local<v8::Signature>(),
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasNoSideEffect);
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->Set(name_string, t);
+}
+void SetProtoMethod(v8::Isolate* isolate,
+                    Local<v8::FunctionTemplate> that,
+                    const char* name,
+                    v8::FunctionCallback callback) {
+    Local<v8::Signature> signature = v8::Signature::New(isolate, that);
+    Local<v8::FunctionTemplate> t =
+    NewFunctionTemplate(isolate,
+                        callback,
+                        signature,
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasSideEffect);
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->PrototypeTemplate()->Set(name_string, t);
+    t->SetClassName(name_string);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
+}
+void SetProtoMethodNoSideEffect(v8::Isolate* isolate,
+                                Local<v8::FunctionTemplate> that,
+                                const char* name,
+                                v8::FunctionCallback callback) {
+    Local<v8::Signature> signature = v8::Signature::New(isolate, that);
+    Local<v8::FunctionTemplate> t =
+    NewFunctionTemplate(isolate,
+                        callback,
+                        signature,
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasNoSideEffect);
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->PrototypeTemplate()->Set(name_string, t);
+    t->SetClassName(name_string);  // NODE_SET_PROTOTYPE_METHOD() compatibility.
+}
+void SetInstanceMethod(v8::Isolate* isolate,
+                       Local<v8::FunctionTemplate> that,
+                       const char* name,
+                       v8::FunctionCallback callback) {
+    Local<v8::Signature> signature = v8::Signature::New(isolate, that);
+    Local<v8::FunctionTemplate> t =
+    NewFunctionTemplate(isolate,
+                        callback,
+                        signature,
+                        v8::ConstructorBehavior::kThrow,
+                        v8::SideEffectType::kHasSideEffect);
+    // kInternalized strings are created in the old space.
+    const v8::NewStringType type = v8::NewStringType::kInternalized;
+    Local<v8::String> name_string =
+    v8::String::NewFromUtf8(isolate, name, type).ToLocalChecked();
+    that->InstanceTemplate()->Set(name_string, t);
+    t->SetClassName(name_string);
+}
+void SetConstructorFunction(Local<v8::Context> context,
+                            Local<v8::Object> that,
+                            const char* name,
+                            Local<v8::FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag) {
+    Isolate* isolate = context->GetIsolate();
+    SetConstructorFunction(
+                           context, that, tns::OneByteString(isolate, name), tmpl, flag);
+}
+void SetConstructorFunction(Local<Context> context,
+                            Local<Object> that,
+                            Local<v8::String> name,
+                            Local<FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag) {
+    if (flag == SetConstructorFunctionFlag::SET_CLASS_NAME)
+        tmpl->SetClassName(name);
+    that->Set(context, name, tmpl->GetFunction(context).ToLocalChecked()).Check();
+}
+void SetConstructorFunction(Isolate* isolate,
+                            Local<Template> that,
+                            const char* name,
+                            Local<FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag) {
+    SetConstructorFunction(
+                           isolate, that, OneByteString(isolate, name), tmpl, flag);
+}
+void SetConstructorFunction(Isolate* isolate,
+                            Local<Template> that,
+                            Local<v8::String> name,
+                            Local<FunctionTemplate> tmpl,
+                            SetConstructorFunctionFlag flag) {
+    if (flag == SetConstructorFunctionFlag::SET_CLASS_NAME)
+        tmpl->SetClassName(name);
+    that->Set(name, tmpl);
+}
+};

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -685,13 +685,14 @@ namespace tns {
 Local<v8::FunctionTemplate> NewFunctionTemplate(
                                                 v8::Isolate* isolate,
                                                 v8::FunctionCallback callback,
+                                                Local<v8::Value> data,
                                                 Local<v8::Signature> signature,
                                                 v8::ConstructorBehavior behavior,
                                                 v8::SideEffectType side_effect_type,
                                                 const v8::CFunction* c_function) {
     return v8::FunctionTemplate::New(isolate,
                                      callback,
-                                     Local<v8::Value>(),
+                                     data,
                                      signature,
                                      0,
                                      behavior,
@@ -701,11 +702,13 @@ Local<v8::FunctionTemplate> NewFunctionTemplate(
 void SetMethod(Local<v8::Context> context,
                Local<v8::Object> that,
                const char* name,
-               v8::FunctionCallback callback) {
+               v8::FunctionCallback callback,
+               Local<v8::Value> data) {
     Isolate* isolate = context->GetIsolate();
     Local<v8::Function> function =
     NewFunctionTemplate(isolate,
                         callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasSideEffect)
@@ -721,10 +724,12 @@ void SetMethod(Local<v8::Context> context,
 void SetMethod(v8::Isolate* isolate,
                v8::Local<v8::Template> that,
                const char* name,
-               v8::FunctionCallback callback) {
+               v8::FunctionCallback callback,
+               Local<v8::Value> data) {
     Local<v8::FunctionTemplate> t =
     NewFunctionTemplate(isolate,
                         callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasSideEffect);
@@ -738,10 +743,12 @@ void SetFastMethod(Isolate* isolate,
                    Local<Template> that,
                    const char* name,
                    v8::FunctionCallback slow_callback,
-                   const v8::CFunction* c_function) {
+                   const v8::CFunction* c_function,
+                   Local<v8::Value> data) {
     Local<v8::FunctionTemplate> t =
     NewFunctionTemplate(isolate,
                         slow_callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasSideEffect,
@@ -756,11 +763,13 @@ void SetFastMethod(Local<v8::Context> context,
                    Local<v8::Object> that,
                    const char* name,
                    v8::FunctionCallback slow_callback,
-                   const v8::CFunction* c_function) {
+                   const v8::CFunction* c_function,
+                   Local<v8::Value> data) {
     Isolate* isolate = context->GetIsolate();
     Local<v8::Function> function =
     NewFunctionTemplate(isolate,
                         slow_callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasSideEffect,
@@ -776,11 +785,13 @@ void SetFastMethodNoSideEffect(Local<v8::Context> context,
                                Local<v8::Object> that,
                                const char* name,
                                v8::FunctionCallback slow_callback,
-                               const v8::CFunction* c_function) {
+                               const v8::CFunction* c_function,
+                               Local<v8::Value> data) {
     Isolate* isolate = context->GetIsolate();
     Local<v8::Function> function =
     NewFunctionTemplate(isolate,
                         slow_callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasNoSideEffect,
@@ -796,10 +807,12 @@ void SetFastMethodNoSideEffect(Isolate* isolate,
                                Local<Template> that,
                                const char* name,
                                v8::FunctionCallback slow_callback,
-                               const v8::CFunction* c_function) {
+                               const v8::CFunction* c_function,
+                               Local<v8::Value> data) {
     Local<v8::FunctionTemplate> t =
     NewFunctionTemplate(isolate,
                         slow_callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasNoSideEffect,
@@ -813,11 +826,13 @@ void SetFastMethodNoSideEffect(Isolate* isolate,
 void SetMethodNoSideEffect(Local<v8::Context> context,
                            Local<v8::Object> that,
                            const char* name,
-                           v8::FunctionCallback callback) {
+                           v8::FunctionCallback callback,
+                           Local<v8::Value> data) {
     Isolate* isolate = context->GetIsolate();
     Local<v8::Function> function =
     NewFunctionTemplate(isolate,
                         callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasNoSideEffect)
@@ -833,10 +848,12 @@ void SetMethodNoSideEffect(Local<v8::Context> context,
 void SetMethodNoSideEffect(Isolate* isolate,
                            Local<v8::Template> that,
                            const char* name,
-                           v8::FunctionCallback callback) {
+                           v8::FunctionCallback callback,
+                           Local<v8::Value> data) {
     Local<v8::FunctionTemplate> t =
     NewFunctionTemplate(isolate,
                         callback,
+                        data,
                         Local<v8::Signature>(),
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasNoSideEffect);
@@ -849,11 +866,13 @@ void SetMethodNoSideEffect(Isolate* isolate,
 void SetProtoMethod(v8::Isolate* isolate,
                     Local<v8::FunctionTemplate> that,
                     const char* name,
-                    v8::FunctionCallback callback) {
+                    v8::FunctionCallback callback,
+                    Local<v8::Value> data) {
     Local<v8::Signature> signature = v8::Signature::New(isolate, that);
     Local<v8::FunctionTemplate> t =
     NewFunctionTemplate(isolate,
                         callback,
+                        data,
                         signature,
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasSideEffect);
@@ -867,11 +886,13 @@ void SetProtoMethod(v8::Isolate* isolate,
 void SetProtoMethodNoSideEffect(v8::Isolate* isolate,
                                 Local<v8::FunctionTemplate> that,
                                 const char* name,
-                                v8::FunctionCallback callback) {
+                                v8::FunctionCallback callback,
+                                Local<v8::Value> data) {
     Local<v8::Signature> signature = v8::Signature::New(isolate, that);
     Local<v8::FunctionTemplate> t =
     NewFunctionTemplate(isolate,
                         callback,
+                        data,
                         signature,
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasNoSideEffect);
@@ -885,11 +906,13 @@ void SetProtoMethodNoSideEffect(v8::Isolate* isolate,
 void SetInstanceMethod(v8::Isolate* isolate,
                        Local<v8::FunctionTemplate> that,
                        const char* name,
-                       v8::FunctionCallback callback) {
+                       v8::FunctionCallback callback,
+                       Local<v8::Value> data) {
     Local<v8::Signature> signature = v8::Signature::New(isolate, that);
     Local<v8::FunctionTemplate> t =
     NewFunctionTemplate(isolate,
                         callback,
+                        data,
                         signature,
                         v8::ConstructorBehavior::kThrow,
                         v8::SideEffectType::kHasSideEffect);

--- a/NativeScript/runtime/ModuleBinding.cpp
+++ b/NativeScript/runtime/ModuleBinding.cpp
@@ -1,0 +1,101 @@
+//
+//  ModuleBinding.cpp
+//  NativeScript
+//
+//  Created by Eduardo Speroni on 5/11/23.
+//  Copyright © 2023 Progress. All rights reserved.
+//
+
+#include "ModuleBinding.hpp"
+
+// TODO: add here
+//#define NSC_BUILTIN_STANDARD_BINDINGS(V)                                      \
+//V(fs)
+
+#define NSC_BUILTIN_STANDARD_BINDINGS(V)
+
+
+#define NSC_BUILTIN_BINDINGS(V)                                               \
+NSC_BUILTIN_STANDARD_BINDINGS(V)
+
+// This is used to load built-in bindings. Instead of using
+// __attribute__((constructor)), we call the _register_<modname>
+// function for each built-in bindings explicitly in
+// binding::RegisterBuiltinBindings(). This is only forward declaration.
+// The definitions are in each binding's implementation when calling
+// the NODE_BINDING_CONTEXT_AWARE_INTERNAL.
+#define V(modname) void _register_##modname();
+NSC_BUILTIN_BINDINGS(V)
+#undef V
+
+
+
+
+#define V(modname)                                                             \
+  void _register_isolate_##modname(v8::Isolate* isolate,            \
+                                   v8::Local<v8::FunctionTemplate> target);
+NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
+#undef V
+
+
+
+using v8::Context;
+using v8::EscapableHandleScope;
+using v8::Exception;
+using v8::FunctionCallbackInfo;
+using v8::FunctionTemplate;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::String;
+using v8::Value;
+
+namespace tns {
+// Globals per process
+static ns_module* modlist_internal;
+static ns_module* modlist_linked;
+static thread_local ns_module* thread_local_modpending;
+bool node_is_initialized = false;
+
+extern "C" void nativescript_module_register(void* m) {
+    struct ns_module* mp = reinterpret_cast<struct ns_module*>(m);
+    
+    if (mp->nm_flags & NM_F_INTERNAL) {
+        mp->nm_link = modlist_internal;
+        modlist_internal = mp;
+    } else if (!node_is_initialized) {
+        // "Linked" modules are included as part of the node project.
+        // Like builtins they are registered *before* node::Init runs.
+        mp->nm_flags = NM_F_LINKED;
+        mp->nm_link = modlist_linked;
+        modlist_linked = mp;
+    } else {
+        thread_local_modpending = mp;
+    }
+}
+
+namespace binding {
+
+void RegisterBuiltinBindings() {
+#define V(modname) _register_##modname();
+    NSC_BUILTIN_BINDINGS(V)
+#undef V
+}
+
+void CreateInternalBindingTemplates(v8::Isolate* isolate, Local<FunctionTemplate> templ) {
+#define V(modname)                                                             \
+  do {                                                                         \
+    /*templ->InstanceTemplate()->SetInternalFieldCount(                          \
+        BaseObject::kInternalFieldCount);*/                                      \
+    _register_isolate_##modname(isolate, templ);                          \
+    /*isolate_data->set_##modname##_binding(templ);*/                              \
+  } while (0);
+  NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)
+#undef V
+}
+
+};
+
+};
+

--- a/NativeScript/runtime/ModuleBinding.hpp
+++ b/NativeScript/runtime/ModuleBinding.hpp
@@ -1,0 +1,101 @@
+//
+//  ModuleBinding.hpp
+//  NativeScript
+//
+//  Created by Eduardo Speroni on 5/11/23.
+//  Copyright © 2023 Progress. All rights reserved.
+//
+
+#ifndef ModuleBinding_hpp
+#define ModuleBinding_hpp
+
+#include "Common.h"
+
+
+namespace tns {
+
+#define NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, priv, flags)          \
+  static tns::ns_module _module = {                                         \
+      NODE_MODULE_VERSION,                                                     \
+      flags,                                                                   \
+      nullptr,                                                                 \
+      __FILE__,                                                                \
+      nullptr,                                                                 \
+      (tns::addon_context_register_func)(regfunc),                            \
+      NODE_STRINGIFY(modname),                                                 \
+      priv,                                                                    \
+      nullptr};                                                                \
+  void _register_##modname() { node_module_register(&_module); }
+
+#define NODE_BINDING_CONTEXT_AWARE_INTERNAL(modname, regfunc)                  \
+  NODE_BINDING_CONTEXT_AWARE_CPP(modname, regfunc, nullptr, NM_F_INTERNAL)
+
+
+
+
+
+
+
+
+#define NODE_BINDING_PER_ISOLATE_INIT(modname, per_isolate_func)               \
+  void _register_isolate_##modname(v8::Isolate* isolate,            \
+                                   v8::Local<v8::FunctionTemplate> target) {   \
+    per_isolate_func(isolate, target);                                    \
+  }
+
+
+// This is a helepr that gives the target as an ObjectTemplate (using target.PrototypeTemplate())
+
+#define NODE_BINDING_PER_ISOLATE_INIT_OBJ(modname, per_isolate_func)               \
+  void _register_isolate_##modname(v8::Isolate* isolate,            \
+                                   v8::Local<v8::FunctionTemplate> target) {   \
+    per_isolate_func(isolate, target->PrototypeTemplate());                                    \
+  }
+
+
+//#define NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V)                                 \
+//  V(worker)
+
+#define NODE_BINDINGS_WITH_PER_ISOLATE_INIT(V) \
+V(worker)
+
+enum {
+    NM_F_BUILTIN = 1 << 0,  // Unused.
+    NM_F_LINKED = 1 << 1,
+    NM_F_INTERNAL = 1 << 2,
+    NM_F_DELETEME = 1 << 3,
+};
+
+typedef void (*addon_register_func)(
+                                    v8::Local<v8::Object> exports,
+                                    v8::Local<v8::Value> module,
+                                    void* priv);
+
+typedef void (*addon_context_register_func)(
+                                            v8::Local<v8::Object> exports,
+                                            v8::Local<v8::Value> module,
+                                            v8::Local<v8::Context> context,
+                                            void* priv);
+
+struct ns_module {
+    int nm_version;
+    unsigned int nm_flags;
+    void* nm_dso_handle;
+    const char* nm_filename;
+    tns::addon_register_func nm_register_func;
+    tns::addon_context_register_func nm_context_register_func;
+    const char* nm_modname;
+    void* nm_priv;
+    struct ns_module* nm_link;
+};
+
+namespace binding {
+void RegisterBuiltinBindings();
+void CreateInternalBindingTemplates(v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> templ);
+};
+
+
+};
+
+
+#endif /* ModuleBinding_hpp */

--- a/NativeScript/runtime/Worker.h
+++ b/NativeScript/runtime/Worker.h
@@ -8,6 +8,7 @@ namespace tns {
 class Worker {
 public:
     static void Init(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> globalTemplate, bool isWorkerThread);
+    static void Init(v8::Isolate* isolate, v8::Local<v8::ObjectTemplate> globalTemplate);
     static std::vector<std::string> GlobalFunctions;
 private:
     static void ConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -6,6 +6,7 @@
 #include "Helpers.h"
 #include "Runtime.h"
 #include "Constants.h"
+#include "ModuleBinding.hpp"
 
 using namespace v8;
 
@@ -15,6 +16,10 @@ std::vector<std::string> Worker::GlobalFunctions = {
     "postMessage",
     "close"
 };
+
+void Worker::Init(Isolate* isolate, Local<ObjectTemplate> globalTemplate) {
+    Worker::Init(isolate, globalTemplate, Caches::Get(isolate)->isWorker);
+}
 
 void Worker::Init(Isolate* isolate, Local<ObjectTemplate> globalTemplate, bool isWorkerThread) {
     if (isWorkerThread) {
@@ -290,3 +295,5 @@ int Worker::GetWorkerId(Isolate* isolate, Local<Object> global) {
 }
 
 }
+
+NODE_BINDING_PER_ISOLATE_INIT_OBJ(worker, tns::Worker::Init)

--- a/v8ios.xcodeproj/project.pbxproj
+++ b/v8ios.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		2B7EA6AF2353477000E5184E /* NativeScriptException.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2B7EA6AD2353476F00E5184E /* NativeScriptException.mm */; };
 		2B7EA6B02353477000E5184E /* NativeScriptException.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7EA6AE2353477000E5184E /* NativeScriptException.h */; };
+		3C78BA5C2A0D600100C20A88 /* ModuleBinding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C78BA5A2A0D600100C20A88 /* ModuleBinding.cpp */; };
+		3C78BA5D2A0D600100C20A88 /* ModuleBinding.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C78BA5B2A0D600100C20A88 /* ModuleBinding.hpp */; };
 		3CA6E53529A78C6000D30F8B /* IsolateWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */; };
 		3CBFF7442971C1C200C5DE36 /* ArcMacro.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CBFF7432971C1C200C5DE36 /* ArcMacro.h */; };
 		3CD1D9C129AA2C14004C1C21 /* DisposerPHV.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3CD1D9BF29AA2C14004C1C21 /* DisposerPHV.mm */; };
@@ -418,6 +420,8 @@
 /* Begin PBXFileReference section */
 		2B7EA6AD2353476F00E5184E /* NativeScriptException.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NativeScriptException.mm; sourceTree = "<group>"; };
 		2B7EA6AE2353477000E5184E /* NativeScriptException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeScriptException.h; sourceTree = "<group>"; };
+		3C78BA5A2A0D600100C20A88 /* ModuleBinding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ModuleBinding.cpp; sourceTree = "<group>"; };
+		3C78BA5B2A0D600100C20A88 /* ModuleBinding.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ModuleBinding.hpp; sourceTree = "<group>"; };
 		3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolateWrapper.h; sourceTree = "<group>"; };
 		3CBFF7432971C1C200C5DE36 /* ArcMacro.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArcMacro.h; sourceTree = "<group>"; };
 		3CD1D9BF29AA2C14004C1C21 /* DisposerPHV.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisposerPHV.mm; sourceTree = "<group>"; };
@@ -1407,6 +1411,8 @@
 				C275F475253B37AB00A997D5 /* UnmanagedType.mm */,
 				3CEF9CCC28F896B70056BA45 /* SpinLock.h */,
 				3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */,
+				3C78BA5A2A0D600100C20A88 /* ModuleBinding.cpp */,
+				3C78BA5B2A0D600100C20A88 /* ModuleBinding.hpp */,
 			);
 			path = runtime;
 			sourceTree = "<group>";
@@ -1518,6 +1524,7 @@
 				3CD1D9C229AA2C14004C1C21 /* DisposerPHV.h in Headers */,
 				C22536B7241A318900192740 /* ffitarget.h in Headers */,
 				C2DDEBAB229EAC8300345BFE /* WeakRef.h in Headers */,
+				3C78BA5D2A0D600100C20A88 /* ModuleBinding.hpp in Headers */,
 				C2DDEBA8229EAC8300345BFE /* SymbolLoader.h in Headers */,
 				C247C17322F82842001D2CA2 /* v8-internal.h in Headers */,
 				C266569822AFFFB000EE15CC /* Reference.h in Headers */,
@@ -2103,6 +2110,7 @@
 				91B25A0A29DAC83D00E3CE04 /* ns-v8-tracing-agent-impl.mm in Sources */,
 				C2DDEBA6229EAC8300345BFE /* Helpers.mm in Sources */,
 				C26656B322B3768C00EE15CC /* InteropTypes.mm in Sources */,
+				3C78BA5C2A0D600100C20A88 /* ModuleBinding.cpp in Sources */,
 				C2F4D0AD232F85E20008A2EB /* SymbolIterator.mm in Sources */,
 				C2DDEBA5229EAC8300345BFE /* Runtime.mm in Sources */,
 				6573B9CF291FE29F00B0ED7C /* V8Runtime.cpp in Sources */,


### PR DESCRIPTION
Draft on how new modules and globals could work

Instead of calling Init manually on the runtime, each module would register itself either as a global (`NODE_BINDING_PER_ISOLATE_INIT_OBJ`) or as a node module (`NODE_BINDING_CONTEXT_AWARE_INTERNAL`).

Globals are already working, we still need work for the node modules (essentially check if a module is a native module and call it + cache it).

This will allow us to `require('ns:crypto')`, for example. In the future, we could even rework the way we use native libraries so you can do: `import { NSString } from 'ns:native:Foundation'` to get a slimmer app size and automatic metadata filtering through bundlers

https://github.com/NativeScript/NativeScript/issues/195