### PR TITLE
chore: use clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+# uses the same styling as V8
+BasedOnStyle: Google
+DerivePointerAlignment: false
+MaxEmptyLinesToKeep: 1

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,11 @@
+# clang format doesn't work properly with * and **
+NativeScript/include/*
+NativeScript/include/*/*
+NativeScript/include/*/*/*
+NativeScript/include/*/*/*/*
+NativeScript/include/*/*/*/*/*
+NativeScript/ada/*
+NativeScript/inspector/third_party/*
+NativeScript/inspector/third_party/*/*
+NativeScript/inspector/third_party/*/*/*
+NativeScript/inspector/third_party/*/*/*/*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged || echo "Linting failed, verify your clang-format installation"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ To start diving into the v8 iOS runtime make sure you have Xcode and [Homebrew](
 # Install CMake
 brew install cmake
 
+# (Optional) Install clang-format to format the code
+brew install clang-format
+
 # To avoid errors, you might need to link cmake to: /usr/local/bin/cmake
 # xcode doesn't read your profile during the build step, which causes it to ignore the PATH
 sudo ln -s /usr/local/bin/cmake $(which cmake)

--- a/package.json
+++ b/package.json
@@ -28,12 +28,20 @@
     "setup-ci": "./build_metadata_generator.sh",
     "update-version": "./update_version.sh",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
-    "version": "npm run changelog && git add CHANGELOG.md"
+    "version": "npm run changelog && git add CHANGELOG.md",
+    "prepare": "husky"
   },
   "license": "Apache-2.0",
   "devDependencies": {
     "conventional-changelog-cli": "^2.1.1",
     "dayjs": "^1.11.7",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.7",
     "semver": "^7.5.0"
+  },
+  "lint-staged": {
+    "{NativeScript,metadata-generator/src}/**/*.{h,hpp,c,cpp,mm}": [
+      "clang-format -i"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "semver": "^7.5.0"
   },
   "lint-staged": {
-    "{NativeScript,metadata-generator/src}/**/*.{h,hpp,c,cpp,mm}": [
+    "{NativeScript,metadata-generator/src,TestFixtures}/**/*.{h,hpp,c,cpp,mm,m}": [
       "clang-format -i"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "**/*"
   ],
   "scripts": {
+    "prepare": "husky",
     "apply-patches": "./apply_patches.sh",
     "build-v8-source": "./build_v8_source.sh",
     "build-v8-source-catalyst": "./build_v8_source_catalyst.sh",
@@ -28,8 +29,7 @@
     "setup-ci": "./build_metadata_generator.sh",
     "update-version": "./update_version.sh",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
-    "version": "npm run changelog && git add CHANGELOG.md",
-    "prepare": "husky"
+    "version": "npm run changelog && git add CHANGELOG.md"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/update_version.sh
+++ b/update_version.sh
@@ -3,9 +3,9 @@ set -e
 
 # If a parameter is passed to this script then replace the version in package.json by appending $PACKAGE_VERSION
 if [ -n "$1" ]; then
-    sed -i.bak "s/\"version\"[[:space:]]*:[[:space:]]*\"\(.*\)\"[[:space:]]*,/\"version\": \"\1-$PACKAGE_VERSION\",/g" package.json && rm package.json.bak
+    jq ".version = \"$PACKAGE_VERSION\"" package.json > package.json.tmp && rm package.json && mv package.json.tmp package.json
 fi
 
 # Read the version from package.json and replace it inside the NativeScript-Prefix.pch precompiled header
-FULL_VERSION=$(sed -nE "s/.*(\"version\"[[:space:]]*:[[:space:]]*\"(.+)\"[[:space:]]*,).*/\2/p" package.json)
+FULL_VERSION=$(jq -r .version package.json)
 sed -i.bak "s/#define[[:space:]]*NATIVESCRIPT_VERSION[[:space:]]*\"\(.*\)\"/#define NATIVESCRIPT_VERSION \"$FULL_VERSION\"/g" NativeScript/NativeScript-Prefix.pch && rm NativeScript/NativeScript-Prefix.pch.bak


### PR DESCRIPTION
uses clang-format to format all files according to the same styling that V8 uses.

We should consider doing this only after the pending PRs we have are merged (including the parallel branches we have with newer V8 versions)