### PR TITLE
feat: add interop.stringFromCString

### DIFF
--- a/NativeScript/runtime/Interop.h
+++ b/NativeScript/runtime/Interop.h
@@ -134,6 +134,7 @@ private:
     static void InitializeStruct(v8::Local<v8::Context> context, void* destBuffer, std::vector<StructField> fields, v8::Local<v8::Value> inititalizer, ptrdiff_t& position);
     static void RegisterInteropType(v8::Local<v8::Context> context, v8::Local<v8::Object> types, std::string name, PrimitiveDataWrapper* wrapper, bool autoDelete = true);
     static void RegisterBufferFromDataFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
+    static void RegisterStringFromCString(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
     static void RegisterHandleOfFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
     static void RegisterAllocFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);
     static void RegisterFreeFunction(v8::Local<v8::Context> context, v8::Local<v8::Object> interop);

--- a/TestRunner/app/tests/Marshalling/ReferenceTests.js
+++ b/TestRunner/app/tests/Marshalling/ReferenceTests.js
@@ -329,6 +329,38 @@ describe(module.id, function () {
         expect(TNSGetOutput()).toBe(str);
         expect(interop.handleof(result).toNumber() == interop.handleof(ptr).toNumber());
         expect(NSString.stringWithUTF8String(result).toString()).toBe(str);
+        interop.free(ptr);
+    });
+
+    it("interops string from CString", function () {
+        const str = "test";
+        const ptr = interop.alloc((str.length + 1) * interop.sizeof(interop.types.uint8));
+        var reference = new interop.Reference(interop.types.uint8, ptr);
+        for (ii in str) {
+            const i = parseInt(ii);
+            reference[i] = str.charCodeAt(i);
+        }
+        reference[str.length] = 0;
+        expect(interop.stringFromCString(ptr)).toBe(str);
+        expect(interop.stringFromCString(reference)).toBe(str);
+        interop.free(ptr);
+    });
+
+    it("interops string from CString with fixed length", function () {
+        const str = "te\0st";
+        const ptr = interop.alloc((str.length + 1) * interop.sizeof(interop.types.uint8));
+        var reference = new interop.Reference(interop.types.uint8, ptr);
+        for (ii in str) {
+            const i = parseInt(ii);
+            reference[i] = str.charCodeAt(i);
+        }
+        reference[str.length] = 0;
+        // no length means it will go until it finds \0
+        expect(interop.stringFromCString(ptr)).toBe('te');
+        expect(interop.stringFromCString(ptr, 1)).toBe('t');
+        expect(interop.stringFromCString(ptr, str.length)).toBe(str);
+        expect(interop.stringFromCString(reference, str.length)).toBe(str);
+        interop.free(ptr);
     });
 
     it("CString should be passed as its UTF8 encoding and returned as a reference to unsigned characters", function () {


### PR DESCRIPTION
adds a new interop function `function interop.stringFromCstring(ptr: interop.Pointer | interop.Reference, length?: number): string` which allows you to easily convert a char* into a JS string (around 10x faster than doing `NSString.stringWithUTF8String().toString()`)