### PR TITLE
fix: prevent JS function to native block leak

### DIFF
--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -37,7 +37,7 @@ Interop::JSBlock::JSBlockDescriptor Interop::JSBlock::kJSBlockDescriptor = {
     .dispose = [](JSBlock* block) {
         if (block->descriptor == &JSBlock::kJSBlockDescriptor) {
             MethodCallbackWrapper* wrapper = static_cast<MethodCallbackWrapper*>(block->userData);
-            if (wrapper->isolateWrapper_.IsValid()) {
+            if (Runtime::IsAlive(wrapper->isolateWrapper_.Isolate()) && wrapper->isolateWrapper_.IsValid()) {
                 Isolate* isolate = wrapper->isolateWrapper_.Isolate();
                 v8::Locker locker(isolate);
                 Isolate::Scope isolate_scope(isolate);

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -80,6 +80,8 @@ CFTypeRef Interop::CreateBlock(const uint8_t initialParamIndex, const uint8_t ar
 
     *blockPointer = {
         .isa = nullptr,
+        // this block is created with a refcount of 1
+        // this means we "own" it and need to free it
         .flags = JSBlock::BLOCK_HAS_COPY_DISPOSE | JSBlock::BLOCK_NEEDS_FREE | (1 /* ref count */ << 1),
         .reserved = 0,
         .invoke = (void*)result.first,
@@ -90,7 +92,8 @@ CFTypeRef Interop::CreateBlock(const uint8_t initialParamIndex, const uint8_t ar
 
     object_setClass((__bridge id)blockPointer, objc_getClass("__NSMallocBlock__"));
 
-    return blockPointer;
+    // transfer ownership back to ARC (see refcount comment above)
+    return CFBridgingRelease(blockPointer);
 }
 
 Local<Value> Interop::CallFunction(CMethodCall& methodCall) {

--- a/TestFixtures/Marshalling/TNSObjCTypes.h
+++ b/TestFixtures/Marshalling/TNSObjCTypes.h
@@ -12,6 +12,7 @@ CFTypeRef TNSFunctionWithCreateCFTypeRefReturn() CF_RETURNS_RETAINED;
 typedef int (^NumberReturner)(int, int, int);
 
 @interface TNSObjCTypes : NSObject
+@property (nonatomic, copy) void (^retainedBlock)(void);
 + (void)methodWithComplexBlock:(id (^)(int, id, SEL, NSObject*, TNSOStruct))block;
 + (id)methodWithObject:(id)x;
 
@@ -21,6 +22,10 @@ typedef int (^NumberReturner)(int, int, int);
 
 - (void)methodWithSimpleBlock:(void (^)(void))block;
 - (void)methodWithComplexBlock:(id (^)(int, id, SEL, NSObject*, TNSOStruct))block;
+
+- (void)methodRetainingBlock:(void (^)(void))block;
+- (void)methodCallRetainingBlock;
+- (void)methodReleaseRetainingBlock;
 
 - (NumberReturner)methodWithBlockScope:(int)number;
 - (id)methodReturningBlockAsId:(int)number;

--- a/TestFixtures/Marshalling/TNSObjCTypes.m
+++ b/TestFixtures/Marshalling/TNSObjCTypes.m
@@ -48,6 +48,16 @@ CFTypeRef TNSFunctionWithCreateCFTypeRefReturn() {
     block();
 }
 
+- (void)methodRetainingBlock:(void (^)(void))block {
+    _retainedBlock = block;
+}
+- (void)methodCallRetainingBlock {
+    _retainedBlock();
+}
+- (void)methodReleaseRetainingBlock {
+    _retainedBlock = NULL;
+}
+
 - (void)methodWithComplexBlock:(id (^)(int, id, SEL, NSObject*, TNSOStruct))block {
     TNSOStruct str = { 5, 6, 7 };
     id result = block(1, @2, @selector(init), @[@3, @4], str);


### PR DESCRIPTION
This is a pretty big change and it affects all blocks, so needs to be carefully tested.

I added 2 unit tests to blocks to ensure they're retained and released accordingly (they currently fail without my changes)