### PR TITLE
feat: add `@deprecation` and `@since` docs

### DIFF
--- a/metadata-generator/src/Meta/MetaEntities.h
+++ b/metadata-generator/src/Meta/MetaEntities.h
@@ -62,6 +62,19 @@ struct Version {
     bool operator >=(const Version& other) const {
         return !(*this < other);
     }
+    std::string toString() const {
+        std::string result;
+        if (Major >= 0) {
+            result.append(std::to_string(Major));
+            if (Minor >= 0) {
+                result.append("." + std::to_string(Minor));
+                if (SubMinor >= 0) {
+                    result.append("." + std::to_string(SubMinor));
+                }
+            }
+        }
+        return result;
+    }
 };
 
 enum MetaFlags : uint16_t {

--- a/metadata-generator/src/TypeScript/DocSetManager.h
+++ b/metadata-generator/src/TypeScript/DocSetManager.h
@@ -21,6 +21,10 @@ struct TSComment {
      * \brief A brief description of the symbol.
      */
     std::string description;
+    
+    Meta::Version introducedIn = UNKNOWN_VERSION;
+    Meta::Version obsoletedIn = UNKNOWN_VERSION;
+    Meta::Version deprecatedIn = UNKNOWN_VERSION;
 
     /*
      * \brief An optional list of parameters. Useful in method and function comments.


### PR DESCRIPTION
This adds deprecation and since notices to APIs:

Before:
```
widgetMaximumSizeForDisplayMode(displayMode: NCWidgetDisplayMode): CGSize;
```

After:

```
	/**
	 * @since 10.0
	 * @deprecated 14.0
	 */
	widgetMaximumSizeForDisplayMode(displayMode: NCWidgetDisplayMode): CGSize;
```