### PR TITLE
feat: use messaging object to pass message to workers

### DIFF
--- a/NativeScript/runtime/ConcurrentQueue.cpp
+++ b/NativeScript/runtime/ConcurrentQueue.cpp
@@ -14,7 +14,7 @@ void ConcurrentQueue::Initialize(CFRunLoopRef runLoop, void (*performWork)(void*
     CFRunLoopAddSource(this->runLoop_, this->runLoopTasksSource_, kCFRunLoopCommonModes);
 }
 
-void ConcurrentQueue::Push(std::string message) {
+void ConcurrentQueue::Push(std::shared_ptr<worker::Message> message) {
     if (this->runLoopTasksSource_ != nullptr && !CFRunLoopSourceIsValid(this->runLoopTasksSource_)) {
         return;
     }
@@ -27,12 +27,12 @@ void ConcurrentQueue::Push(std::string message) {
     this->SignalAndWakeUp();
 }
 
-std::vector<std::string> ConcurrentQueue::PopAll() {
+std::vector<std::shared_ptr<worker::Message>> ConcurrentQueue::PopAll() {
     std::unique_lock<std::mutex> mlock(this->mutex_);
-    std::vector<std::string> messages;
+    std::vector<std::shared_ptr<worker::Message>> messages;
 
     while (!this->messagesQueue_.empty()) {
-        std::string message = this->messagesQueue_.front();
+        std::shared_ptr<worker::Message> message = this->messagesQueue_.front();
         this->messagesQueue_.pop();
         messages.push_back(message);
     }

--- a/NativeScript/runtime/ConcurrentQueue.h
+++ b/NativeScript/runtime/ConcurrentQueue.h
@@ -6,17 +6,18 @@
 #include <string>
 #include <queue>
 #include <mutex>
+#include "Message.hpp"
 
 namespace tns {
 
 struct ConcurrentQueue {
 public:
     void Initialize(CFRunLoopRef runLoop, void (*performWork)(void*), void* info);
-    void Push(std::string message);
-    std::vector<std::string> PopAll();
+    void Push(std::shared_ptr<worker::Message> message);
+    std::vector<std::shared_ptr<worker::Message>> PopAll();
     void Terminate();
 private:
-    std::queue<std::string> messagesQueue_;
+    std::queue<std::shared_ptr<worker::Message>> messagesQueue_;
     CFRunLoopSourceRef runLoopTasksSource_ = nullptr;
     CFRunLoopRef runLoop_ = nullptr;
     bool terminated = false;

--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -654,12 +654,12 @@ private:
 
 class WorkerWrapper: public BaseDataWrapper {
 public:
-    WorkerWrapper(v8::Isolate* mainIsolate, std::function<void (v8::Isolate*, v8::Local<v8::Object> thiz, std::string)> onMessage);
+    WorkerWrapper(v8::Isolate* mainIsolate, std::function<void (v8::Isolate*, v8::Local<v8::Object> thiz, std::shared_ptr<worker::Message>)> onMessage);
 
     void Start(std::shared_ptr<v8::Persistent<v8::Value>> poWorker, std::function<v8::Isolate* ()> func);
     void CallOnErrorHandlers(v8::TryCatch& tc);
     void PassUncaughtExceptionFromWorkerToMain(v8::Local<v8::Context> context, v8::TryCatch& tc, bool async = true);
-    void PostMessage(std::string message);
+    void PostMessage(std::shared_ptr<worker::Message> message);
     void Close();
     void Terminate();
 
@@ -691,7 +691,7 @@ private:
     std::atomic<bool> isTerminating_;
     bool isDisposed_;
     bool isWeak_;
-    std::function<void (v8::Isolate*, v8::Local<v8::Object> thiz, std::string)> onMessage_;
+    std::function<void (v8::Isolate*, v8::Local<v8::Object> thiz, std::shared_ptr<worker::Message>)> onMessage_;
     std::shared_ptr<v8::Persistent<v8::Value>> poWorker_;
     ConcurrentQueue queue_;
     static std::atomic<int> nextId_;

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -340,6 +340,57 @@ void SetConstructorFunction(v8::Isolate* isolate,
                             SetConstructorFunctionFlag::SET_CLASS_NAME);
 
 
+template <int N>
+inline v8::Local<v8::String> FIXED_ONE_BYTE_STRING(
+    v8::Isolate* isolate,
+    const char(&data)[N]) {
+  return OneByteString(isolate, data, N - 1);
+}
+
+template <std::size_t N>
+inline v8::Local<v8::String> FIXED_ONE_BYTE_STRING(
+    v8::Isolate* isolate,
+    const std::array<char, N>& arr) {
+  return OneByteString(isolate, arr.data(), N - 1);
+}
+
+class PersistentToLocal {
+ public:
+  // If persistent.IsWeak() == false, then do not call persistent.Reset()
+  // while the returned Local<T> is still in scope, it will destroy the
+  // reference to the object.
+  template <class TypeName>
+  static inline v8::Local<TypeName> Default(
+      v8::Isolate* isolate,
+      const v8::PersistentBase<TypeName>& persistent) {
+    if (persistent.IsWeak()) {
+      return PersistentToLocal::Weak(isolate, persistent);
+    } else {
+      return PersistentToLocal::Strong(persistent);
+    }
+  }
+
+  // Unchecked conversion from a non-weak Persistent<T> to Local<T>,
+  // use with care!
+  //
+  // Do not call persistent.Reset() while the returned Local<T> is still in
+  // scope, it will destroy the reference to the object.
+  template <class TypeName>
+  static inline v8::Local<TypeName> Strong(
+      const v8::PersistentBase<TypeName>& persistent) {
+//    DCHECK(!persistent.IsWeak());
+    return *reinterpret_cast<v8::Local<TypeName>*>(
+        const_cast<v8::PersistentBase<TypeName>*>(&persistent));
+  }
+
+  template <class TypeName>
+  static inline v8::Local<TypeName> Weak(
+      v8::Isolate* isolate,
+      const v8::PersistentBase<TypeName>& persistent) {
+    return v8::Local<TypeName>::New(isolate, persistent);
+  }
+};
+
 }
 
 #endif /* Helpers_h */

--- a/NativeScript/runtime/Message.cpp
+++ b/NativeScript/runtime/Message.cpp
@@ -1,0 +1,488 @@
+//
+//  Message.cpp
+//  NativeScript
+//
+//  Created by Eduardo Speroni on 11/22/23.
+//  Copyright © 2023 Progress. All rights reserved.
+//
+
+#include "Helpers.h"
+#include "Message.hpp"
+#include "NativeScriptException.h"
+
+using namespace v8;
+
+namespace tns {
+namespace worker {
+namespace {
+void ThrowDataCloneException(Local<Context> context,
+                             Local<v8::String> message) {
+  Isolate* isolate = context->GetIsolate();
+  //  Local<Value> argv[] = {message,
+  //                         FIXED_ONE_BYTE_STRING(isolate, "DataCloneError")};
+  Local<Value> exception;
+  Local<v8::Function> domexception_ctor;
+  NativeScriptException except(isolate, tns::ToString(isolate, message),
+                               "DataCloneError");
+  except.ReThrowToV8(isolate);
+}
+class SerializerDelegate : public v8::ValueSerializer::Delegate {
+ public:
+  SerializerDelegate(Isolate* isolate, Local<Context> context, Message* m)
+      : isolate_(isolate), context_(context), msg_(m) {}
+
+  void ThrowDataCloneError(Local<v8::String> message) override {
+    ThrowDataCloneException(context_, message);
+  }
+
+  Maybe<bool> WriteHostObject(Isolate* isolate, Local<Object> object) override {
+    return Just(true);
+    //    if (BaseObject::IsBaseObject(object)) {
+    //      return WriteHostObject(
+    //          BaseObjectPtr<BaseObject> { Unwrap<BaseObject>(object) });
+    //    }
+    //
+    //    // Convert process.env to a regular object.
+    //    auto env_proxy_ctor_template = env_->env_proxy_ctor_template();
+    //    if (!env_proxy_ctor_template.IsEmpty() &&
+    //        env_proxy_ctor_template->HasInstance(object)) {
+    //      HandleScope scope(isolate);
+    //      // TODO(bnoordhuis) Prototype-less object in case process.env
+    //      contains
+    //      // a "__proto__" key? process.env has a prototype with concomitant
+    //      // methods like toString(). It's probably confusing if that gets
+    //      lost
+    //      // in transmission.
+    //      Local<Object> normal_object = Object::New(isolate);
+    //      env_->env_vars()->AssignToObject(isolate, env_->context(),
+    //      normal_object); serializer->WriteUint32(kNormalObject);  // Instead
+    //      of a BaseObject. return serializer->WriteValue(env_->context(),
+    //      normal_object);
+    //    }
+    //
+    //    ThrowDataCloneError(env_->clone_unsupported_type_str());
+    //    return Nothing<bool>();
+  }
+
+  Maybe<uint32_t> GetSharedArrayBufferId(
+      Isolate* isolate, Local<SharedArrayBuffer> shared_array_buffer) override {
+    uint32_t i;
+    for (i = 0; i < seen_shared_array_buffers_.size(); ++i) {
+      if (PersistentToLocal::Strong(seen_shared_array_buffers_[i]) ==
+          shared_array_buffer) {
+        return Just(i);
+      }
+    }
+
+    seen_shared_array_buffers_.emplace_back(
+        Global<SharedArrayBuffer>{isolate, shared_array_buffer});
+    msg_->AddSharedArrayBuffer(shared_array_buffer->GetBackingStore());
+    return Just(i);
+  }
+
+  //  Maybe<uint32_t> GetWasmModuleTransferId(
+  //      Isolate* isolate, Local<WasmModuleObject> module) override {
+  //    return Just(msg_->AddWASMModule(module->GetCompiledModule()));
+  //  }
+
+  //  bool AdoptSharedValueConveyor(Isolate* isolate,
+  //                                SharedValueConveyor&& conveyor) override {
+  //    msg_->AdoptSharedValueConveyor(std::move(conveyor));
+  //    return true;
+  //  }
+
+  //  Maybe<bool> Finish(Local<Context> context) {
+  //    for (uint32_t i = 0; i < host_objects_.size(); i++) {
+  //      BaseObjectPtr<BaseObject> host_object = std::move(host_objects_[i]);
+  //      std::unique_ptr<TransferData> data;
+  //      if (i < first_cloned_object_index_)
+  //        data = host_object->TransferForMessaging();
+  //      if (!data)
+  //        data = host_object->CloneForMessaging();
+  //      if (!data) return Nothing<bool>();
+  //      if (data->FinalizeTransferWrite(context, serializer).IsNothing())
+  //        return Nothing<bool>();
+  //      msg_->AddTransferable(std::move(data));
+  //    }
+  //    return Just(true);
+  //  }
+
+  //  inline void AddHostObject(BaseObjectPtr<BaseObject> host_object) {
+  //    // Make sure we have not started serializing the value itself yet.
+  //    CHECK_EQ(first_cloned_object_index_, SIZE_MAX);
+  //    host_objects_.emplace_back(std::move(host_object));
+  //  }
+  //
+  //  // Some objects in the transfer list may register sub-objects that can be
+  //  // transferred. This could e.g. be a public JS wrapper object, such as a
+  //  // FileHandle, that is registering its C++ handle for transfer.
+  //  inline Maybe<bool> AddNestedHostObjects() {
+  //    for (size_t i = 0; i < host_objects_.size(); i++) {
+  //      std::vector<BaseObjectPtr<BaseObject>> nested_transferables;
+  //      if
+  //      (!host_objects_[i]->NestedTransferables().To(&nested_transferables))
+  //        return Nothing<bool>();
+  //      for (auto& nested_transferable : nested_transferables) {
+  //        if (std::find(host_objects_.begin(),
+  //                      host_objects_.end(),
+  //                      nested_transferable) == host_objects_.end()) {
+  //          AddHostObject(nested_transferable);
+  //        }
+  //      }
+  //    }
+  //    return Just(true);
+  //  }
+
+  ValueSerializer* serializer = nullptr;
+
+ private:
+  //  Maybe<bool> WriteHostObject(BaseObjectPtr<BaseObject> host_object) {
+  //    BaseObject::TransferMode mode = host_object->GetTransferMode();
+  //    if (mode == BaseObject::TransferMode::kUntransferable) {
+  //      ThrowDataCloneError(env_->clone_unsupported_type_str());
+  //      return Nothing<bool>();
+  //    }
+  //
+  //    for (uint32_t i = 0; i < host_objects_.size(); i++) {
+  //      if (host_objects_[i] == host_object) {
+  //        serializer->WriteUint32(i);
+  //        return Just(true);
+  //      }
+  //    }
+  //
+  //    if (mode == BaseObject::TransferMode::kTransferable) {
+  //      THROW_ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST(env_);
+  //      return Nothing<bool>();
+  //    }
+  //
+  //    CHECK_EQ(mode, BaseObject::TransferMode::kCloneable);
+  //    uint32_t index = host_objects_.size();
+  //    if (first_cloned_object_index_ == SIZE_MAX)
+  //      first_cloned_object_index_ = index;
+  //    serializer->WriteUint32(index);
+  //    host_objects_.push_back(host_object);
+  //    return Just(true);
+  //  }
+
+  __unused Isolate* isolate_;
+  __unused Local<Context> context_;
+  Message* msg_;
+  std::vector<Global<SharedArrayBuffer>> seen_shared_array_buffers_;
+  //  std::vector<BaseObjectPtr<BaseObject>> host_objects_;
+  __unused size_t first_cloned_object_index_ = SIZE_MAX;
+
+  friend class tns::worker::Message;
+};
+
+class DeserializerDelegate : public ValueDeserializer::Delegate {
+ public:
+  DeserializerDelegate(
+      Message* m, Isolate* isolate,
+      //      const std::vector<BaseObjectPtr<BaseObject>>& host_objects,
+      const std::vector<Local<SharedArrayBuffer>>& shared_array_buffers
+      //      const std::vector<CompiledWasmModule>& wasm_modules,
+      //      const std::optional<SharedValueConveyor>& shared_value_conveyor
+      )
+      :  //    host_objects_(host_objects),
+        shared_array_buffers_(shared_array_buffers)
+  //        wasm_modules_(wasm_modules),
+  //        shared_value_conveyor_(shared_value_conveyor)
+  {}
+
+  MaybeLocal<Object> ReadHostObject(Isolate* isolate) override {
+    EscapableHandleScope scope(isolate);
+    Local<Object> object = Object::New(isolate);
+    return scope.Escape(object).As<Object>();
+    //    // Identifying the index in the message's BaseObject array is
+    //    sufficient. uint32_t id; if (!deserializer->ReadUint32(&id))
+    //      return MaybeLocal<Object>();
+    //    if (id != kNormalObject) {
+    //      CHECK_LT(id, host_objects_.size());
+    //      return host_objects_[id]->object(isolate);
+    //    }
+    //    EscapableHandleScope scope(isolate);
+    //    Local<Context> context = isolate->GetCurrentContext();
+    //    Local<Value> object;
+    //    if (!deserializer->ReadValue(context).ToLocal(&object))
+    //      return MaybeLocal<Object>();
+    //    CHECK(object->IsObject());
+    //    return scope.Escape(object.As<Object>());
+  }
+
+  MaybeLocal<SharedArrayBuffer> GetSharedArrayBufferFromId(
+      Isolate* isolate, uint32_t clone_id) override {
+    //    CHECK_LT(clone_id, shared_array_buffers_.size());
+    return shared_array_buffers_[clone_id];
+  }
+
+  //  MaybeLocal<WasmModuleObject> GetWasmModuleFromId(
+  //      Isolate* isolate, uint32_t transfer_id) override {
+  ////    CHECK_LT(transfer_id, wasm_modules_.size());
+  //    return WasmModuleObject::FromCompiledModule(
+  //        isolate, wasm_modules_[transfer_id]);
+  //  }
+
+  //  const SharedValueConveyor* GetSharedValueConveyor(Isolate* isolate)
+  //  override {
+  ////    CHECK(shared_value_conveyor_.has_value());
+  //    return &shared_value_conveyor_.value();
+  //  }
+
+  ValueDeserializer* deserializer = nullptr;
+
+ private:
+  //  const std::vector<BaseObjectPtr<BaseObject>>& host_objects_;
+  const std::vector<Local<SharedArrayBuffer>>& shared_array_buffers_;
+  //  const std::vector<CompiledWasmModule>& wasm_modules_;
+  //  const std::optional<SharedValueConveyor>& shared_value_conveyor_;
+};
+};  // namespace
+
+v8::Maybe<bool> Message::Serialize(v8::Isolate* isolate,
+                                   v8::Local<v8::Context> context,
+                                   v8::Local<v8::Value> input) {
+  HandleScope handle_scope(isolate);
+  v8::Context::Scope context_scope(context);
+
+  // Verify that we're not silently overwriting an existing message.
+  tns::Assert(main_message_buf_.is_empty());
+
+  SerializerDelegate delegate(isolate, context, this);
+  ValueSerializer serializer(isolate, &delegate);
+  delegate.serializer = &serializer;
+
+  std::vector<Local<ArrayBuffer>> array_buffers;
+  //      for (uint32_t i = 0; i < transfer_list_v.length(); ++i) {
+  //        Local<Value> entry = transfer_list_v[i];
+  //        if (entry->IsObject()) {
+  //          // See
+  //          https://github.com/nodejs/node/pull/30339#issuecomment-552225353
+  //          // for details.
+  //          bool untransferable;
+  //          if (!entry.As<Object>()->HasPrivate(
+  //                  context,
+  //                  env->untransferable_object_private_symbol())
+  //                  .To(&untransferable)) {
+  //            return Nothing<bool>();
+  //          }
+  //          if (untransferable) {
+  //            ThrowDataCloneException(context,
+  //            env->transfer_unsupported_type_str()); return Nothing<bool>();
+  //          }
+  //        }
+  //
+  //        // Currently, we support ArrayBuffers and BaseObjects for which
+  //        // GetTransferMode() returns kTransferable.
+  //        if (entry->IsArrayBuffer()) {
+  //          Local<ArrayBuffer> ab = entry.As<ArrayBuffer>();
+  //          // If we cannot render the ArrayBuffer unusable in this Isolate,
+  //          // copying the buffer will have to do.
+  //          // Note that we can currently transfer ArrayBuffers even if they
+  //          were
+  //          // not allocated by Node’s ArrayBufferAllocator in the first
+  //          place,
+  //          // because we pass the underlying v8::BackingStore around rather
+  //          than
+  //          // raw data *and* an Isolate with a non-default ArrayBuffer
+  //          allocator
+  //          // is always going to outlive any Workers it creates, and so will
+  //          its
+  //          // allocator along with it.
+  //          if (!ab->IsDetachable() || ab->WasDetached()) {
+  //            ThrowDataCloneException(context,
+  //            env->transfer_unsupported_type_str()); return Nothing<bool>();
+  //          }
+  //          if (std::find(array_buffers.begin(), array_buffers.end(), ab) !=
+  //              array_buffers.end()) {
+  //            ThrowDataCloneException(
+  //                context,
+  //                FIXED_ONE_BYTE_STRING(
+  //                    env->isolate(),
+  //                    "Transfer list contains duplicate ArrayBuffer"));
+  //            return Nothing<bool>();
+  //          }
+  //          // We simply use the array index in the `array_buffers` list as
+  //          the
+  //          // ID that we write into the serialized buffer.
+  //          uint32_t id = array_buffers.size();
+  //          array_buffers.push_back(ab);
+  //          serializer.TransferArrayBuffer(id, ab);
+  //          continue;
+  //        } else if (entry->IsObject() &&
+  //                   BaseObject::IsBaseObject(entry.As<Object>())) {
+  //          // Check if the source MessagePort is being transferred.
+  //          if (!source_port.IsEmpty() && entry == source_port) {
+  //            ThrowDataCloneException(
+  //                context,
+  //                FIXED_ONE_BYTE_STRING(env->isolate(),
+  //                                      "Transfer list contains source
+  //                                      port"));
+  //            return Nothing<bool>();
+  //          }
+  //          BaseObjectPtr<BaseObject> host_object {
+  //              Unwrap<BaseObject>(entry.As<Object>()) };
+  //          if (env->message_port_constructor_template()->HasInstance(entry)
+  //          &&
+  //              (!host_object ||
+  //               static_cast<MessagePort*>(host_object.get())->IsDetached()))
+  //               {
+  //            ThrowDataCloneException(
+  //                context,
+  //                FIXED_ONE_BYTE_STRING(
+  //                    env->isolate(),
+  //                    "MessagePort in transfer list is already detached"));
+  //            return Nothing<bool>();
+  //          }
+  //          if (std::find(delegate.host_objects_.begin(),
+  //                        delegate.host_objects_.end(),
+  //                        host_object) != delegate.host_objects_.end()) {
+  //            ThrowDataCloneException(
+  //                context,
+  //                String::Concat(env->isolate(),
+  //                    FIXED_ONE_BYTE_STRING(
+  //                      env->isolate(),
+  //                      "Transfer list contains duplicate "),
+  //                    entry.As<Object>()->GetConstructorName()));
+  //            return Nothing<bool>();
+  //          }
+  //          if (host_object && host_object->GetTransferMode() ==
+  //                                 BaseObject::TransferMode::kTransferable) {
+  //            delegate.AddHostObject(host_object);
+  //            continue;
+  //          }
+  //        }
+  //
+  //        THROW_ERR_INVALID_TRANSFER_OBJECT(env);
+  //        return Nothing<bool>();
+  //      }
+  //      if (delegate.AddNestedHostObjects().IsNothing())
+  //        return Nothing<bool>();
+
+  serializer.WriteHeader();
+  if (serializer.WriteValue(context, input).IsNothing()) {
+    return Nothing<bool>();
+  }
+
+  for (Local<ArrayBuffer> ab : array_buffers) {
+    // If serialization succeeded, we render it inaccessible in this Isolate.
+    std::shared_ptr<BackingStore> backing_store = ab->GetBackingStore();
+    ab->Detach();
+
+    array_buffers_.emplace_back(std::move(backing_store));
+  }
+
+  //      if (delegate.Finish(context).IsNothing())
+  //        return Nothing<bool>();
+
+  // The serializer gave us a buffer allocated using `malloc()`.
+  std::pair<uint8_t*, size_t> data = serializer.Release();
+  tns::Assert(data.first != NULL, isolate);
+  main_message_buf_ =
+      MallocedBuffer<char>(reinterpret_cast<char*>(data.first), data.second);
+  return Just(true);
+}
+
+MaybeLocal<Value> Message::Deserialize(Isolate* isolate,
+                                       Local<Context> context) {
+  Context::Scope context_scope(context);
+
+  //  CHECK(!IsCloseMessage());
+  //  if (port_list != nullptr && !transferables_.empty()) {
+  //    // Need to create this outside of the EscapableHandleScope, but inside
+  //    // the Context::Scope.
+  //    *port_list = Array::New(env->isolate());
+  //  }
+
+  EscapableHandleScope handle_scope(isolate);
+
+  // Create all necessary objects for transferables, e.g. MessagePort handles.
+  //  std::vector<BaseObjectPtr<BaseObject>>
+  //  host_objects(transferables_.size()); auto cleanup = OnScopeLeave([&]() {
+  //    for (BaseObjectPtr<BaseObject> object : host_objects) {
+  //      if (!object) continue;
+  //
+  //      // If the function did not finish successfully, host_objects will
+  //      contain
+  //      // a list of objects that will never be passed to JS. Therefore, we
+  //      // destroy them here.
+  //      object->Detach();
+  //    }
+  //  });
+
+  //  for (uint32_t i = 0; i < transferables_.size(); ++i) {
+  //    HandleScope handle_scope(env->isolate());
+  //    TransferData* data = transferables_[i].get();
+  //    host_objects[i] = data->Deserialize(
+  //        env, context, std::move(transferables_[i]));
+  //    if (!host_objects[i]) return {};
+  //    if (port_list != nullptr) {
+  //      // If we gather a list of all message ports, and this transferred
+  //      object
+  //      // is a message port, add it to that list. This is a bit of an odd
+  //      case
+  //      // of special handling for MessagePorts (as opposed to applying to all
+  //      // transferables), but it's required for spec compliance.
+  //      DCHECK((*port_list)->IsArray());
+  //      Local<Array> port_list_array = port_list->As<Array>();
+  //      Local<Object> obj = host_objects[i]->object();
+  //      if (env->message_port_constructor_template()->HasInstance(obj)) {
+  //        if (port_list_array->Set(context,
+  //                                 port_list_array->Length(),
+  //                                 obj).IsNothing()) {
+  //          return {};
+  //        }
+  //      }
+  //    }
+  //  }
+  //  transferables_.clear();
+
+  std::vector<Local<SharedArrayBuffer>> shared_array_buffers;
+  // Attach all transferred SharedArrayBuffers to their new Isolate.
+  for (uint32_t i = 0; i < shared_array_buffers_.size(); ++i) {
+    Local<SharedArrayBuffer> sab =
+        SharedArrayBuffer::New(isolate, shared_array_buffers_[i]);
+    shared_array_buffers.push_back(sab);
+  }
+
+  DeserializerDelegate delegate(
+      this, isolate,
+      //                                host_objects,
+      shared_array_buffers
+      //                                wasm_modules_,
+      //                                shared_value_conveyor_
+  );
+  ValueDeserializer deserializer(
+      isolate, reinterpret_cast<const uint8_t*>(main_message_buf_.data),
+      main_message_buf_.size, &delegate);
+  delegate.deserializer = &deserializer;
+
+  // Attach all transferred ArrayBuffers to their new Isolate.
+  for (uint32_t i = 0; i < array_buffers_.size(); ++i) {
+    Local<ArrayBuffer> ab =
+        ArrayBuffer::New(isolate, std::move(array_buffers_[i]));
+    deserializer.TransferArrayBuffer(i, ab);
+  }
+
+  if (deserializer.ReadHeader(context).IsNothing()) return {};
+  Local<Value> return_value;
+  if (!deserializer.ReadValue(context).ToLocal(&return_value)) return {};
+
+  //  for (BaseObjectPtr<BaseObject> base_object : host_objects) {
+  //    if (base_object->FinalizeTransferRead(context,
+  //    &deserializer).IsNothing())
+  //      return {};
+  //  }
+
+  //  host_objects.clear();
+  return handle_scope.Escape(return_value);
+}
+
+void Message::AddSharedArrayBuffer(
+    std::shared_ptr<BackingStore> backing_store) {
+  shared_array_buffers_.emplace_back(std::move(backing_store));
+}
+
+Message::Message(MallocedBuffer<char>&& payload)
+    : main_message_buf_(std::move(payload)) {}
+};  // namespace worker
+};  // namespace tns

--- a/NativeScript/runtime/Message.hpp
+++ b/NativeScript/runtime/Message.hpp
@@ -1,0 +1,136 @@
+//
+//  Message.hpp
+//  NativeScript
+//
+//  Created by Eduardo Speroni on 11/22/23.
+//  Copyright © 2023 Progress. All rights reserved.
+//
+
+#ifndef Message_hpp
+#define Message_hpp
+#include "v8.h"
+
+namespace tns {
+
+template <typename T>
+inline T* Malloc(size_t n) {
+  T* ret = malloc(n);
+  return ret;
+}
+
+template <typename T>
+T* UncheckedRealloc(T* pointer, size_t n) {
+  size_t full_size = sizeof(T) * n;
+
+  if (full_size == 0) {
+    free(pointer);
+    return nullptr;
+  }
+
+  void* allocated = realloc(pointer, full_size);
+
+  //  if (UNLIKELY(allocated == nullptr)) {
+  //    // Tell V8 that memory is low and retry.
+  //    LowMemoryNotification();
+  //    allocated = realloc(pointer, full_size);
+  //  }
+
+  return static_cast<T*>(allocated);
+}
+
+template <typename T>
+struct MallocedBuffer {
+  T* data;
+  size_t size;
+
+  T* release() {
+    T* ret = data;
+    data = nullptr;
+    return ret;
+  }
+
+  void Truncate(size_t new_size) {
+    CHECK_LE(new_size, size);
+    size = new_size;
+  }
+
+  void Realloc(size_t new_size) {
+    Truncate(new_size);
+    data = UncheckedRealloc(data, new_size);
+  }
+
+  bool is_empty() const { return data == nullptr; }
+
+  MallocedBuffer() : data(nullptr), size(0) {}
+  explicit MallocedBuffer(size_t size) : data(Malloc<T>(size)), size(size) {}
+  MallocedBuffer(T* data, size_t size) : data(data), size(size) {}
+  MallocedBuffer(MallocedBuffer&& other) : data(other.data), size(other.size) {
+    other.data = nullptr;
+  }
+  MallocedBuffer& operator=(MallocedBuffer&& other) {
+    this->~MallocedBuffer();
+    return *new (this) MallocedBuffer(std::move(other));
+  }
+  ~MallocedBuffer() { free(data); }
+  MallocedBuffer(const MallocedBuffer&) = delete;
+  MallocedBuffer& operator=(const MallocedBuffer&) = delete;
+};
+
+namespace worker {
+
+class Message {
+ public:
+  Message(MallocedBuffer<char>&& payload = MallocedBuffer<char>());
+  Message(Message&& other) = default;
+  Message& operator=(Message&& other) = default;
+  Message& operator=(const Message&) = delete;
+  Message(const Message&) = delete;
+  v8::Maybe<bool> Serialize(v8::Isolate* isolate,
+                            v8::Local<v8::Context> context,
+                            v8::Local<v8::Value> input);
+  v8::MaybeLocal<v8::Value> Deserialize(v8::Isolate* isolate,
+                                        v8::Local<v8::Context> context);
+  // Internal method of Message that is called when a new SharedArrayBuffer
+  // object is encountered in the incoming value's structure.
+  void AddSharedArrayBuffer(std::shared_ptr<v8::BackingStore> backing_store);
+  // Internal method of Message that is called once serialization finishes
+  // and that transfers ownership of `data` to this message.
+  //      void AddTransferable(std::unique_ptr<TransferData>&& data);
+  // Internal method of Message that is called when a new WebAssembly.Module
+  // object is encountered in the incoming value's structure.
+  //      uint32_t AddWASMModule(v8::CompiledWasmModule&& mod);
+  // Internal method of Message that is called when a shared value is
+  // encountered for the first time in the incoming value's structure.
+  //      void AdoptSharedValueConveyor(v8::SharedValueConveyor&& conveyor);
+
+  // The host objects that will be transferred, as recorded by Serialize()
+  // (e.g. MessagePorts).
+  // Used for warning user about posting the target MessagePort to itself,
+  // which will as a side effect destroy the communication channel.
+  //      const std::vector<std::unique_ptr<TransferData>>& transferables()
+  //      const {
+  //        return transferables_;
+  //      }
+  //      bool has_transferables() const {
+  //        return !transferables_.empty() || !array_buffers_.empty();
+  //      }
+
+  //      void MemoryInfo(MemoryTracker* tracker) const override;
+  //
+  //      SET_MEMORY_INFO_NAME(Message)
+  //      SET_SELF_SIZE(Message)
+ private:
+  MallocedBuffer<char> main_message_buf_;
+  // TODO(addaleax): Make this a std::variant to save storage size in the common
+  // case (which is that all of these vectors are empty) once that is available
+  // with C++17.
+  std::vector<std::shared_ptr<v8::BackingStore>> array_buffers_;
+  std::vector<std::shared_ptr<v8::BackingStore>> shared_array_buffers_;
+  //      std::vector<std::unique_ptr<TransferData>> transferables_;
+  //      std::vector<v8::CompiledWasmModule> wasm_modules_;
+  //      std::optional<v8::SharedValueConveyor> shared_value_conveyor_;
+};
+};  // namespace worker
+}  // namespace tns
+
+#endif /* Message_hpp */

--- a/NativeScript/runtime/NativeScriptException.h
+++ b/NativeScript/runtime/NativeScriptException.h
@@ -10,17 +10,20 @@ class NativeScriptException {
 public:
     NativeScriptException(const std::string& message);
     NativeScriptException(v8::Isolate* isolate, v8::TryCatch& tc, const std::string& message);
+    NativeScriptException(v8::Isolate* isolate, const std::string& message, const std::string& name = "NativeScriptException");
     ~NativeScriptException();
     void ReThrowToV8(v8::Isolate* isolate);
     static void OnUncaughtError(v8::Local<v8::Message> message, v8::Local<v8::Value> error);
 private:
     v8::Persistent<v8::Value>* javascriptException_;
+    std::string name_;
     std::string message_;
     std::string stackTrace_;
     std::string fullMessage_;
     static std::string GetErrorStackTrace(v8::Isolate* isolate, const v8::Local<v8::StackTrace>& stackTrace);
     static std::string GetErrorMessage(v8::Isolate* isolate, v8::Local<v8::Value>& error, const std::string& prependMessage = "");
     static std::string GetFullMessage(v8::Isolate* isolate, const v8::TryCatch& tc, const std::string& jsExceptionMessage);
+    static std::string GetFullMessage(v8::Isolate* isolate, v8::Local<v8::Message> message, const std::string& jsExceptionMessage);
 };
 
 }

--- a/NativeScript/runtime/Worker.h
+++ b/NativeScript/runtime/Worker.h
@@ -2,6 +2,7 @@
 #define Worker_h
 
 #include "Common.h"
+#include "Message.hpp"
 
 namespace tns {
 
@@ -14,7 +15,7 @@ private:
     static void ConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void PostMessageCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void TerminateCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
-    static void OnMessageCallback(v8::Isolate* isolate, v8::Local<v8::Value> receiver, std::string message);
+    static void OnMessageCallback(v8::Isolate* isolate, v8::Local<v8::Value> receiver, std::shared_ptr<worker::Message> message);
     static void PostMessageToMainCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static void CloseWorkerCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
     static v8::Local<v8::String> Serialize(v8::Isolate* isolate, v8::Local<v8::Value> value, v8::Local<v8::Value>& error);

--- a/TestRunner/app/tests/shared/Workers/index.js
+++ b/TestRunner/app/tests/shared/Workers/index.js
@@ -193,7 +193,7 @@ describe("TNS Workers", () => {
         worker.terminate();
     });
 
-    it("Should throw error if post circular object", () => {
+    xit("Should throw error if post circular object", () => {
         var worker = new Worker("./tests/shared/Workers/EvalWorker.js");
 
         var parent = { parent: true };

--- a/v8ios.xcodeproj/project.pbxproj
+++ b/v8ios.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		2B7EA6B02353477000E5184E /* NativeScriptException.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7EA6AE2353477000E5184E /* NativeScriptException.h */; };
 		3C1850542A6DCB2D002ACC81 /* Timers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C1850522A6DCB2D002ACC81 /* Timers.cpp */; };
 		3C1850552A6DCB2D002ACC81 /* Timers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C1850532A6DCB2D002ACC81 /* Timers.hpp */; };
+		3C5333342B0E683100BE0C47 /* Message.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C5333322B0E683100BE0C47 /* Message.cpp */; };
+		3C5333352B0E683100BE0C47 /* Message.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C5333332B0E683100BE0C47 /* Message.hpp */; };
 		3C78BA5C2A0D600100C20A88 /* ModuleBinding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3C78BA5A2A0D600100C20A88 /* ModuleBinding.cpp */; };
 		3C78BA5D2A0D600100C20A88 /* ModuleBinding.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3C78BA5B2A0D600100C20A88 /* ModuleBinding.hpp */; };
 		3CA6E53529A78C6000D30F8B /* IsolateWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */; };
@@ -425,6 +427,8 @@
 		2B7EA6AE2353477000E5184E /* NativeScriptException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NativeScriptException.h; sourceTree = "<group>"; };
 		3C1850522A6DCB2D002ACC81 /* Timers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Timers.cpp; sourceTree = "<group>"; };
 		3C1850532A6DCB2D002ACC81 /* Timers.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Timers.hpp; sourceTree = "<group>"; };
+		3C5333322B0E683100BE0C47 /* Message.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Message.cpp; sourceTree = "<group>"; };
+		3C5333332B0E683100BE0C47 /* Message.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Message.hpp; sourceTree = "<group>"; };
 		3C78BA5A2A0D600100C20A88 /* ModuleBinding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ModuleBinding.cpp; sourceTree = "<group>"; };
 		3C78BA5B2A0D600100C20A88 /* ModuleBinding.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ModuleBinding.hpp; sourceTree = "<group>"; };
 		3CA6E53429A78C6000D30F8B /* IsolateWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IsolateWrapper.h; sourceTree = "<group>"; };
@@ -1422,6 +1426,8 @@
 				3C78BA5B2A0D600100C20A88 /* ModuleBinding.hpp */,
 				3C1850522A6DCB2D002ACC81 /* Timers.cpp */,
 				3C1850532A6DCB2D002ACC81 /* Timers.hpp */,
+				3C5333322B0E683100BE0C47 /* Message.cpp */,
+				3C5333332B0E683100BE0C47 /* Message.hpp */,
 			);
 			path = runtime;
 			sourceTree = "<group>";
@@ -1513,6 +1519,7 @@
 				C266567C22AA630F00EE15CC /* NSDataAdapter.h in Headers */,
 				C2D7E9D523F42C1100DB289C /* PromiseProxy.h in Headers */,
 				C2A5F86B2359AEB600074AFA /* ExtVector.h in Headers */,
+				3C5333352B0E683100BE0C47 /* Message.hpp in Headers */,
 				C2DDEBB0229EAC8300345BFE /* StringHasher.h in Headers */,
 				C247C16A22F82842001D2CA2 /* v8-profiler.h in Headers */,
 				C2DDEB8E229EAC8300345BFE /* Interop.h in Headers */,
@@ -2129,6 +2136,7 @@
 				C2DDEB91229EAC8300345BFE /* FFICall.cpp in Sources */,
 				C2DDEBAA229EAC8300345BFE /* ModuleInternal.mm in Sources */,
 				C2DDEBA3229EAC8300345BFE /* ArrayAdapter.mm in Sources */,
+				3C5333342B0E683100BE0C47 /* Message.cpp in Sources */,
 				C2C8EE7422CE3266001F8CEC /* ConcurrentQueue.cpp in Sources */,
 				C2DDEBA0229EAC8300345BFE /* Interop.mm in Sources */,
 				C2D7E9D623F42C1100DB289C /* PromiseProxy.cpp in Sources */,


### PR DESCRIPTION
This is still a WIP. It uses a lot of node code to pass messages between the workers. This already allows us to pass 2 things we previously couldn't:

1. SharedArrayBuffer
2. circular objects

this PR will be complete once we're able to pass host objects as well, which will require some additional thought, as we might need to add more logic into the wrappers (like making the objects they hold shared_ptrs), so they can be released only when all are released. Since we're redesigning all our host objects logic for v8 v11.x, we might just delay this implementation