### PR TITLE
fix: Xcode 15.3+ not setting TARGET_OS_IOS correctly

### DIFF
--- a/metadata-generator/build-step-metadata-generator.py
+++ b/metadata-generator/build-step-metadata-generator.py
@@ -152,10 +152,11 @@ def generate_metadata(arch):
                              deployment_target_flag_name + "=" + deployment_target])
     else:
       generator_call.extend(["-target", "{}-{}-{}{}".format(arch, llvm_target_triple_vendor, llvm_target_triple_os_version, llvm_target_triple_suffix)])
-      # since iPhoneOS 17.4 sdk TARGET_OS_IPHONE is not defined for non-simulator builds
+      # since iPhoneOS 17.4 sdk TARGET_OS_IPHONE and TARGET_OS_IOS is not defined for non-simulator builds
       # this seems to be a bug on Apple's side
       if effective_platform_name == "-iphoneos" and not llvm_target_triple_suffix:
         generator_call.extend(["-DTARGET_OS_IPHONE=1"])
+        generator_call.extend(["-DTARGET_OS_IOS=1"])
 
     generator_call.extend(header_search_paths_parsed)  # HEADER_SEARCH_PATHS
     generator_call.extend(framework_search_paths_parsed)  # FRAMEWORK_SEARCH_PATHS


### PR DESCRIPTION
This stems from my work on a plugin that uses the SDWebImage package. Metadata for some classes were not getting generated when building for a physical device. 

This will probably also resolve #245 since they were also running into problems with the same SDWebImage package.