### PR TITLE
release: 8.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [8.6.4](https://github.com/NativeScript/ios/compare/v8.6.3...v8.6.4) (2024-03-13)
+
+
+### Bug Fixes
+
+* Xcode 15.3+ not setting TARGET_OS_IPHONE correctly ([#242](https://github.com/NativeScript/ios/issues/242)) ([d2f4ee4](https://github.com/NativeScript/ios/commit/d2f4ee4074b36d43f31d41048a08233b3912a5a1))
+
+
+
 ## [8.6.3](https://github.com/NativeScript/ios/compare/v8.6.2...v8.6.3) (2023-11-08)
 
 

--- a/NativeScript/NativeScript-Prefix.pch
+++ b/NativeScript/NativeScript-Prefix.pch
@@ -1,7 +1,7 @@
 #ifndef NativeScript_Prefix_pch
 #define NativeScript_Prefix_pch
 
-#define NATIVESCRIPT_VERSION "8.6.1"
+#define NATIVESCRIPT_VERSION "8.6.4"
 
 #ifdef DEBUG
 #define SIZEOF_OFF_T 8

--- a/metadata-generator/build-step-metadata-generator.py
+++ b/metadata-generator/build-step-metadata-generator.py
@@ -144,6 +144,10 @@ def generate_metadata(arch):
                              deployment_target_flag_name + "=" + deployment_target])
     else:
       generator_call.extend(["-target", "{}-{}-{}{}".format(arch, llvm_target_triple_vendor, llvm_target_triple_os_version, llvm_target_triple_suffix)])
+      # since iPhoneOS 17.4 sdk TARGET_OS_IPHONE is not defined for non-simulator builds
+      # this seems to be a bug on Apple's side
+      if effective_platform_name == "-iphoneos" and not llvm_target_triple_suffix:
+        generator_call.extend(["-DTARGET_OS_IPHONE=1"])
 
     generator_call.extend(header_search_paths_parsed)  # HEADER_SEARCH_PATHS
     generator_call.extend(framework_search_paths_parsed)  # FRAMEWORK_SEARCH_PATHS

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nativescript/ios",
   "description": "NativeScript Runtime for iOS",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "keywords": [
     "NativeScript",
     "iOS",


### PR DESCRIPTION
8.6.4 cherry picks #242 from main

_(Note: accidentally committed as `release: 8.6.3` - but the tag/version is 8.6.4 correctly)_