### PR TITLE
fix: symbol loader log true errors only to not confuse terminal output

### DIFF
--- a/NativeScript/runtime/SymbolLoader.mm
+++ b/NativeScript/runtime/SymbolLoader.mm
@@ -108,8 +108,6 @@ SymbolResolver* SymbolLoader::resolveModule(const ModuleMeta* module) {
         NSURL* bundleUrl = [NSURL URLWithString:frameworkPathStr relativeToURL:baseUrl];
         if (CFBundleRef bundle = CFBundleCreate(kCFAllocatorDefault, (CFURLRef)bundleUrl)) {
             resolver = std::make_unique<CFBundleSymbolResolver>(bundle);
-        } else {
-            os_log_debug(ns_symbolloader_log(), "NativeScript could not load bundle %{public}s", bundleUrl.absoluteString.UTF8String);
         }
     } else if (module->libraries->count == 1) {
         if (module->isSystem()) {
@@ -118,7 +116,6 @@ SymbolResolver* SymbolLoader::resolveModule(const ModuleMeta* module) {
             NSString* libraryPath = [NSString stringWithFormat:@"%@/lib%s.dylib", libsPath, module->libraries->first()->value().getName()];
 
             if (void* library = dlopen(libraryPath.UTF8String, RTLD_LAZY | RTLD_LOCAL)) {
-                os_log_debug(ns_symbolloader_log(), "NativeScript loaded library %{public}s", libraryPath.UTF8String);
                 resolver = std::make_unique<DlSymbolResolver>(library);
             } else if (const char* libraryError = dlerror()) {
                 os_log_debug(ns_symbolloader_log(), "NativeScript could not load library %{public}s, error: %{public}s", libraryPath.UTF8String, libraryError);

--- a/NativeScript/runtime/SymbolLoader.mm
+++ b/NativeScript/runtime/SymbolLoader.mm
@@ -43,7 +43,7 @@ public:
         CFErrorRef error = nullptr;
         bool loaded = CFBundleLoadExecutableAndReturnError(this->_bundle, &error);
         if (error) {
-            NSLog(@"%s", [[(NSError*)error localizedDescription] UTF8String]);
+            os_log_error(ns_symbolloader_log(), "%{public}s", [[(NSError*)error localizedDescription] UTF8String]);
         }
 
         return loaded;
@@ -109,7 +109,7 @@ SymbolResolver* SymbolLoader::resolveModule(const ModuleMeta* module) {
         if (CFBundleRef bundle = CFBundleCreate(kCFAllocatorDefault, (CFURLRef)bundleUrl)) {
             resolver = std::make_unique<CFBundleSymbolResolver>(bundle);
         } else {
-            os_log_error(ns_symbolloader_log(), "NativeScript could not load bundle %{public}s", bundleUrl.absoluteString.UTF8String);
+            os_log_debug(ns_symbolloader_log(), "NativeScript could not load bundle %{public}s", bundleUrl.absoluteString.UTF8String);
         }
     } else if (module->libraries->count == 1) {
         if (module->isSystem()) {
@@ -118,10 +118,10 @@ SymbolResolver* SymbolLoader::resolveModule(const ModuleMeta* module) {
             NSString* libraryPath = [NSString stringWithFormat:@"%@/lib%s.dylib", libsPath, module->libraries->first()->value().getName()];
 
             if (void* library = dlopen(libraryPath.UTF8String, RTLD_LAZY | RTLD_LOCAL)) {
-                os_log_info(ns_symbolloader_log(), "NativeScript loaded library %{public}s", libraryPath.UTF8String);
+                os_log_debug(ns_symbolloader_log(), "NativeScript loaded library %{public}s", libraryPath.UTF8String);
                 resolver = std::make_unique<DlSymbolResolver>(library);
             } else if (const char* libraryError = dlerror()) {
-                os_log_error(ns_symbolloader_log(), "NativeScript could not load library %{public}s, error: %{public}s", libraryPath.UTF8String, libraryError);
+                os_log_debug(ns_symbolloader_log(), "NativeScript could not load library %{public}s, error: %{public}s", libraryPath.UTF8String, libraryError);
             }
         }
     }


### PR DESCRIPTION
Right now the symbol loader will just log to terminal certain processed paths that are not indicative of a functional issue:
```
NativeScript could not load bundle file:///Library/Developer/CoreSimulator/Volumes/iOS_22B81/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS%2018.1.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/UIUtilities.framework
```
These will no longer cloud the terminal output which can cause confusion.