### PR TITLE
fix(ios): Fix broken build of WatchOS embedded apps

### DIFF
--- a/project-template-ios/internal/Swift-ObjC-Bridging-Header.h
+++ b/project-template-ios/internal/Swift-ObjC-Bridging-Header.h
@@ -10,5 +10,9 @@
 // the *-Swift.h*.
 // https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_objective-c_into_swift
 
-#import "NativeScript/NativeScript.h"
-#import "NativeScriptStart.h"
+#import "TargetConditionals.h"
+
+#ifndef TARGET_OS_WATCH
+    #import "NativeScript/NativeScript.h"
+    #import "NativeScriptStart.h"
+#endif


### PR DESCRIPTION
This commit aims to fix this issue reported here: https://github.com/NativeScript/ios/issues/249

I don't know if this is the best solution, but as we don't need NS headers at WatchOS development, I think we can disable it for the target `TARGET_OS_WATCH`.