### PR TITLE
fix: only generate metadata for the targeted arch

### DIFF
--- a/metadata-generator/build-step-metadata-generator.py
+++ b/metadata-generator/build-step-metadata-generator.py
@@ -174,5 +174,11 @@ def generate_metadata(arch):
 
 
 for arch in env("ARCHS").split():
+    # skip metadata generation for architectures different than the one specified in the command line
+    # in case the command line argument is not specified, generate metadata for all architectures
+    if len(sys.argv) >= 2 and sys.argv[1].lower() != arch.lower():
+        print("Skipping metadata generation for " + arch)
+        continue
+
     print("Generating metadata for " + arch)
     generate_metadata(arch)

--- a/project-template/internal/nsld.sh
+++ b/project-template/internal/nsld.sh
@@ -44,17 +44,19 @@ function GEN_MODULEMAP() {
 }
 
 function GEN_METADATA() {
+    TARGET_ARCH=$1
     set -e
     cpu_arch=$(uname -m)
     pushd "$SRCROOT/internal/metadata-generator-${cpu_arch}/bin"
-    ./build-step-metadata-generator.py
+    ./build-step-metadata-generator.py $TARGET_ARCH
     popd
 }
 
 # Workaround for ARCH being set to `undefined_arch` here. Extract it from command line arguments.
-GEN_MODULEMAP $(getArch "$@")
+TARGET_ARCH=$(getArch "$@")
+GEN_MODULEMAP $TARGET_ARCH
 printf "Generating metadata..."
-GEN_METADATA
+GEN_METADATA $TARGET_ARCH
 DELETE_SWIFT_MODULES_DIR
 NS_LD="${NS_LD:-"$TOOLCHAIN_DIR/usr/bin/clang"}"
 $NS_LD "$@"


### PR DESCRIPTION
`nsld.sh` is usually invoked per target architecture.

Right now, we generate metadata for all valid architectures from `env[ARCH]`. This can cause issues in case we run mutiple builds in parallel (one for each target architecture) in which case both metadata generators output to the same files likely causing file corruption.

With these changes, in case a first argument is passed to the metadata generator python script, we skip architectures that don't match the argument.

This way, in case the metadata generation is invoked via nsld - we pass through the target architecture.