### PR TITLE
feat: support native ES classes with lazy registration, including static usage before construction

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -827,7 +827,7 @@ std::vector<Local<Value>> ArgConverter::GetInitializerArgs(Local<Object> obj,
 }
 
 static bool TryConstructESDerivedInstance(Local<Context> context, id target, Local<Value>& out) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = v8::Isolate::GetCurrent();
   auto cache = Caches::Get(isolate);
   if (cache->PendingESAdopt != nullptr) {
     return false;
@@ -838,7 +838,7 @@ static bool TryConstructESDerivedInstance(Local<Context> context, id target, Loc
     return false;
   }
 
-  auto it = cache->CtorFuncs.find(std::string_view(className));
+  auto it = cache->CtorFuncs.find(className);
   if (it == cache->CtorFuncs.end()) {
     return false;
   }

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -15,6 +15,8 @@ using namespace std;
 
 namespace tns {
 
+static bool TryConstructESDerivedInstance(Local<Context> context, id target, Local<Value>& out);
+
 void ArgConverter::Init(Local<Context> context, NamedPropertyGetterCallback structPropertyGetter,
                         NamedPropertySetterCallbackV2 structPropertySetter) {
   Isolate* isolate = v8::Isolate::GetCurrent();
@@ -568,7 +570,16 @@ void ArgConverter::ConstructObject(Local<Context> context, const FunctionCallbac
   // be claimed with takeRetainedValue — so that path takes its own reference.
   bool resultIsOwned = false;
 
-  if (info.Length() == 1) {
+  auto cache = Caches::Get(isolate);
+  if (cache->PendingESAdopt != nullptr) {
+    // Adopt path: native already created this object. Bind it to the ES
+    // construct and do not alloc/init again (that would be N2, or recurse).
+    result = (__bridge id)cache->PendingESAdopt;
+    cache->PendingESAdopt = nullptr;
+    resultIsOwned = false;
+  }
+
+  if (result == nil && info.Length() == 1) {
     BaseDataWrapper* wrapper = tns::GetValue(isolate, info[0]);
     if (wrapper != nullptr && wrapper->Type() == WrapperType::Pointer) {
       PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
@@ -599,7 +610,6 @@ void ArgConverter::ConstructObject(Local<Context> context, const FunctionCallbac
     resultIsOwned = true;
   }
 
-  auto cache = Caches::Get(isolate);
   auto poInstance = ArgConverter::FindCachedInstance(isolate, cache, result);
   if (poInstance != nullptr) {
     // An initializer that answered with an already wrapped object (a singleton,
@@ -816,6 +826,53 @@ std::vector<Local<Value>> ArgConverter::GetInitializerArgs(Local<Object> obj,
   return args;
 }
 
+static bool TryConstructESDerivedInstance(Local<Context> context, id target, Local<Value>& out) {
+  Isolate* isolate = context->GetIsolate();
+  auto cache = Caches::Get(isolate);
+  if (cache->PendingESAdopt != nullptr) {
+    return false;
+  }
+
+  const char* className = object_getClassName(target);
+  if (className == nullptr) {
+    return false;
+  }
+
+  auto it = cache->CtorFuncs.find(std::string_view(className));
+  if (it == cache->CtorFuncs.end()) {
+    return false;
+  }
+
+  Local<v8::Function> ctor = it->second->Get(isolate);
+  BaseDataWrapper* ctorWrapper = tns::GetValue(isolate, ctor);
+  if (ctorWrapper == nullptr || ctorWrapper->Type() != WrapperType::ObjCClass) {
+    return false;
+  }
+  if (!static_cast<ObjCClassWrapper*>(ctorWrapper)->ESDerivedClass()) {
+    return false;
+  }
+
+  cache->PendingESAdopt = (__bridge void*)target;
+  TryCatch tc(isolate);
+  Local<Value> constructed;
+  bool ok = ctor->CallAsConstructor(context, 0, nullptr).ToLocal(&constructed);
+  cache->PendingESAdopt = nullptr;
+  if (!ok) {
+    throw NativeScriptException(isolate, tc, "Failed to construct ES class for native instance");
+  }
+
+  auto cached = ArgConverter::FindCachedInstance(isolate, cache, target);
+  if (cached != nullptr) {
+    out = cached->Get(isolate);
+    return true;
+  }
+  if (!constructed.IsEmpty() && constructed->IsObject()) {
+    out = constructed;
+    return true;
+  }
+  return false;
+}
+
 Local<Value> ArgConverter::CreateJsWrapper(Local<Context> context, BaseDataWrapper* wrapper,
                                            Local<Object> receiver, bool skipGCRegistration,
                                            const std::vector<std::string>& additionalProtocols) {
@@ -892,10 +949,17 @@ Local<Value> ArgConverter::CreateJsWrapper(Local<Context> context, BaseDataWrapp
 
   auto cache = Caches::Get(isolate);
   if (receiver.IsEmpty()) {
-    auto it = cache->Instances.find(target);
-    if (it != cache->Instances.end()) {
-      receiver = it->second->Get(isolate).As<Object>();
+    auto cached = ArgConverter::FindCachedInstance(isolate, cache, target);
+    if (cached != nullptr) {
+      receiver = cached->Get(isolate).As<Object>();
     } else {
+      tns::Assert(cache->PendingESAdopt != (__bridge void*)target, isolate);
+
+      Local<Value> constructed;
+      if (TryConstructESDerivedInstance(context, target, constructed)) {
+        return constructed;
+      }
+
       std::shared_ptr<Persistent<Value>> poValue = CreateEmptyObject(context, skipGCRegistration);
       receiver = poValue->Get(isolate).As<Object>();
       tns::SetValue(isolate, receiver, wrapper);

--- a/NativeScript/runtime/Caches.h
+++ b/NativeScript/runtime/Caches.h
@@ -144,6 +144,12 @@ class Caches {
 
   robin_hood::unordered_map<id, std::shared_ptr<v8::Persistent<v8::Value>>>
       Instances;
+
+  // Native object being adopted by an in-flight ES construct (CreateJsWrapper
+  // → CallAsConstructor → super()). void* so this header stays includable
+  // from C++ TUs; .mm files cast to/from id. ConstructObject consumes it
+  // so super() binds that id and does not alloc/init again.
+  void* PendingESAdopt = nullptr;
   robin_hood::unordered_map<std::pair<void*, std::string>,
                             std::shared_ptr<v8::Persistent<v8::Value>>,
                             pair_hash>

--- a/NativeScript/runtime/ClassBuilder.h
+++ b/NativeScript/runtime/ClassBuilder.h
@@ -1,6 +1,9 @@
 #ifndef ClassBuilder_h
 #define ClassBuilder_h
 
+#include <string>
+#include <unordered_set>
+
 #include "Common.h"
 #include "Metadata.h"
 
@@ -28,6 +31,16 @@ public:
     static void RegisterBaseTypeScriptExtendsFunction(v8::Local<v8::Context> context);
     static void RegisterNativeTypeScriptExtendsFunction(v8::Local<v8::Context> context);
     static std::string GetTypeEncoding(const TypeEncoding* typeEncoding, int argsCount);
+
+    // Lazily registers an Objective-C subclass for a plain ES `class X extends NativeBase {}`
+    // constructor function. Returns the registered class, or nil when ctorFunc is not part of a
+    // native inheritance chain (or the chain goes through a legacy `.extend()`-created class).
+    // Idempotent: subsequent calls return the cached class from the ctor's ObjCClassWrapper.
+    static Class EnsureExtendedClass(v8::Local<v8::Context> context, v8::Local<v8::Function> ctorFunc);
+
+    // Resolves the Objective-C class that should be instantiated for a construct call, honoring
+    // `new.target` so that plain ES subclasses of native classes get their own registered class.
+    static Class ResolveConstructedClass(v8::Local<v8::Context> context, v8::Local<v8::Value> newTarget, Class fallback);
 private:
     static std::atomic<unsigned long long> classNameCounter_;
 
@@ -35,7 +48,8 @@ private:
     static void SuperAccessorGetterCallback(v8::Local<v8::Name> name, const v8::PropertyCallbackInfo<v8::Value>& info);
     static void ExtendedClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
-    static void ExposeDynamicMethods(v8::Local<v8::Context> context, Class extendedClass, v8::Local<v8::Value> exposedMethods, v8::Local<v8::Value> exposedProtocols, v8::Local<v8::Object> implementationObject);
+    static void SwizzleRetainRelease(v8::Isolate* isolate, Class extendedClass);
+    static void ExposeDynamicMethods(v8::Local<v8::Context> context, Class extendedClass, v8::Local<v8::Value> exposedMethods, v8::Local<v8::Value> exposedProtocols, v8::Local<v8::Object> implementationObject, std::unordered_set<std::string>* visitedNames = nullptr);
     static void ExposeDynamicMembers(v8::Local<v8::Context> context, Class extendedClass, v8::Local<v8::Object> implementationObject, v8::Local<v8::Object> nativeSignature);
     static void VisitMethods(Class extendedClass, std::string methodName, const BaseClassMeta* meta, std::vector<const MethodMeta*>& methodMetas, std::vector<const ProtocolMeta*> exposedProtocols);
     static void VisitProperties(std::string propertyName, const BaseClassMeta* meta, std::vector<const PropertyMeta*>& propertyMetas, std::vector<const ProtocolMeta*> exposedProtocols);

--- a/NativeScript/runtime/ClassBuilder.h
+++ b/NativeScript/runtime/ClassBuilder.h
@@ -1,6 +1,9 @@
 #ifndef ClassBuilder_h
 #define ClassBuilder_h
 
+#include <string>
+#include <unordered_set>
+
 #include "Common.h"
 #include "Metadata.h"
 
@@ -38,6 +41,22 @@ class ClassBuilder {
   static std::string GetTypeEncoding(const TypeEncoding* typeEncoding,
                                      int argsCount);
 
+  // Lazily registers an Objective-C subclass for a plain ES
+  // `class X extends NativeBase {}` constructor function. Returns the
+  // registered class, or nil when ctorFunc is not part of a native inheritance
+  // chain (or the chain goes through a legacy `.extend()`-created class).
+  // Idempotent: subsequent calls return the cached class from the ctor's
+  // ObjCClassWrapper.
+  static Class EnsureExtendedClass(v8::Local<v8::Context> context,
+                                   v8::Local<v8::Function> ctorFunc);
+
+  // Resolves the Objective-C class that should be instantiated for a construct
+  // call, honoring `new.target` so that plain ES subclasses of native classes
+  // get their own registered class.
+  static Class ResolveConstructedClass(v8::Local<v8::Context> context,
+                                       v8::Local<v8::Value> newTarget,
+                                       Class fallback);
+
  private:
   static std::atomic<unsigned long long> classNameCounter_;
 
@@ -47,11 +66,13 @@ class ClassBuilder {
   static void ExtendedClassConstructorCallback(
       const v8::FunctionCallbackInfo<v8::Value>& info);
 
-  static void ExposeDynamicMethods(v8::Local<v8::Context> context,
-                                   Class extendedClass,
-                                   v8::Local<v8::Value> exposedMethods,
-                                   v8::Local<v8::Value> exposedProtocols,
-                                   v8::Local<v8::Object> implementationObject);
+  static void SwizzleRetainRelease(v8::Isolate* isolate, Class extendedClass);
+  static void ExposeDynamicMethods(
+      v8::Local<v8::Context> context, Class extendedClass,
+      v8::Local<v8::Value> exposedMethods,
+      v8::Local<v8::Value> exposedProtocols,
+      v8::Local<v8::Object> implementationObject,
+      std::unordered_set<std::string>* visitedNames = nullptr);
   static void ExposeDynamicMembers(v8::Local<v8::Context> context,
                                    Class extendedClass,
                                    v8::Local<v8::Object> implementationObject,

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -141,7 +141,7 @@ void ClassBuilder::ExtendedClassConstructorCallback(const FunctionCallbackInfo<V
 
   try {
     CacheItem* item = static_cast<CacheItem*>(info.Data().As<External>()->Value());
-    Class klass = item->data_;
+    Class klass = ClassBuilder::ResolveConstructedClass(context, info.NewTarget(), item->data_);
 
     ArgConverter::ConstructObject(context, info, klass);
   } catch (NativeScriptException& ex) {
@@ -295,104 +295,7 @@ void ClassBuilder::RegisterNativeTypeScriptExtendsFunction(Local<Context> contex
         class_addMethod(object_getClass(extendedClass), @selector(initialize), newInitialize,
                         "v@:");
 
-        /// We swizzle the retain and release methods for the following reason:
-        /// When we instantiate a native class via a JavaScript call we add it to the object
-        /// instances map thus incrementing the retainCount by 1. Then, when the native object is
-        /// referenced somewhere else its count will become more than 1. Since we want to keep the
-        /// corresponding JavaScript object alive even if it is not used anywhere, we call GcProtect
-        /// on it. Whenever the native object is released so that its retainCount is 1 (the object
-        /// instances map), we unprotect the corresponding JavaScript object in order to make both
-        /// of them destroyable/GC-able. When the JavaScript object is GC-ed we release the native
-        /// counterpart as well.
-        void (*retain)(id, SEL) =
-            (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(retain));
-        IMP newRetain = imp_implementationWithBlock(^(id self) {
-          if (!isolateWrapper.IsValid()) {
-            return retain(self, @selector(retain));
-          }
-          if ([self retainCount] == 1) {
-            auto runtime = Runtime::GetRuntime(isolate);
-            auto runtimeLoop = runtime->RuntimeLoop();
-            void* weakSelf = (__bridge void*)self;
-            auto gcProtect = ^() {
-              auto innerCache = isolateWrapper.GetCache();
-              auto it = innerCache->Instances.find((id)weakSelf);
-              if (it != innerCache->Instances.end()) {
-                v8::Locker locker(isolate);
-                Isolate::Scope isolate_scope(isolate);
-                HandleScope handle_scope(isolate);
-                Local<Value> value = it->second->Get(isolate);
-                BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-                if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
-                  ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                  objcWrapper->GcProtect();
-                }
-              }
-            };
-            if (CFRunLoopGetCurrent() != runtimeLoop) {
-              tns::ExecuteOnRunLoop(runtimeLoop, gcProtect);
-            } else {
-              gcProtect();
-            }
-          }
-
-          return retain(self, @selector(retain));
-        });
-        class_addMethod(extendedClass, @selector(retain), newRetain, "@@:");
-
-        void (*release)(id, SEL) =
-            (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(release));
-        IMP newRelease = imp_implementationWithBlock(^(id self) {
-          if (!isolateWrapper.IsValid()) {
-            release(self, @selector(release));
-            return;
-          }
-
-          if ([self retainCount] == 2) {
-            void* weakSelf = (__bridge void*)self;
-            auto gcUnprotect = ^() {
-              auto innerCache = isolateWrapper.GetCache();
-              auto it = innerCache->Instances.find((id)weakSelf);
-              if (it != innerCache->Instances.end()) {
-                v8::Locker locker(isolate);
-                Isolate::Scope isolate_scope(isolate);
-                HandleScope handle_scope(isolate);
-                if (it->second != nullptr) {
-                  Local<Value> value = it->second->Get(isolate);
-                  BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-                  if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
-                    ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                    objcWrapper->GcUnprotect();
-                  }
-                }
-              }
-            };
-            auto runtime = Runtime::GetRuntime(isolate);
-            auto runtimeLoop = runtime->RuntimeLoop();
-            if (CFRunLoopGetCurrent() != runtimeLoop) {
-              tns::ExecuteOnRunLoop(runtimeLoop, gcUnprotect);
-            } else {
-              auto innerCache = isolateWrapper.GetCache();
-              auto it = innerCache->Instances.find(self);
-              if (it != innerCache->Instances.end()) {
-                v8::Locker locker(isolate);
-                Isolate::Scope isolate_scope(isolate);
-                HandleScope handle_scope(isolate);
-                if (it->second != nullptr) {
-                  Local<Value> value = it->second->Get(isolate);
-                  BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-                  if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
-                    ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                    objcWrapper->GcUnprotect();
-                  }
-                }
-              }
-            }
-          }
-
-          release(self, @selector(release));
-        });
-        class_addMethod(extendedClass, @selector(release), newRelease, "v@:");
+        ClassBuilder::SwizzleRetainRelease(isolate, extendedClass);
 
         info.GetReturnValue().SetUndefined();
       }).ToLocalChecked();
@@ -402,6 +305,247 @@ void ClassBuilder::RegisterNativeTypeScriptExtendsFunction(Local<Context> contex
       global->DefineOwnProperty(context, tns::ToV8String(isolate, "__extends"), extendsFunc, flags)
           .FromMaybe(false);
   tns::Assert(success, isolate);
+}
+
+void ClassBuilder::SwizzleRetainRelease(Isolate* isolate, Class extendedClass) {
+  IsolateWrapper isolateWrapper(isolate);
+
+  /// We swizzle the retain and release methods for the following reason:
+  /// When we instantiate a native class via a JavaScript call we add it to the object
+  /// instances map thus incrementing the retainCount by 1. Then, when the native object is
+  /// referenced somewhere else its count will become more than 1. Since we want to keep the
+  /// corresponding JavaScript object alive even if it is not used anywhere, we call GcProtect
+  /// on it. Whenever the native object is released so that its retainCount is 1 (the object
+  /// instances map), we unprotect the corresponding JavaScript object in order to make both
+  /// of them destroyable/GC-able. When the JavaScript object is GC-ed we release the native
+  /// counterpart as well.
+  void (*retain)(id, SEL) =
+      (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(retain));
+  IMP newRetain = imp_implementationWithBlock(^(id self) {
+    if (!isolateWrapper.IsValid()) {
+      return retain(self, @selector(retain));
+    }
+    if ([self retainCount] == 1) {
+      auto runtime = Runtime::GetRuntime(isolate);
+      auto runtimeLoop = runtime->RuntimeLoop();
+      void* weakSelf = (__bridge void*)self;
+      auto gcProtect = ^() {
+        auto innerCache = isolateWrapper.GetCache();
+        auto it = innerCache->Instances.find((id)weakSelf);
+        if (it != innerCache->Instances.end()) {
+          v8::Locker locker(isolate);
+          Isolate::Scope isolate_scope(isolate);
+          HandleScope handle_scope(isolate);
+          Local<Value> value = it->second->Get(isolate);
+          BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+          if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
+            ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+            objcWrapper->GcProtect();
+          }
+        }
+      };
+      if (CFRunLoopGetCurrent() != runtimeLoop) {
+        tns::ExecuteOnRunLoop(runtimeLoop, gcProtect);
+      } else {
+        gcProtect();
+      }
+    }
+
+    return retain(self, @selector(retain));
+  });
+  class_addMethod(extendedClass, @selector(retain), newRetain, "@@:");
+
+  void (*release)(id, SEL) =
+      (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(release));
+  IMP newRelease = imp_implementationWithBlock(^(id self) {
+    if (!isolateWrapper.IsValid()) {
+      release(self, @selector(release));
+      return;
+    }
+
+    if ([self retainCount] == 2) {
+      void* weakSelf = (__bridge void*)self;
+      auto gcUnprotect = ^() {
+        auto innerCache = isolateWrapper.GetCache();
+        auto it = innerCache->Instances.find((id)weakSelf);
+        if (it != innerCache->Instances.end()) {
+          v8::Locker locker(isolate);
+          Isolate::Scope isolate_scope(isolate);
+          HandleScope handle_scope(isolate);
+          if (it->second != nullptr) {
+            Local<Value> value = it->second->Get(isolate);
+            BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+            if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
+              ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+              objcWrapper->GcUnprotect();
+            }
+          }
+        }
+      };
+      auto runtime = Runtime::GetRuntime(isolate);
+      auto runtimeLoop = runtime->RuntimeLoop();
+      if (CFRunLoopGetCurrent() != runtimeLoop) {
+        tns::ExecuteOnRunLoop(runtimeLoop, gcUnprotect);
+      } else {
+        auto innerCache = isolateWrapper.GetCache();
+        auto it = innerCache->Instances.find(self);
+        if (it != innerCache->Instances.end()) {
+          v8::Locker locker(isolate);
+          Isolate::Scope isolate_scope(isolate);
+          HandleScope handle_scope(isolate);
+          if (it->second != nullptr) {
+            Local<Value> value = it->second->Get(isolate);
+            BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+            if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
+              ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+              objcWrapper->GcUnprotect();
+            }
+          }
+        }
+      }
+    }
+
+    release(self, @selector(release));
+  });
+  class_addMethod(extendedClass, @selector(release), newRelease, "v@:");
+}
+
+Class ClassBuilder::EnsureExtendedClass(Local<Context> context, Local<v8::Function> ctorFunc) {
+  Isolate* isolate = context->GetIsolate();
+
+  // Already registered (or a native/extended constructor that carries a class wrapper)
+  BaseDataWrapper* existingWrapper = tns::GetValue(isolate, ctorFunc);
+  if (existingWrapper != nullptr) {
+    if (existingWrapper->Type() == WrapperType::ObjCClass) {
+      return static_cast<ObjCClassWrapper*>(existingWrapper)->Klass();
+    }
+    return nil;
+  }
+
+  // Walk the constructor prototype chain (mirrors the `class X extends Y` chain) and collect
+  // every plain (unregistered) ES constructor level until we reach a constructor holding an
+  // ObjCClassWrapper. ES-registered ancestors are flattened into this registration; legacy
+  // `.extend()`-created ancestors are not supported (mirrors the historic restriction) and
+  // make this function bail out so callers preserve their old behavior.
+  std::vector<Local<v8::Function>> chainCtors;
+  Local<v8::Function> current = ctorFunc;
+  Class baseClass = nil;
+  while (true) {
+    chainCtors.push_back(current);
+
+    Local<Value> parentValue = current->GetPrototype();
+    if (parentValue.IsEmpty() || !parentValue->IsObject() || !parentValue->IsFunction()) {
+      return nil;
+    }
+
+    Local<v8::Function> parent = parentValue.As<v8::Function>();
+    BaseDataWrapper* parentWrapper = tns::GetValue(isolate, parent);
+    if (parentWrapper == nullptr) {
+      current = parent;
+      continue;
+    }
+
+    if (parentWrapper->Type() != WrapperType::ObjCClass) {
+      return nil;
+    }
+
+    ObjCClassWrapper* parentClassWrapper = static_cast<ObjCClassWrapper*>(parentWrapper);
+    if (!parentClassWrapper->ExtendedClass()) {
+      baseClass = parentClassWrapper->Klass();
+      break;
+    }
+
+    if (parentClassWrapper->ESDerivedClass()) {
+      // Flatten: the parent's registered class sits directly under the pure native base, so
+      // keep walking (collecting the parent's prototype for scanning) until we reach it.
+      current = parent;
+      continue;
+    }
+
+    // Legacy `.extend()`-created base - not supported for ES class chaining.
+    return nil;
+  }
+
+  if (baseClass == nil) {
+    return nil;
+  }
+
+  auto cache = Caches::Get(isolate);
+  auto isolateId = cache->getIsolateId();
+
+  std::string baseClassName = class_getName(baseClass);
+  std::string className = tns::ToString(isolate, ctorFunc->GetName());
+
+  Class extendedClass = ClassBuilder::GetExtendedClass(baseClassName, className,
+                                                       std::to_string(isolateId) + "_");
+  class_addProtocol(extendedClass, @protocol(TNSDerivedClass));
+  class_addProtocol(object_getClass(extendedClass), @protocol(TNSDerivedClass));
+
+  // Expose members level by level, most-derived first, so JS shadowing semantics carry over to
+  // the installed Objective-C implementations. Statics like ObjCProtocols/ObjCExposedMethods are
+  // read through the constructor (inheriting through the static chain like class statics do).
+  std::unordered_set<std::string> visitedNames;
+  for (Local<v8::Function> levelCtor : chainCtors) {
+    Local<Value> prototypeValue;
+    bool success = levelCtor->Get(context, tns::ToV8String(isolate, "prototype"))
+                       .ToLocal(&prototypeValue);
+    tns::Assert(success && !prototypeValue.IsEmpty() && prototypeValue->IsObject(), isolate);
+    Local<Object> implementationObject = prototypeValue.As<Object>();
+
+    Local<Value> exposedMethods;
+    success = levelCtor->Get(context, tns::ToV8String(isolate, "ObjCExposedMethods"))
+                  .ToLocal(&exposedMethods);
+    tns::Assert(success, isolate);
+
+    Local<Value> exposedProtocols;
+    success = levelCtor->Get(context, tns::ToV8String(isolate, "ObjCProtocols"))
+                  .ToLocal(&exposedProtocols);
+    tns::Assert(success, isolate);
+
+    ClassBuilder::ExposeDynamicMethods(context, extendedClass, exposedMethods, exposedProtocols,
+                                       implementationObject, &visitedNames);
+  }
+
+  tns::SetValue(isolate, ctorFunc, new ObjCClassWrapper(extendedClass, true, true));
+
+  std::string extendedClassName = class_getName(extendedClass);
+
+  auto extendedPersistent = std::make_unique<Persistent<v8::Function>>(isolate, ctorFunc);
+  extendedPersistent->SetWrapperClassId(Constants::ClassTypes::DataWrapper);
+  cache->CtorFuncs.emplace(extendedClassName, std::move(extendedPersistent));
+
+  Local<Value> ctorPrototypeValue;
+  bool success = ctorFunc->Get(context, tns::ToV8String(isolate, "prototype"))
+                     .ToLocal(&ctorPrototypeValue);
+  tns::Assert(success && !ctorPrototypeValue.IsEmpty() && ctorPrototypeValue->IsObject(), isolate);
+  cache->ClassPrototypes.emplace(extendedClassName,
+                                 std::make_unique<Persistent<Object>>(
+                                     isolate, ctorPrototypeValue.As<Object>()));
+
+  ClassBuilder::SwizzleRetainRelease(isolate, extendedClass);
+
+  return extendedClass;
+}
+
+Class ClassBuilder::ResolveConstructedClass(Local<Context> context, Local<Value> newTarget,
+                                            Class fallback) {
+  if (newTarget.IsEmpty() || !newTarget->IsFunction()) {
+    return fallback;
+  }
+
+  Isolate* isolate = context->GetIsolate();
+  Local<v8::Function> newTargetFunc = newTarget.As<v8::Function>();
+
+  BaseDataWrapper* wrapper = tns::GetValue(isolate, newTargetFunc);
+  if (wrapper != nullptr) {
+    if (wrapper->Type() == WrapperType::ObjCClass) {
+      return static_cast<ObjCClassWrapper*>(wrapper)->Klass();
+    }
+    return fallback;
+  }
+
+  Class ensured = ClassBuilder::EnsureExtendedClass(context, newTargetFunc);
+  return ensured != nil ? ensured : fallback;
 }
 
 void ClassBuilder::ExposeDynamicMembers(v8::Local<v8::Context> context, Class extendedClass,
@@ -578,7 +722,8 @@ BinaryTypeEncodingType ClassBuilder::GetTypeEncodingType(Isolate* isolate, Local
 
 void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedClass,
                                         Local<Value> exposedMethods, Local<Value> exposedProtocols,
-                                        Local<Object> implementationObject) {
+                                        Local<Object> implementationObject,
+                                        std::unordered_set<std::string>* visitedNames) {
   Isolate* isolate = context->GetIsolate();
   std::vector<const ProtocolMeta*> protocols;
   if (!exposedProtocols.IsEmpty() && exposedProtocols->IsArray()) {
@@ -612,6 +757,13 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
       Local<Value> methodName;
       bool success = methodNames->Get(context, i).ToLocal(&methodName);
       tns::Assert(success, isolate);
+
+      // When flattening a multi-level ES class chain, skip names already exposed by a more
+      // derived level (JS shadowing semantics)
+      if (visitedNames != nullptr &&
+          !visitedNames->insert("exposed:" + tns::ToString(isolate, methodName)).second) {
+        continue;
+      }
 
       Local<Value> methodSignature;
       success = exposedMethods.As<Object>()->Get(context, methodName).ToLocal(&methodSignature);
@@ -700,7 +852,8 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
       implementationObject->Get(context, Symbol::GetIterator(isolate)).ToLocal(&symbolIterator);
   tns::Assert(success, isolate);
 
-  if (!symbolIterator.IsEmpty() && symbolIterator->IsFunction()) {
+  if (!symbolIterator.IsEmpty() && symbolIterator->IsFunction() &&
+      !class_conformsToProtocol(extendedClass, @protocol(NSFastEnumeration))) {
     Local<v8::Function> symbolIteratorFunc = symbolIterator.As<v8::Function>();
 
     class_addProtocol(extendedClass, @protocol(NSFastEnumeration));
@@ -723,7 +876,14 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
         isolate);
   }
 
-  tns::Assert(implementationObject->GetOwnPropertyNames(context).ToLocal(&propertyNames), isolate);
+  // Use ALL_PROPERTIES so that non-enumerable members are picked up too - methods and accessors
+  // declared with ES class syntax are non-enumerable, unlike the plain object literals passed to
+  // the legacy `.extend()` API.
+  PropertyFilter propertyFilter =
+      static_cast<PropertyFilter>(PropertyFilter::ALL_PROPERTIES | PropertyFilter::SKIP_SYMBOLS);
+  tns::Assert(
+      implementationObject->GetOwnPropertyNames(context, propertyFilter).ToLocal(&propertyNames),
+      isolate);
   for (uint32_t i = 0; i < propertyNames->Length(); i++) {
     Local<Value> key;
     bool success = propertyNames->Get(context, i).ToLocal(&key);
@@ -733,6 +893,16 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
     }
 
     std::string methodName = tns::ToString(isolate, key);
+
+    if (methodName == "constructor") {
+      continue;
+    }
+
+    // When flattening a multi-level ES class chain, skip names already handled by a more derived
+    // level (JS shadowing semantics)
+    if (visitedNames != nullptr && !visitedNames->insert(methodName).second) {
+      continue;
+    }
 
     Local<Value> propertyDescriptor;
     tns::Assert(implementationObject->GetOwnPropertyDescriptor(context, key.As<v8::Name>())

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -163,7 +163,7 @@ void ClassBuilder::ExtendedClassConstructorCallback(const FunctionCallbackInfo<V
   try {
     CacheItem* item = static_cast<CacheItem*>(
         info.Data().As<External>()->Value(v8::kExternalPointerTypeTagDefault));
-    Class klass = item->data_;
+    Class klass = ClassBuilder::ResolveConstructedClass(context, info.NewTarget(), item->data_);
 
     ArgConverter::ConstructObject(context, info, klass);
   } catch (NativeScriptException& ex) {
@@ -302,108 +302,7 @@ void ClassBuilder::RegisterNativeTypeScriptExtendsFunction(Local<Context> contex
         class_addMethod(object_getClass(extendedClass), @selector(initialize), newInitialize,
                         "v@:");
 
-        /// We swizzle the retain and release methods for the following reason:
-        /// When we instantiate a native class via a JavaScript call we add it to the object
-        /// instances map thus incrementing the retainCount by 1. Then, when the native object is
-        /// referenced somewhere else its count will become more than 1. Since we want to keep the
-        /// corresponding JavaScript object alive even if it is not used anywhere, we call GcProtect
-        /// on it. Whenever the native object is released so that its retainCount is 1 (the object
-        /// instances map), we unprotect the corresponding JavaScript object in order to make both
-        /// of them destroyable/GC-able. When the JavaScript object is GC-ed we release the native
-        /// counterpart as well.
-        void (*retain)(id, SEL) =
-            (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(retain));
-        IMP newRetain = imp_implementationWithBlock(^(id self) {
-          if (!isolateWrapper.IsValid()) {
-            return retain(self, @selector(retain));
-          }
-          if ([self retainCount] == 1) {
-            auto runtime = Runtime::GetRuntime(isolate);
-            auto runtimeLoop = runtime->RuntimeLoop();
-            void* weakSelf = (__bridge void*)self;
-            auto gcProtect = [isolateWrapper, weakSelf, isolate]() {
-              auto innerCache = isolateWrapper.GetCache();
-              auto it = innerCache->Instances.find((id)weakSelf);
-              if (it != innerCache->Instances.end()) {
-                v8::Locker locker(isolate);
-                Isolate::Scope isolate_scope(isolate);
-                HandleScope handle_scope(isolate);
-                Local<Value> value = it->second->Get(isolate);
-                BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-                if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
-                  ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                  objcWrapper->GcProtect();
-                }
-              }
-            };
-            if (CFRunLoopGetCurrent() != runtimeLoop) {
-              // bare entry: the closure does its own Locker ceremony, exactly
-              // like the performed block it replaces
-              runtime->GetEventLoop()->PostInternalBare(gcProtect);
-            } else {
-              gcProtect();
-            }
-          }
-
-          return retain(self, @selector(retain));
-        });
-        class_addMethod(extendedClass, @selector(retain), newRetain, "@@:");
-
-        void (*release)(id, SEL) =
-            (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(release));
-        IMP newRelease = imp_implementationWithBlock(^(id self) {
-          if (!isolateWrapper.IsValid()) {
-            release(self, @selector(release));
-            return;
-          }
-
-          if ([self retainCount] == 2) {
-            void* weakSelf = (__bridge void*)self;
-            auto gcUnprotect = [isolateWrapper, weakSelf, isolate]() {
-              auto innerCache = isolateWrapper.GetCache();
-              auto it = innerCache->Instances.find((id)weakSelf);
-              if (it != innerCache->Instances.end()) {
-                v8::Locker locker(isolate);
-                Isolate::Scope isolate_scope(isolate);
-                HandleScope handle_scope(isolate);
-                if (it->second != nullptr) {
-                  Local<Value> value = it->second->Get(isolate);
-                  BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-                  if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
-                    ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                    objcWrapper->GcUnprotect();
-                  }
-                }
-              }
-            };
-            auto runtime = Runtime::GetRuntime(isolate);
-            auto runtimeLoop = runtime->RuntimeLoop();
-            if (CFRunLoopGetCurrent() != runtimeLoop) {
-              // bare entry: the closure does its own Locker ceremony, exactly
-              // like the performed block it replaces
-              runtime->GetEventLoop()->PostInternalBare(gcUnprotect);
-            } else {
-              auto innerCache = isolateWrapper.GetCache();
-              auto it = innerCache->Instances.find(self);
-              if (it != innerCache->Instances.end()) {
-                v8::Locker locker(isolate);
-                Isolate::Scope isolate_scope(isolate);
-                HandleScope handle_scope(isolate);
-                if (it->second != nullptr) {
-                  Local<Value> value = it->second->Get(isolate);
-                  BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-                  if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
-                    ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
-                    objcWrapper->GcUnprotect();
-                  }
-                }
-              }
-            }
-          }
-
-          release(self, @selector(release));
-        });
-        class_addMethod(extendedClass, @selector(release), newRelease, "v@:");
+        ClassBuilder::SwizzleRetainRelease(isolate, extendedClass);
 
         info.GetReturnValue().SetUndefined();
       }).ToLocalChecked();
@@ -413,6 +312,252 @@ void ClassBuilder::RegisterNativeTypeScriptExtendsFunction(Local<Context> contex
       global->DefineOwnProperty(context, tns::ToV8String(isolate, "__extends"), extendsFunc, flags)
           .FromMaybe(false);
   tns::Assert(success, isolate);
+}
+
+void ClassBuilder::SwizzleRetainRelease(Isolate* isolate, Class extendedClass) {
+  IsolateWrapper isolateWrapper(isolate);
+
+  /// We swizzle the retain and release methods for the following reason:
+  /// When we instantiate a native class via a JavaScript call we add it to the object
+  /// instances map thus incrementing the retainCount by 1. Then, when the native object is
+  /// referenced somewhere else its count will become more than 1. Since we want to keep the
+  /// corresponding JavaScript object alive even if it is not used anywhere, we call GcProtect
+  /// on it. Whenever the native object is released so that its retainCount is 1 (the object
+  /// instances map), we unprotect the corresponding JavaScript object in order to make both
+  /// of them destroyable/GC-able. When the JavaScript object is GC-ed we release the native
+  /// counterpart as well.
+  void (*retain)(id, SEL) =
+      (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(retain));
+  IMP newRetain = imp_implementationWithBlock(^(id self) {
+    if (!isolateWrapper.IsValid()) {
+      return retain(self, @selector(retain));
+    }
+    if ([self retainCount] == 1) {
+      auto runtime = Runtime::GetRuntime(isolate);
+      auto runtimeLoop = runtime->RuntimeLoop();
+      void* weakSelf = (__bridge void*)self;
+      auto gcProtect = [isolateWrapper, weakSelf, isolate]() {
+        auto innerCache = isolateWrapper.GetCache();
+        auto it = innerCache->Instances.find((id)weakSelf);
+        if (it != innerCache->Instances.end()) {
+          v8::Locker locker(isolate);
+          Isolate::Scope isolate_scope(isolate);
+          HandleScope handle_scope(isolate);
+          Local<Value> value = it->second->Get(isolate);
+          BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+          if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
+            ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+            objcWrapper->GcProtect();
+          }
+        }
+      };
+      if (CFRunLoopGetCurrent() != runtimeLoop) {
+        // bare entry: the closure does its own Locker ceremony, exactly
+        // like the performed block it replaces
+        runtime->GetEventLoop()->PostInternalBare(gcProtect);
+      } else {
+        gcProtect();
+      }
+    }
+
+    return retain(self, @selector(retain));
+  });
+  class_addMethod(extendedClass, @selector(retain), newRetain, "@@:");
+
+  void (*release)(id, SEL) =
+      (void (*)(id, SEL))FindNotOverridenMethod(extendedClass, @selector(release));
+  IMP newRelease = imp_implementationWithBlock(^(id self) {
+    if (!isolateWrapper.IsValid()) {
+      release(self, @selector(release));
+      return;
+    }
+
+    if ([self retainCount] == 2) {
+      void* weakSelf = (__bridge void*)self;
+      auto gcUnprotect = [isolateWrapper, weakSelf, isolate]() {
+        auto innerCache = isolateWrapper.GetCache();
+        auto it = innerCache->Instances.find((id)weakSelf);
+        if (it != innerCache->Instances.end()) {
+          v8::Locker locker(isolate);
+          Isolate::Scope isolate_scope(isolate);
+          HandleScope handle_scope(isolate);
+          if (it->second != nullptr) {
+            Local<Value> value = it->second->Get(isolate);
+            BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+            if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
+              ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+              objcWrapper->GcUnprotect();
+            }
+          }
+        }
+      };
+      auto runtime = Runtime::GetRuntime(isolate);
+      auto runtimeLoop = runtime->RuntimeLoop();
+      if (CFRunLoopGetCurrent() != runtimeLoop) {
+        // bare entry: the closure does its own Locker ceremony, exactly
+        // like the performed block it replaces
+        runtime->GetEventLoop()->PostInternalBare(gcUnprotect);
+      } else {
+        auto innerCache = isolateWrapper.GetCache();
+        auto it = innerCache->Instances.find(self);
+        if (it != innerCache->Instances.end()) {
+          v8::Locker locker(isolate);
+          Isolate::Scope isolate_scope(isolate);
+          HandleScope handle_scope(isolate);
+          if (it->second != nullptr) {
+            Local<Value> value = it->second->Get(isolate);
+            BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
+            if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
+              ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
+              objcWrapper->GcUnprotect();
+            }
+          }
+        }
+      }
+    }
+
+    release(self, @selector(release));
+  });
+  class_addMethod(extendedClass, @selector(release), newRelease, "v@:");
+}
+
+Class ClassBuilder::EnsureExtendedClass(Local<Context> context, Local<v8::Function> ctorFunc) {
+  Isolate* isolate = context->GetIsolate();
+
+  // Already registered (or a native/extended constructor that carries a class wrapper)
+  BaseDataWrapper* existingWrapper = tns::GetValue(isolate, ctorFunc);
+  if (existingWrapper != nullptr) {
+    if (existingWrapper->Type() == WrapperType::ObjCClass) {
+      return static_cast<ObjCClassWrapper*>(existingWrapper)->Klass();
+    }
+    return nil;
+  }
+
+  // Walk the constructor prototype chain (mirrors the `class X extends Y` chain) and collect
+  // every plain (unregistered) ES constructor level until we reach a constructor holding an
+  // ObjCClassWrapper. ES-registered ancestors are flattened into this registration; legacy
+  // `.extend()`-created ancestors are not supported (mirrors the historic restriction) and
+  // make this function bail out so callers preserve their old behavior.
+  std::vector<Local<v8::Function>> chainCtors;
+  Local<v8::Function> current = ctorFunc;
+  Class baseClass = nil;
+  while (true) {
+    chainCtors.push_back(current);
+
+    Local<Value> parentValue = current->GetPrototype();
+    if (parentValue.IsEmpty() || !parentValue->IsObject() || !parentValue->IsFunction()) {
+      return nil;
+    }
+
+    Local<v8::Function> parent = parentValue.As<v8::Function>();
+    BaseDataWrapper* parentWrapper = tns::GetValue(isolate, parent);
+    if (parentWrapper == nullptr) {
+      current = parent;
+      continue;
+    }
+
+    if (parentWrapper->Type() != WrapperType::ObjCClass) {
+      return nil;
+    }
+
+    ObjCClassWrapper* parentClassWrapper = static_cast<ObjCClassWrapper*>(parentWrapper);
+    if (!parentClassWrapper->ExtendedClass()) {
+      baseClass = parentClassWrapper->Klass();
+      break;
+    }
+
+    if (parentClassWrapper->ESDerivedClass()) {
+      // Flatten: the parent's registered class sits directly under the pure native base, so
+      // keep walking (collecting the parent's prototype for scanning) until we reach it.
+      current = parent;
+      continue;
+    }
+
+    // Legacy `.extend()`-created base - not supported for ES class chaining.
+    return nil;
+  }
+
+  if (baseClass == nil) {
+    return nil;
+  }
+
+  auto cache = Caches::Get(isolate);
+  auto isolateId = cache->getIsolateId();
+
+  std::string baseClassName = class_getName(baseClass);
+  std::string className = tns::ToString(isolate, ctorFunc->GetName());
+
+  ScopeClassNameToIsolate(className, isolateId);
+  Class extendedClass = ClassBuilder::GetExtendedClass(baseClassName, className, isolateId);
+  tns::Assert(extendedClass != nil, isolate);
+  class_addProtocol(extendedClass, @protocol(TNSDerivedClass));
+  class_addProtocol(object_getClass(extendedClass), @protocol(TNSDerivedClass));
+
+  // Expose members level by level, most-derived first, so JS shadowing semantics carry over to
+  // the installed Objective-C implementations. Statics like ObjCProtocols/ObjCExposedMethods are
+  // read through the constructor (inheriting through the static chain like class statics do).
+  std::unordered_set<std::string> visitedNames;
+  for (Local<v8::Function> levelCtor : chainCtors) {
+    Local<Value> prototypeValue;
+    bool success = levelCtor->Get(context, tns::ToV8String(isolate, "prototype"))
+                       .ToLocal(&prototypeValue);
+    tns::Assert(success && !prototypeValue.IsEmpty() && prototypeValue->IsObject(), isolate);
+    Local<Object> implementationObject = prototypeValue.As<Object>();
+
+    Local<Value> exposedMethods;
+    success = levelCtor->Get(context, tns::ToV8String(isolate, "ObjCExposedMethods"))
+                  .ToLocal(&exposedMethods);
+    tns::Assert(success, isolate);
+
+    Local<Value> exposedProtocols;
+    success = levelCtor->Get(context, tns::ToV8String(isolate, "ObjCProtocols"))
+                  .ToLocal(&exposedProtocols);
+    tns::Assert(success, isolate);
+
+    ClassBuilder::ExposeDynamicMethods(context, extendedClass, exposedMethods, exposedProtocols,
+                                       implementationObject, &visitedNames);
+  }
+
+  tns::SetValue(isolate, ctorFunc, new ObjCClassWrapper(extendedClass, true, true));
+
+  std::string extendedClassName = class_getName(extendedClass);
+
+  auto extendedPersistent = std::make_unique<Persistent<v8::Function>>(isolate, ctorFunc);
+  extendedPersistent->SetWrapperClassId(Constants::ClassTypes::DataWrapper);
+  cache->CtorFuncs.emplace(extendedClassName, std::move(extendedPersistent));
+
+  Local<Value> ctorPrototypeValue;
+  bool success = ctorFunc->Get(context, tns::ToV8String(isolate, "prototype"))
+                     .ToLocal(&ctorPrototypeValue);
+  tns::Assert(success && !ctorPrototypeValue.IsEmpty() && ctorPrototypeValue->IsObject(), isolate);
+  cache->ClassPrototypes.emplace(extendedClassName,
+                                 std::make_unique<Persistent<Object>>(
+                                     isolate, ctorPrototypeValue.As<Object>()));
+
+  ClassBuilder::SwizzleRetainRelease(isolate, extendedClass);
+
+  return extendedClass;
+}
+
+Class ClassBuilder::ResolveConstructedClass(Local<Context> context, Local<Value> newTarget,
+                                            Class fallback) {
+  if (newTarget.IsEmpty() || !newTarget->IsFunction()) {
+    return fallback;
+  }
+
+  Isolate* isolate = context->GetIsolate();
+  Local<v8::Function> newTargetFunc = newTarget.As<v8::Function>();
+
+  BaseDataWrapper* wrapper = tns::GetValue(isolate, newTargetFunc);
+  if (wrapper != nullptr) {
+    if (wrapper->Type() == WrapperType::ObjCClass) {
+      return static_cast<ObjCClassWrapper*>(wrapper)->Klass();
+    }
+    return fallback;
+  }
+
+  Class ensured = ClassBuilder::EnsureExtendedClass(context, newTargetFunc);
+  return ensured != nil ? ensured : fallback;
 }
 
 void ClassBuilder::ExposeDynamicMembers(v8::Local<v8::Context> context, Class extendedClass,
@@ -589,8 +734,9 @@ BinaryTypeEncodingType ClassBuilder::GetTypeEncodingType(Isolate* isolate, Local
 
 void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedClass,
                                         Local<Value> exposedMethods, Local<Value> exposedProtocols,
-                                        Local<Object> implementationObject) {
-  Isolate* isolate = v8::Isolate::GetCurrent();
+                                        Local<Object> implementationObject,
+                                        std::unordered_set<std::string>* visitedNames) {
+  Isolate* isolate = context->GetIsolate();
   std::vector<const ProtocolMeta*> protocols;
   if (!exposedProtocols.IsEmpty() && exposedProtocols->IsArray()) {
     Local<v8::Array> protocolsArray = exposedProtocols.As<v8::Array>();
@@ -623,6 +769,13 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
       Local<Value> methodName;
       bool success = methodNames->Get(context, i).ToLocal(&methodName);
       tns::Assert(success, isolate);
+
+      // When flattening a multi-level ES class chain, skip names already exposed by a more
+      // derived level (JS shadowing semantics)
+      if (visitedNames != nullptr &&
+          !visitedNames->insert("exposed:" + tns::ToString(isolate, methodName)).second) {
+        continue;
+      }
 
       Local<Value> methodSignature;
       success = exposedMethods.As<Object>()->Get(context, methodName).ToLocal(&methodSignature);
@@ -711,7 +864,8 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
       implementationObject->Get(context, Symbol::GetIterator(isolate)).ToLocal(&symbolIterator);
   tns::Assert(success, isolate);
 
-  if (!symbolIterator.IsEmpty() && symbolIterator->IsFunction()) {
+  if (!symbolIterator.IsEmpty() && symbolIterator->IsFunction() &&
+      !class_conformsToProtocol(extendedClass, @protocol(NSFastEnumeration))) {
     Local<v8::Function> symbolIteratorFunc = symbolIterator.As<v8::Function>();
 
     class_addProtocol(extendedClass, @protocol(NSFastEnumeration));
@@ -734,7 +888,14 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
         isolate);
   }
 
-  tns::Assert(implementationObject->GetOwnPropertyNames(context).ToLocal(&propertyNames), isolate);
+  // Use ALL_PROPERTIES so that non-enumerable members are picked up too - methods and accessors
+  // declared with ES class syntax are non-enumerable, unlike the plain object literals passed to
+  // the legacy `.extend()` API.
+  PropertyFilter propertyFilter =
+      static_cast<PropertyFilter>(PropertyFilter::ALL_PROPERTIES | PropertyFilter::SKIP_SYMBOLS);
+  tns::Assert(
+      implementationObject->GetOwnPropertyNames(context, propertyFilter).ToLocal(&propertyNames),
+      isolate);
   for (uint32_t i = 0; i < propertyNames->Length(); i++) {
     Local<Value> key;
     bool success = propertyNames->Get(context, i).ToLocal(&key);
@@ -744,6 +905,16 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
     }
 
     std::string methodName = tns::ToString(isolate, key);
+
+    if (methodName == "constructor") {
+      continue;
+    }
+
+    // When flattening a multi-level ES class chain, skip names already handled by a more derived
+    // level (JS shadowing semantics)
+    if (visitedNames != nullptr && !visitedNames->insert(methodName).second) {
+      continue;
+    }
 
     Local<Value> propertyDescriptor;
     tns::Assert(implementationObject->GetOwnPropertyDescriptor(context, key.As<v8::Name>())

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -433,6 +433,13 @@ Class ClassBuilder::EnsureExtendedClass(Local<Context> context, Local<v8::Functi
     return nil;
   }
 
+  // Only the main isolate mints ES-derived ObjC classes. Workers keep
+  // NativeClass / lazy registration as a no-op so they cannot claim
+  // process-global names. Legacy `.extend()` still scopes names per isolate.
+  if (Runtime::IsWorker()) {
+    return nil;
+  }
+
   // Walk the constructor prototype chain (mirrors the `class X extends Y` chain) and collect
   // every plain (unregistered) ES constructor level until we reach a constructor holding an
   // ObjCClassWrapper. ES-registered ancestors are flattened into this registration; legacy

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -422,7 +422,7 @@ void ClassBuilder::SwizzleRetainRelease(Isolate* isolate, Class extendedClass) {
 }
 
 Class ClassBuilder::EnsureExtendedClass(Local<Context> context, Local<v8::Function> ctorFunc) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = v8::Isolate::GetCurrent();
 
   // Already registered (or a native/extended constructor that carries a class wrapper)
   BaseDataWrapper* existingWrapper = tns::GetValue(isolate, ctorFunc);
@@ -552,7 +552,7 @@ Class ClassBuilder::ResolveConstructedClass(Local<Context> context, Local<Value>
     return fallback;
   }
 
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = v8::Isolate::GetCurrent();
   Local<v8::Function> newTargetFunc = newTarget.As<v8::Function>();
 
   BaseDataWrapper* wrapper = tns::GetValue(isolate, newTargetFunc);
@@ -743,7 +743,7 @@ void ClassBuilder::ExposeDynamicMethods(Local<Context> context, Class extendedCl
                                         Local<Value> exposedMethods, Local<Value> exposedProtocols,
                                         Local<Object> implementationObject,
                                         std::unordered_set<std::string>* visitedNames) {
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = v8::Isolate::GetCurrent();
   std::vector<const ProtocolMeta*> protocols;
   if (!exposedProtocols.IsEmpty() && exposedProtocols->IsArray()) {
     Local<v8::Array> protocolsArray = exposedProtocols.As<v8::Array>();

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -485,7 +485,14 @@ Class ClassBuilder::EnsureExtendedClass(Local<Context> context, Local<v8::Functi
   auto isolateId = cache->getIsolateId();
 
   std::string baseClassName = class_getName(baseClass);
-  std::string className = tns::ToString(isolate, ctorFunc->GetName());
+  std::string className;
+  Local<Value> explicitName;
+  if (ctorFunc->Get(context, tns::ToV8String(isolate, "ObjCClassName")).ToLocal(&explicitName) &&
+      !explicitName.IsEmpty() && explicitName->IsString()) {
+    className = tns::ToString(isolate, explicitName);
+  } else {
+    className = tns::ToString(isolate, ctorFunc->GetName());
+  }
 
   ScopeClassNameToIsolate(className, isolateId);
   Class extendedClass = ClassBuilder::GetExtendedClass(baseClassName, className, isolateId);

--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -368,8 +368,8 @@ class ObjCDataWrapper : public BaseDataWrapper {
 
 class ObjCClassWrapper : public BaseDataWrapper {
  public:
-  ObjCClassWrapper(Class klazz, bool extendedClass = false)
-      : klass_(klazz), extendedClass_(extendedClass) {}
+  ObjCClassWrapper(Class klazz, bool extendedClass = false, bool esDerivedClass = false)
+      : klass_(klazz), extendedClass_(extendedClass), esDerivedClass_(esDerivedClass) {}
 
   const WrapperType Type() { return WrapperType::ObjCClass; }
 
@@ -377,9 +377,14 @@ class ObjCClassWrapper : public BaseDataWrapper {
 
   bool ExtendedClass() { return this->extendedClass_; }
 
+  // true when the class was registered lazily from a plain ES `class X extends NativeBase {}`
+  // constructor (see ClassBuilder::EnsureExtendedClass)
+  bool ESDerivedClass() { return this->esDerivedClass_; }
+
  private:
   Class klass_;
   bool extendedClass_;
+  bool esDerivedClass_;
 };
 
 class ObjCProtocolWrapper : public BaseDataWrapper {

--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -390,8 +390,8 @@ class ObjCDataWrapper : public BaseDataWrapper {
 
 class ObjCClassWrapper : public BaseDataWrapper {
  public:
-  ObjCClassWrapper(Class klazz, bool extendedClass = false)
-      : klass_(klazz), extendedClass_(extendedClass) {}
+  ObjCClassWrapper(Class klazz, bool extendedClass = false, bool esDerivedClass = false)
+      : klass_(klazz), extendedClass_(extendedClass), esDerivedClass_(esDerivedClass) {}
 
   const WrapperType Type() { return WrapperType::ObjCClass; }
 
@@ -399,9 +399,14 @@ class ObjCClassWrapper : public BaseDataWrapper {
 
   bool ExtendedClass() { return this->extendedClass_; }
 
+  // true when the class was registered lazily from a plain ES `class X extends NativeBase {}`
+  // constructor (see ClassBuilder::EnsureExtendedClass)
+  bool ESDerivedClass() { return this->esDerivedClass_; }
+
  private:
   Class klass_;
   bool extendedClass_;
+  bool esDerivedClass_;
 };
 
 class ObjCProtocolWrapper : public BaseDataWrapper {

--- a/NativeScript/runtime/InlineFunctions.cpp
+++ b/NativeScript/runtime/InlineFunctions.cpp
@@ -43,6 +43,18 @@ void InlineFunctions::Init(Local<Context> context) {
         "            }"
         "        }"
         "    },"
+        "    NativeClass(arg) {"
+        "        if (typeof arg === 'function') {"
+        "            return arg;"
+        "        }"
+        "        var options = arg || {};"
+        "        return function (target) {"
+        "            if (options.protocols && options.protocols.length > 0) {"
+        "                target.ObjCProtocols = (target.ObjCProtocols && target.ObjCProtocols instanceof Array ? target.ObjCProtocols.concat(options.protocols) : options.protocols.slice());"
+        "            }"
+        "            return target;"
+        "        }"
+        "    },"
         "    ObjCMethod() {"
         "        var name = arguments[0];"
         "        var hasName = (name !== undefined && typeof name === \"string\");"
@@ -134,6 +146,7 @@ bool InlineFunctions::IsGlobalFunction(std::string name) {
         name == "NSMakeRange" ||
         name == "__decorate" ||
         name == "__param" ||
+        name == "NativeClass" ||
         name == "ObjCClass" ||
         name == "ObjCMethod" ||
         name == "ObjC" ||

--- a/NativeScript/runtime/InlineFunctions.cpp
+++ b/NativeScript/runtime/InlineFunctions.cpp
@@ -21,8 +21,8 @@ bool InlineFunctions::IsGlobalFunction(const std::string& name) {
   return name == "CGPointMake" || name == "CGRectMake" ||
          name == "CGSizeMake" || name == "UIEdgeInsetsMake" ||
          name == "NSMakeRange" || name == "__decorate" || name == "__param" ||
-         name == "ObjCClass" || name == "ObjCMethod" || name == "ObjC" ||
-         name == "ObjCParam" || name == "__tsEnum";
+         name == "NativeClass" || name == "ObjCClass" || name == "ObjCMethod" ||
+         name == "ObjC" || name == "ObjCParam" || name == "__tsEnum";
 }
 
 }  // namespace tns

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -4,6 +4,7 @@
 #include "ArgConverter.h"
 #include "ArrayAdapter.h"
 #include "Caches.h"
+#include "ClassBuilder.h"
 #include "Constants.h"
 #include "DictionaryAdapter.h"
 #include "ExtVector.h"
@@ -576,6 +577,15 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
   } else if (argHelper.isObject() && typeEncoding->type == BinaryTypeEncodingType::ClassEncoding) {
     Local<Object> obj = arg.As<Object>();
     BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
+    if (wrapper == nullptr && obj->IsFunction()) {
+      // A plain ES subclass of a native type passed where a Class is expected
+      // (e.g. `tableView.registerClassForCellReuseIdentifier(JSClass, ...)`) - lazily
+      // register its derived class first.
+      Class ensured = ClassBuilder::EnsureExtendedClass(context, obj.As<v8::Function>());
+      if (ensured != nil) {
+        wrapper = tns::GetValue(isolate, obj);
+      }
+    }
     tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ObjCClass, isolate);
     ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
     Class clazz = classWrapper->Klass();
@@ -728,6 +738,14 @@ id Interop::ToObject(Local<Context> context, v8::Local<v8::Value> arg) {
       }
     } else {
       Local<Object> obj = arg.As<Object>();
+      if (obj->IsFunction()) {
+        // A plain ES subclass of a native type passed where an `id` is expected - lazily
+        // register its derived class and marshal the Objective-C Class object.
+        Class ensured = ClassBuilder::EnsureExtendedClass(context, obj.As<v8::Function>());
+        if (ensured != nil) {
+          return ensured;
+        }
+      }
       DictionaryAdapter* adapter = [[DictionaryAdapter alloc] initWithJSObject:obj isolate:isolate];
       // CFAutorelease(adapter);
       return adapter;

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -4,6 +4,7 @@
 #include "ArgConverter.h"
 #include "ArrayAdapter.h"
 #include "Caches.h"
+#include "ClassBuilder.h"
 #include "Constants.h"
 #include "DictionaryAdapter.h"
 #include "ExtVector.h"
@@ -583,6 +584,15 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
   } else if (argHelper.isObject() && typeEncoding->type == BinaryTypeEncodingType::ClassEncoding) {
     Local<Object> obj = arg.As<Object>();
     BaseDataWrapper* wrapper = tns::GetValue(isolate, obj);
+    if (wrapper == nullptr && obj->IsFunction()) {
+      // A plain ES subclass of a native type passed where a Class is expected
+      // (e.g. `tableView.registerClassForCellReuseIdentifier(JSClass, ...)`) - lazily
+      // register its derived class first.
+      Class ensured = ClassBuilder::EnsureExtendedClass(context, obj.As<v8::Function>());
+      if (ensured != nil) {
+        wrapper = tns::GetValue(isolate, obj);
+      }
+    }
     tns::Assert(wrapper != nullptr && wrapper->Type() == WrapperType::ObjCClass, isolate);
     ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
     Class clazz = classWrapper->Klass();
@@ -737,6 +747,14 @@ id Interop::ToObject(Local<Context> context, v8::Local<v8::Value> arg) {
       }
     } else {
       Local<Object> obj = arg.As<Object>();
+      if (obj->IsFunction()) {
+        // A plain ES subclass of a native type passed where an `id` is expected - lazily
+        // register its derived class and marshal the Objective-C Class object.
+        Class ensured = ClassBuilder::EnsureExtendedClass(context, obj.As<v8::Function>());
+        if (ensured != nil) {
+          return ensured;
+        }
+      }
       DictionaryAdapter* adapter = [[DictionaryAdapter alloc] initWithJSObject:obj isolate:isolate];
       // CFAutorelease(adapter);
       return adapter;

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -620,6 +620,10 @@ void MetadataBuilder::ClassConstructorCallback(const FunctionCallbackInfo<Value>
         CacheItem<BaseClassMeta>* item = static_cast<CacheItem<BaseClassMeta>*>(info.Data().As<External>()->Value());
         Class klass = objc_getClass(item->meta_->name());
 
+        // Plain ES `class X extends NativeType {}` subclasses reach this callback through
+        // super(); use new.target to lazily register (and construct) the derived class.
+        klass = ClassBuilder::ResolveConstructedClass(context, info.NewTarget(), klass);
+
         const InterfaceMeta* interfaceMeta = static_cast<const InterfaceMeta*>(item->meta_);
         ArgConverter::ConstructObject(context, info, klass, interfaceMeta);
     } catch (NativeScriptException& ex) {
@@ -633,19 +637,24 @@ void MetadataBuilder::AllocCallback(const FunctionCallbackInfo<Value>& info) {
 
     try {
         Local<Object> thiz = info.This();
-        Class klass;
+        Local<Context> context = isolate->GetCurrentContext();
+        Class klass = nil;
 
         BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
         if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCClass) {
             ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
             klass = classWrapper->Klass();
-        } else {
+        } else if (wrapper == nullptr && thiz->IsFunction()) {
+            // `JSClass.alloc()` where JSClass is a plain ES subclass of a native type that has
+            // not been constructed yet - lazily register its derived class first.
+            klass = ClassBuilder::EnsureExtendedClass(context, thiz.As<v8::Function>());
+        }
+
+        if (klass == nil) {
             CacheItem<InterfaceMeta>* item = static_cast<CacheItem<InterfaceMeta>*>(info.Data().As<External>()->Value());
             const InterfaceMeta* meta = item->meta_;
             klass = objc_getClass(meta->name());
         }
-
-        Local<Context> context = isolate->GetCurrentContext();
         ObjCAllocDataWrapper* allocWrapper = new ObjCAllocDataWrapper(klass);
         Local<Value> result = ArgConverter::CreateJsWrapper(context, allocWrapper, Local<Object>());
         info.GetReturnValue().Set(result);
@@ -663,15 +672,24 @@ void MetadataBuilder::MethodCallback(const FunctionCallbackInfo<Value>& info) {
 
     std::string className = item->className_;
 
+    Local<Context> context = isolate->GetCurrentContext();
     Local<Object> thiz = info.This();
     if (thiz->IsFunction()) {
-        if (BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz)) {
+        BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
+        if (wrapper != nullptr) {
             ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
             className = class_getName(classWrapper->Klass());
+        } else {
+            // Static call through a plain ES subclass of a native type (inherited static),
+            // e.g. `JSClass.new()` - lazily register the derived class so the invocation
+            // dispatches to it.
+            Class ensured = ClassBuilder::EnsureExtendedClass(context, thiz.As<v8::Function>());
+            if (ensured != nil) {
+                className = class_getName(ensured);
+            }
         }
     }
 
-    Local<Context> context = isolate->GetCurrentContext();
     Local<Value> result = instanceMethod
         ? MetadataBuilder::InvokeMethod(context, item->meta_, info.This(), args, className, true)
         : MetadataBuilder::InvokeMethod(context, item->meta_, Local<Object>(), args, className, true);
@@ -720,6 +738,31 @@ void MetadataBuilder::PropertySetterCallback(const FunctionCallbackInfo<Value> &
     MetadataBuilder::InvokeMethod(context, item->meta_->setter(), receiver, args, item->className_, true);
 }
 
+// Resolves the class name a static member access should dispatch to, honoring plain ES
+// subclasses of native types used as receivers (e.g. `JSClass.someStaticProperty`).
+static std::string ResolveStaticReceiverClassName(Local<Context> context, Local<Object> receiver,
+                                                  const std::string& fallback) {
+    if (receiver.IsEmpty() || !receiver->IsFunction()) {
+        return fallback;
+    }
+
+    Isolate* isolate = context->GetIsolate();
+    BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
+    if (wrapper != nullptr) {
+        if (wrapper->Type() == WrapperType::ObjCClass) {
+            return class_getName(static_cast<ObjCClassWrapper*>(wrapper)->Klass());
+        }
+        return fallback;
+    }
+
+    Class ensured = ClassBuilder::EnsureExtendedClass(context, receiver.As<v8::Function>());
+    if (ensured != nil) {
+        return class_getName(ensured);
+    }
+
+    return fallback;
+}
+
 void MetadataBuilder::PropertyNameGetterCallback(Local<v8::Name> name, const PropertyCallbackInfo<Value> &info) {
     Isolate* isolate = info.GetIsolate();
     CacheItem<PropertyMeta>* item = static_cast<CacheItem<PropertyMeta>*>(info.Data().As<External>()->Value());
@@ -731,7 +774,8 @@ void MetadataBuilder::PropertyNameGetterCallback(Local<v8::Name> name, const Pro
 
     V8EmptyValueArgs args;
     Local<Context> context = isolate->GetCurrentContext();
-    Local<Value> result = MetadataBuilder::InvokeMethod(context, item->meta_->getter(), Local<Object>(), args, item->className_, false);
+    std::string className = ResolveStaticReceiverClassName(context, info.This(), item->className_);
+    Local<Value> result = MetadataBuilder::InvokeMethod(context, item->meta_->getter(), Local<Object>(), args, className, false);
     if (!result.IsEmpty()) {
         info.GetReturnValue().Set(result);
     }
@@ -748,7 +792,8 @@ void MetadataBuilder::PropertyNameSetterCallback(Local<v8::Name> name, Local<Val
 
     V8SimpleValueArgs args(value);
     Local<Context> context = isolate->GetCurrentContext();
-    MetadataBuilder::InvokeMethod(context, item->meta_->setter(), Local<Object>(), args, item->className_, false);
+    std::string className = ResolveStaticReceiverClassName(context, info.This(), item->className_);
+    MetadataBuilder::InvokeMethod(context, item->meta_->setter(), Local<Object>(), args, className, false);
 }
 
 void MetadataBuilder::StructPropertyGetterCallback(Local<v8::Name> property, const PropertyCallbackInfo<Value>& info) {

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -861,7 +861,7 @@ static std::string ResolveStaticReceiverClassName(Local<Context> context, Local<
     return fallback;
   }
 
-  Isolate* isolate = context->GetIsolate();
+  Isolate* isolate = v8::Isolate::GetCurrent();
   BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
   if (wrapper != nullptr) {
     if (wrapper->Type() == WrapperType::ObjCClass) {

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -2,6 +2,7 @@
 #include <Foundation/Foundation.h>
 #include "ArgConverter.h"
 #include "Caches.h"
+#include "ClassBuilder.h"
 #include "Constants.h"
 #include "Helpers.h"
 #include "InlineFunctions.h"
@@ -720,6 +721,10 @@ void MetadataBuilder::ClassConstructorCallback(const FunctionCallbackInfo<Value>
         info.Data().As<External>()->Value(v8::kExternalPointerTypeTagDefault));
     Class klass = objc_getClass(item->meta_->name());
 
+    // Plain ES `class X extends NativeType {}` subclasses reach this callback through
+    // super(); use new.target to lazily register (and construct) the derived class.
+    klass = ClassBuilder::ResolveConstructedClass(context, info.NewTarget(), klass);
+
     const InterfaceMeta* interfaceMeta = static_cast<const InterfaceMeta*>(item->meta_);
     ArgConverter::ConstructObject(context, info, klass, interfaceMeta);
   } catch (NativeScriptException& ex) {
@@ -733,20 +738,26 @@ void MetadataBuilder::AllocCallback(const FunctionCallbackInfo<Value>& info) {
 
   try {
     Local<Object> thiz = info.This();
-    Class klass;
+    Local<Context> context = isolate->GetCurrentContext();
+    Class klass = nil;
 
     BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz);
     if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCClass) {
       ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
       klass = classWrapper->Klass();
-    } else {
+    } else if (wrapper == nullptr && thiz->IsFunction()) {
+      // `JSClass.alloc()` where JSClass is a plain ES subclass of a native type that has
+      // not been constructed yet - lazily register its derived class first.
+      klass = ClassBuilder::EnsureExtendedClass(context, thiz.As<v8::Function>());
+    }
+
+    if (klass == nil) {
       CacheItem<InterfaceMeta>* item = static_cast<CacheItem<InterfaceMeta>*>(
           info.Data().As<External>()->Value(v8::kExternalPointerTypeTagDefault));
       const InterfaceMeta* meta = item->meta_;
       klass = objc_getClass(meta->name());
     }
 
-    Local<Context> context = isolate->GetCurrentContext();
     ObjCAllocDataWrapper* allocWrapper = new ObjCAllocDataWrapper(klass);
     Local<Value> result = ArgConverter::CreateJsWrapper(context, allocWrapper, Local<Object>());
     info.GetReturnValue().Set(result);
@@ -768,16 +779,25 @@ void MetadataBuilder::MethodCallback(const FunctionCallbackInfo<Value>& info) {
   const std::string* className = &item->className_;
   std::string classWrapperName;
 
+  Local<Context> context = isolate->GetCurrentContext();
   Local<Object> thiz = info.This();
   if (thiz->IsFunction()) {
     if (BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz)) {
       ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
       classWrapperName = class_getName(classWrapper->Klass());
       className = &classWrapperName;
+    } else {
+      // Static call through a plain ES subclass of a native type (inherited static),
+      // e.g. `JSClass.new()` - lazily register the derived class so the invocation
+      // dispatches to it.
+      Class ensured = ClassBuilder::EnsureExtendedClass(context, thiz.As<v8::Function>());
+      if (ensured != nil) {
+        classWrapperName = class_getName(ensured);
+        className = &classWrapperName;
+      }
     }
   }
 
-  Local<Context> context = isolate->GetCurrentContext();
   Local<Value> result =
       instanceMethod
           ? MetadataBuilder::InvokeMethod(context, item->meta_, info.This(), args, *className, true)
@@ -833,6 +853,31 @@ void MetadataBuilder::PropertySetterCallback(const FunctionCallbackInfo<Value>& 
                                 true);
 }
 
+// Resolves the class name a static member access should dispatch to, honoring plain ES
+// subclasses of native types used as receivers (e.g. `JSClass.someStaticProperty`).
+static std::string ResolveStaticReceiverClassName(Local<Context> context, Local<Object> receiver,
+                                                  const std::string& fallback) {
+  if (receiver.IsEmpty() || !receiver->IsFunction()) {
+    return fallback;
+  }
+
+  Isolate* isolate = context->GetIsolate();
+  BaseDataWrapper* wrapper = tns::GetValue(isolate, receiver);
+  if (wrapper != nullptr) {
+    if (wrapper->Type() == WrapperType::ObjCClass) {
+      return class_getName(static_cast<ObjCClassWrapper*>(wrapper)->Klass());
+    }
+    return fallback;
+  }
+
+  Class ensured = ClassBuilder::EnsureExtendedClass(context, receiver.As<v8::Function>());
+  if (ensured != nil) {
+    return class_getName(ensured);
+  }
+
+  return fallback;
+}
+
 void MetadataBuilder::PropertyNameGetterCallback(const FunctionCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();
   CacheItem<PropertyMeta>* item = static_cast<CacheItem<PropertyMeta>*>(
@@ -845,8 +890,9 @@ void MetadataBuilder::PropertyNameGetterCallback(const FunctionCallbackInfo<Valu
 
   V8EmptyValueArgs args;
   Local<Context> context = isolate->GetCurrentContext();
+  std::string className = ResolveStaticReceiverClassName(context, info.This(), item->className_);
   Local<Value> result = MetadataBuilder::InvokeMethod(
-      context, item->meta_->getter(), Local<Object>(), args, item->className_, false);
+      context, item->meta_->getter(), Local<Object>(), args, className, false);
   if (!result.IsEmpty()) {
     info.GetReturnValue().Set(result);
   }
@@ -866,8 +912,9 @@ void MetadataBuilder::PropertyNameSetterCallback(const FunctionCallbackInfo<Valu
 
   V8SimpleValueArgs args(value);
   Local<Context> context = isolate->GetCurrentContext();
-  MetadataBuilder::InvokeMethod(context, item->meta_->setter(), Local<Object>(), args,
-                                item->className_, false);
+  std::string className = ResolveStaticReceiverClassName(context, info.This(), item->className_);
+  MetadataBuilder::InvokeMethod(context, item->meta_->setter(), Local<Object>(), args, className,
+                                false);
 }
 
 Intercepted MetadataBuilder::StructPropertyGetterCallback(Local<v8::Name> property,

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -523,6 +523,13 @@ void Runtime::DefineGlobalObject(Local<Context> context, bool isWorker) {
     tns::Assert(false, isolate);
   }
 
+  if (isWorker && !global
+                       ->DefineOwnProperty(context, ToV8String(isolate, "__ns__worker"),
+                                           v8::True(isolate), readOnlyFlags)
+                       .FromMaybe(false)) {
+    tns::Assert(false, isolate);
+  }
+
   if (isWorker) {
     // Register proper interop types for worker context
     // Worker bundles need full interop functionality, not just simple stubs

--- a/NativeScript/runtime/js/inline-functions.js
+++ b/NativeScript/runtime/js/inline-functions.js
@@ -9,6 +9,10 @@ const {
 } = primordials;
 
 function applyNativeClassOptions(target, options) {
+    // Workers must not mint or rename process-global native classes.
+    if (global.__ns__worker) {
+        return target;
+    }
     var ios = options && options.ios;
     var protocols = (ios && ios.protocols) || (options && options.protocols);
     var methods = (ios && ios.methods) || (options && options.methods);

--- a/NativeScript/runtime/js/inline-functions.js
+++ b/NativeScript/runtime/js/inline-functions.js
@@ -8,6 +8,34 @@ const {
     ObjectKeys,
 } = primordials;
 
+function applyNativeClassOptions(target, options) {
+    var ios = options && options.ios;
+    var protocols = (ios && ios.protocols) || (options && options.protocols);
+    var methods = (ios && ios.methods) || (options && options.methods);
+    var name = ios && ios.name;
+
+    if (protocols && protocols.length > 0) {
+        target.ObjCProtocols = (target.ObjCProtocols && target.ObjCProtocols instanceof Array ? ArrayPrototypeConcat(target.ObjCProtocols, protocols) : ArrayPrototypeSlice(protocols));
+    }
+    if (methods) {
+        if (!target.ObjCExposedMethods) {
+            target.ObjCExposedMethods = {};
+        }
+        var methodKeys = ObjectKeys(methods);
+        for (var mi = 0; mi < methodKeys.length; mi++) {
+            var selector = methodKeys[mi];
+            target.ObjCExposedMethods[selector] = methods[selector];
+        }
+    }
+    if (name) {
+        target.ObjCClassName = name;
+        if (typeof target.class === 'function') {
+            target.class();
+        }
+    }
+    return target;
+}
+
 ObjectAssign(global, {
     CGPointMake(x, y) {
         return new CGPoint({ x, y });
@@ -51,14 +79,11 @@ ObjectAssign(global, {
     },
     NativeClass(arg) {
         if (typeof arg === 'function') {
-            return arg;
+            return applyNativeClassOptions(arg, {});
         }
         var options = arg || {};
         return function (target) {
-            if (options.protocols && options.protocols.length > 0) {
-                target.ObjCProtocols = (target.ObjCProtocols && target.ObjCProtocols instanceof Array ? ArrayPrototypeConcat(target.ObjCProtocols, options.protocols) : ArrayPrototypeSlice(options.protocols));
-            }
-            return target;
+            return applyNativeClassOptions(target, options);
         }
     },
     ObjCMethod() {

--- a/NativeScript/runtime/js/inline-functions.js
+++ b/NativeScript/runtime/js/inline-functions.js
@@ -1,5 +1,6 @@
 const {
     ArrayPrototypeConcat,
+    ArrayPrototypeSlice,
     FunctionPrototypeApply,
     ObjectAssign,
     ObjectDefineProperty,
@@ -46,6 +47,18 @@ ObjectAssign(global, {
             if (protocols.length > 0) {
                 target.ObjCProtocols = (target.ObjCProtocols && target.ObjCProtocols instanceof Array ? ArrayPrototypeConcat(target.ObjCProtocols, protocols) : protocols);
             }
+        }
+    },
+    NativeClass(arg) {
+        if (typeof arg === 'function') {
+            return arg;
+        }
+        var options = arg || {};
+        return function (target) {
+            if (options.protocols && options.protocols.length > 0) {
+                target.ObjCProtocols = (target.ObjCProtocols && target.ObjCProtocols instanceof Array ? ArrayPrototypeConcat(target.ObjCProtocols, options.protocols) : ArrayPrototypeSlice(options.protocols));
+            }
+            return target;
         }
     },
     ObjCMethod() {

--- a/TestRunner/app/tests/Inheritance/ESClassTests.js
+++ b/TestRunner/app/tests/Inheritance/ESClassTests.js
@@ -1,0 +1,287 @@
+// Tests for native ES class support: plain `class X extends NativeType {}` without the
+// @NativeClass decorator or ES5 downleveling. The Objective-C class is registered lazily by
+// the runtime on first use (construction, alloc/new, static dispatch or Class marshalling).
+describe(module.id, function () {
+    afterEach(function () {
+        TNSClearOutput();
+    });
+
+    it('ESClassLazyRegistration', function () {
+        class ESLazyObject extends NSObject {
+        }
+
+        // Defining the class must not register anything with the Objective-C runtime
+        expect(NSClassFromString('ESLazyObject')).toBeNull();
+
+        var instance = new ESLazyObject();
+        expect(instance instanceof ESLazyObject).toBe(true);
+
+        // First construction registers the class under the ES class name
+        expect(NSClassFromString('ESLazyObject')).toBe(ESLazyObject);
+    });
+
+    it('ESClassSimpleInheritance', function () {
+        class ESSimpleObject extends TNSDerivedInterface {
+        }
+
+        var object = new ESSimpleObject();
+        expect(object.constructor).toBe(ESSimpleObject);
+        expect(object instanceof ESSimpleObject).toBe(true);
+        expect(object instanceof TNSDerivedInterface).toBe(true);
+        expect(object instanceof NSObject).toBe(true);
+        expect(object.class()).toBe(ESSimpleObject);
+        expect(object.superclass).toBe(TNSDerivedInterface);
+        expect(ESSimpleObject.class()).toBe(ESSimpleObject);
+        expect(ESSimpleObject.superclass()).toBe(TNSDerivedInterface);
+        expect(NSStringFromClass(ESSimpleObject)).toBe('ESSimpleObject');
+    });
+
+    it('ESClassConstructorLogicAndFields', function () {
+        class ESConstructorObject extends NSObject {
+            field = 42;
+
+            constructor() {
+                super();
+                this.initialized = true;
+            }
+        }
+
+        var object = new ESConstructorObject();
+        // The receiver created by super() must be the native-backed instance, with class
+        // fields and constructor logic applied to it
+        expect(object.field).toBe(42);
+        expect(object.initialized).toBe(true);
+        expect(object instanceof ESConstructorObject).toBe(true);
+        expect(object instanceof NSObject).toBe(true);
+        expect(NSStringFromClass(object.class())).toBe('ESConstructorObject');
+    });
+
+    it('ESClassInstanceMethodsAndSuper', function () {
+        class ESMethodsObject extends TNSDerivedInterface {
+            baseMethod() {
+                TNSLog('js baseMethod called');
+                super.baseMethod();
+            }
+            derivedMethod() {
+                TNSLog('js derivedMethod called');
+                super.derivedMethod();
+            }
+        }
+
+        var object = new ESMethodsObject();
+        object.baseMethod();
+        object.derivedMethod();
+        expect(TNSGetOutput()).toBe('js baseMethod called' +
+            'instance baseMethod called' +
+            'js derivedMethod called' +
+            'instance derivedMethod called');
+    });
+
+    it('ESClassPropertyAccessorsAndSuper', function () {
+        class ESPropertyObject extends TNSDerivedInterface {
+            get baseProperty() {
+                TNSLog('js getBaseProperty called');
+                return super.baseProperty;
+            }
+            set baseProperty(x) {
+                TNSLog('js setBaseProperty called');
+                super.baseProperty = x;
+            }
+        }
+
+        var object = new ESPropertyObject();
+        object.baseProperty = 0;
+        UNUSED(object.baseProperty);
+        expect(TNSGetOutput()).toBe('js setBaseProperty called' +
+            'instance setBaseProperty: called' +
+            'js getBaseProperty called' +
+            'instance baseProperty called');
+    });
+
+    it('ESClassAllocInitBeforeConstruction', function () {
+        class ESAllocObject extends NSObject {
+            getAnswer() {
+                return 42;
+            }
+        }
+
+        // alloc().init() without ever calling `new` must register and use the derived class
+        var object = ESAllocObject.alloc().init();
+        expect(object instanceof ESAllocObject).toBe(true);
+        expect(object.getAnswer()).toBe(42);
+        expect(NSStringFromClass(object.class())).toBe('ESAllocObject');
+    });
+
+    it('ESClassNewBeforeConstruction', function () {
+        class ESNewObject extends NSObject {
+        }
+
+        var object = ESNewObject.new();
+        expect(object instanceof ESNewObject).toBe(true);
+        expect(NSStringFromClass(object.class())).toBe('ESNewObject');
+    });
+
+    it('ESClassStaticMethodDispatch', function () {
+        class ESStaticMethodObject extends TNSDerivedInterface {
+        }
+
+        ESStaticMethodObject.baseMethod();
+        ESStaticMethodObject.derivedMethod();
+        expect(TNSGetOutput()).toBe('static baseMethod called' +
+            'static derivedMethod called');
+    });
+
+    it('ESClassStaticPropertyDispatch', function () {
+        class ESStaticPropertyObject extends TNSDerivedInterface {
+        }
+
+        ESStaticPropertyObject.baseProperty = 1;
+        UNUSED(ESStaticPropertyObject.baseProperty);
+        expect(TNSGetOutput()).toBe('static setBaseProperty: called' +
+            'static baseProperty called');
+    });
+
+    it('ESClassPassedAsClassArgument', function () {
+        class ESClassArgObject extends NSObject {
+        }
+
+        // Passing the class to a native API before any instance exists must register it
+        expect(NSStringFromClass(ESClassArgObject)).toBe('ESClassArgObject');
+
+        var object = new ESClassArgObject();
+        expect(object.isKindOfClass(ESClassArgObject)).toBe(true);
+        expect(object.isMemberOfClass(ESClassArgObject)).toBe(true);
+        expect(object.isKindOfClass(NSObject)).toBe(true);
+    });
+
+    it('ESClassProtocolImplementation', function () {
+        class ESProtocolObject extends NSObject {
+            static ObjCProtocols = [TNSBaseProtocol2];
+
+            baseProtocolMethod1() {
+                TNSLog('baseProtocolMethod1 called');
+            }
+            baseProtocolMethod2() {
+                TNSLog('baseProtocolMethod2 called');
+            }
+        }
+
+        var object = ESProtocolObject.alloc().init();
+        TNSTestNativeCallbacks.protocolImplementationProtocolInheritance(object);
+        expect(TNSGetOutput()).toBe('baseProtocolMethod1 called' +
+            'baseProtocolMethod2 called');
+    });
+
+    it('ESClassExposedMethods', function () {
+        class ESExposedObject extends NSObject {
+            static ObjCExposedMethods = {
+                'voidSelector': { returns: interop.types.void },
+                'variadicSelector:x:': { returns: NSObject, params: [NSString, interop.types.int32] }
+            };
+
+            voidSelector() {
+                TNSLog('voidSelector called');
+            }
+            ['variadicSelector:x:'](a, b) {
+                TNSLog('variadicSelector:' + a + ' x:' + b + ' called');
+                return a;
+            }
+        }
+
+        var object = new ESExposedObject();
+        TNSTestNativeCallbacks.inheritanceVoidSelector(object);
+        expect(TNSTestNativeCallbacks.inheritanceVariadicSelector(object)).toBe('native');
+        expect(TNSGetOutput()).toBe('voidSelector called' +
+            'variadicSelector:native x:9 called');
+    });
+
+    it('ESClassDescriptionOverrideFromNative', function () {
+        class ESDescriptionObject extends NSObject {
+            get description() {
+                return 'js description';
+            }
+        }
+
+        // Throws (native assert) if [object description] does not dispatch to the JS getter
+        TNSTestNativeCallbacks.apiDescriptionOverride(new ESDescriptionObject());
+    });
+
+    it('ESClassMultiLevelInheritance', function () {
+        class ESLevelA extends TNSDerivedInterface {
+            baseMethod() {
+                TNSLog('A baseMethod called');
+                super.baseMethod();
+            }
+            derivedMethod() {
+                TNSLog('A derivedMethod called');
+                super.derivedMethod();
+            }
+        }
+
+        class ESLevelB extends ESLevelA {
+            baseMethod() {
+                TNSLog('B baseMethod called');
+                super.baseMethod();
+            }
+        }
+
+        var b = new ESLevelB();
+        expect(b instanceof ESLevelB).toBe(true);
+        expect(b instanceof ESLevelA).toBe(true);
+        expect(b instanceof TNSDerivedInterface).toBe(true);
+
+        b.baseMethod();
+        b.derivedMethod();
+        expect(TNSGetOutput()).toBe('B baseMethod called' +
+            'A baseMethod called' +
+            'instance baseMethod called' +
+            'A derivedMethod called' +
+            'instance derivedMethod called');
+        TNSClearOutput();
+
+        // The intermediate class works standalone too, with its own registration
+        var a = new ESLevelA();
+        expect(a instanceof ESLevelA).toBe(true);
+        expect(a instanceof ESLevelB).toBe(false);
+        a.baseMethod();
+        expect(TNSGetOutput()).toBe('A baseMethod called' +
+            'instance baseMethod called');
+    });
+
+    it('ESClassPlainJsSubclassUnaffected', function () {
+        class PlainBase {
+        }
+        class PlainDerived extends PlainBase {
+        }
+
+        // Classes with no native type in their prototype chain stay plain JS
+        var object = new PlainDerived();
+        expect(object instanceof PlainDerived).toBe(true);
+        expect(object instanceof PlainBase).toBe(true);
+    });
+
+    it('NativeClassGlobalDecoratorNoop', function () {
+        expect(typeof global.NativeClass).toBe('function');
+
+        const ESDecoratedPlain = NativeClass(class ESDecoratedPlainObject extends NSObject {
+        });
+        var instance = new ESDecoratedPlain();
+        expect(instance instanceof ESDecoratedPlain).toBe(true);
+
+        const ESDecoratedProtocols = NativeClass({ protocols: [TNSBaseProtocol2] })(
+            class ESDecoratedProtocolsObject extends NSObject {
+                baseProtocolMethod1() {
+                    TNSLog('baseProtocolMethod1 called');
+                }
+                baseProtocolMethod2() {
+                    TNSLog('baseProtocolMethod2 called');
+                }
+            }
+        );
+
+        var object = new ESDecoratedProtocols();
+        TNSTestNativeCallbacks.protocolImplementationProtocolInheritance(object);
+        expect(TNSGetOutput()).toBe('baseProtocolMethod1 called' +
+            'baseProtocolMethod2 called');
+    });
+});

--- a/TestRunner/app/tests/Inheritance/ESClassTests.js
+++ b/TestRunner/app/tests/Inheritance/ESClassTests.js
@@ -56,6 +56,45 @@ describe(module.id, function () {
         expect(NSStringFromClass(object.class())).toBe('ESConstructorObject');
     });
 
+    it('ESClassSuperArgsSelectInitializer', function () {
+        class ESCtorArgsObject extends TNSCInterface {
+            constructor(name, x) {
+                // Arguments passed to super(...) drive native initializer resolution;
+                // arguments passed to `new` are only seen by the JS constructor.
+                super(x);
+                this.name = name;
+            }
+        }
+
+        var object = new ESCtorArgsObject('first', 7);
+        expect(object instanceof ESCtorArgsObject).toBe(true);
+        expect(object.name).toBe('first');
+        expect(TNSGetOutput()).toBe('initWithPrimitive:7 called');
+        TNSClearOutput();
+
+        class ESCtorTwoArgsObject extends TNSCInterface {
+            constructor(a, b) {
+                super(a, b);
+            }
+        }
+
+        var object2 = new ESCtorTwoArgsObject(5, 10);
+        expect(object2 instanceof ESCtorTwoArgsObject).toBe(true);
+        expect(TNSGetOutput()).toBe('initWithInt:andInt: 5 10 called');
+        TNSClearOutput();
+
+        // super() with no arguments falls back to plain [[Class alloc] init]
+        class ESCtorNoArgsObject extends TNSCInterface {
+            constructor() {
+                super();
+            }
+        }
+
+        var object3 = new ESCtorNoArgsObject();
+        expect(object3 instanceof ESCtorNoArgsObject).toBe(true);
+        expect(TNSGetOutput()).toBe('init called');
+    });
+
     it('ESClassInstanceMethodsAndSuper', function () {
         class ESMethodsObject extends TNSDerivedInterface {
             baseMethod() {
@@ -110,6 +149,34 @@ describe(module.id, function () {
         expect(object instanceof ESAllocObject).toBe(true);
         expect(object.getAnswer()).toBe(42);
         expect(NSStringFromClass(object.class())).toBe('ESAllocObject');
+    });
+
+    it('ESClassAllocInitDoesNotRunJsConstructor', function () {
+        var constructorRuns = 0;
+
+        class ESAllocNoCtorObject extends NSObject {
+            field = 42;
+
+            constructor() {
+                super();
+                constructorRuns++;
+                this.initializedFromJs = true;
+            }
+        }
+
+        // alloc().init() is purely native initialization: the JS constructor body and
+        // class field initializers only run through `new`, never through alloc/init.
+        var allocated = ESAllocNoCtorObject.alloc().init();
+        expect(constructorRuns).toBe(0);
+        expect(allocated.field).toBe(undefined);
+        expect(allocated.initializedFromJs).toBe(undefined);
+        expect(allocated instanceof ESAllocNoCtorObject).toBe(true);
+        expect(NSStringFromClass(allocated.class())).toBe('ESAllocNoCtorObject');
+
+        var constructed = new ESAllocNoCtorObject();
+        expect(constructorRuns).toBe(1);
+        expect(constructed.field).toBe(42);
+        expect(constructed.initializedFromJs).toBe(true);
     });
 
     it('ESClassNewBeforeConstruction', function () {

--- a/TestRunner/app/tests/Inheritance/ESClassTests.js
+++ b/TestRunner/app/tests/Inheritance/ESClassTests.js
@@ -151,10 +151,10 @@ describe(module.id, function () {
         expect(NSStringFromClass(object.class())).toBe('ESAllocObject');
     });
 
-    it('ESClassAllocInitDoesNotRunJsConstructor', function () {
+    it('ESClassAllocInitRunsJsConstructor', function () {
         var constructorRuns = 0;
 
-        class ESAllocNoCtorObject extends NSObject {
+        class ESAllocCtorObject extends NSObject {
             field = 42;
 
             constructor() {
@@ -164,19 +164,94 @@ describe(module.id, function () {
             }
         }
 
-        // alloc().init() is purely native initialization: the JS constructor body and
-        // class field initializers only run through `new`, never through alloc/init.
-        var allocated = ESAllocNoCtorObject.alloc().init();
-        expect(constructorRuns).toBe(0);
-        expect(allocated.field).toBe(undefined);
-        expect(allocated.initializedFromJs).toBe(undefined);
-        expect(allocated instanceof ESAllocNoCtorObject).toBe(true);
-        expect(NSStringFromClass(allocated.class())).toBe('ESAllocNoCtorObject');
-
-        var constructed = new ESAllocNoCtorObject();
+        // Objects Objective-C allocates — alloc/init here, but equally cell reuse,
+        // storyboards or NSCoding — are adopted into a real ES construct so class
+        // fields and the constructor body run on both paths.
+        var allocated = ESAllocCtorObject.alloc().init();
         expect(constructorRuns).toBe(1);
+        expect(allocated.field).toBe(42);
+        expect(allocated.initializedFromJs).toBe(true);
+        expect(allocated instanceof ESAllocCtorObject).toBe(true);
+        expect(NSStringFromClass(allocated.class())).toBe('ESAllocCtorObject');
+
+        var constructed = new ESAllocCtorObject();
+        expect(constructorRuns).toBe(2);
         expect(constructed.field).toBe(42);
         expect(constructed.initializedFromJs).toBe(true);
+    });
+
+    it('ESClassAllocInitPrivateFields', function () {
+        class ESPrivateAllocObject extends NSObject {
+            #a = 1;
+
+            constructor() {
+                super();
+            }
+
+            someMethod() {
+                return this.#a;
+            }
+        }
+
+        expect(new ESPrivateAllocObject().someMethod()).toBe(1);
+        expect(ESPrivateAllocObject.alloc().init().someMethod()).toBe(1);
+    });
+
+    it('ESClassAllocInitDoesNotDoubleAlloc', function () {
+        class ESAdoptOnceObject extends TNSCInterface {
+            constructor() {
+                super({ primitive: 7 });
+            }
+        }
+
+        TNSClearOutput();
+        var allocated = ESAdoptOnceObject.alloc().init();
+        // Native already called init; adopt must not run initWithPrimitive.
+        expect(TNSGetOutput()).toBe('init called');
+        expect(allocated instanceof ESAdoptOnceObject).toBe(true);
+
+        TNSClearOutput();
+        var constructed = new ESAdoptOnceObject();
+        expect(TNSGetOutput()).toBe('initWithPrimitive:7 called');
+        expect(constructed instanceof ESAdoptOnceObject).toBe(true);
+    });
+
+    it('ESClassSuperObjectTokensSelectInitializer', function () {
+        class ESTokenCtorObject extends TNSCInterface {
+            constructor() {
+                super({ primitive: 7 });
+            }
+        }
+
+        TNSClearOutput();
+        var object = new ESTokenCtorObject();
+        expect(object instanceof ESTokenCtorObject).toBe(true);
+        expect(TNSGetOutput()).toBe('initWithPrimitive:7 called');
+    });
+
+    it('ESClassAllocInitThrowingConstructor', function () {
+        class ESThrowingCtorObject extends NSObject {
+            constructor() {
+                super();
+                throw new Error('adopt construct failed');
+            }
+        }
+
+        var threw = false;
+        try {
+            ESThrowingCtorObject.alloc().init();
+        } catch (e) {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+
+        threw = false;
+        try {
+            new ESThrowingCtorObject();
+        } catch (e) {
+            threw = true;
+        }
+        expect(threw).toBe(true);
     });
 
     it('ESClassNewBeforeConstruction', function () {
@@ -327,7 +402,7 @@ describe(module.id, function () {
         expect(object instanceof PlainBase).toBe(true);
     });
 
-    it('NativeClassGlobalDecoratorNoop', function () {
+    it('NativeClassDecoratorAppliesIOSOptions', function () {
         expect(typeof global.NativeClass).toBe('function');
 
         const ESDecoratedPlain = NativeClass(class ESDecoratedPlainObject extends NSObject {
@@ -335,7 +410,11 @@ describe(module.id, function () {
         var instance = new ESDecoratedPlain();
         expect(instance instanceof ESDecoratedPlain).toBe(true);
 
-        const ESDecoratedProtocols = NativeClass({ protocols: [TNSBaseProtocol2] })(
+        const ESDecoratedProtocols = NativeClass({
+            ios: {
+                protocols: [TNSBaseProtocol2]
+            }
+        })(
             class ESDecoratedProtocolsObject extends NSObject {
                 baseProtocolMethod1() {
                     TNSLog('baseProtocolMethod1 called');
@@ -350,5 +429,38 @@ describe(module.id, function () {
         TNSTestNativeCallbacks.protocolImplementationProtocolInheritance(object);
         expect(TNSGetOutput()).toBe('baseProtocolMethod1 called' +
             'baseProtocolMethod2 called');
+    });
+
+    it('NativeClassEagerNameRegistersImmediately', function () {
+        const ESEagerNamed = NativeClass({
+            ios: {
+                name: 'ESEagerNamedObject'
+            }
+        })(class UnusedJsNameForEager extends NSObject {
+        });
+
+        expect(NSClassFromString('ESEagerNamedObject')).toBe(ESEagerNamed);
+        expect(NSStringFromClass(ESEagerNamed)).toBe('ESEagerNamedObject');
+        expect(new ESEagerNamed() instanceof ESEagerNamed).toBe(true);
+    });
+
+    it('NativeClassExposedMethodsFromIOSOptions', function () {
+        const ESDecoratedExposed = NativeClass({
+            ios: {
+                methods: {
+                    'voidSelector': { returns: interop.types.void }
+                }
+            }
+        })(
+            class ESDecoratedExposedObject extends NSObject {
+                voidSelector() {
+                    TNSLog('voidSelector called');
+                }
+            }
+        );
+
+        var object = new ESDecoratedExposed();
+        TNSTestNativeCallbacks.inheritanceVoidSelector(object);
+        expect(TNSGetOutput()).toBe('voidSelector called');
     });
 });

--- a/TestRunner/app/tests/Inheritance/ESClassTests.js
+++ b/TestRunner/app/tests/Inheritance/ESClassTests.js
@@ -444,6 +444,23 @@ describe(module.id, function () {
         expect(new ESEagerNamed() instanceof ESEagerNamed).toBe(true);
     });
 
+    it('NativeClassIsNoOpOnWorkers', function (done) {
+        var worker = new Worker('~/shared/Workers/EvalWorker.js');
+        worker.onmessage = function (msg) {
+            worker.terminate();
+            expect(msg.data.isFunction).toBe(true);
+            expect(msg.data.isWorker).toBe(true);
+            expect(msg.data.hasName).toBe(false);
+            expect(msg.data.registered).toBe(false);
+            expect(NSClassFromString('TNSWorkerNativeClassName')).toBeNull();
+            done();
+        };
+        worker.postMessage({
+            eval: "var C = NativeClass({ ios: { name: 'TNSWorkerNativeClassName' } })(class TNSWorkerNativeClass extends NSObject {}); " +
+                  "postMessage({ isFunction: typeof NativeClass === 'function', isWorker: !!__ns__worker, hasName: C.ObjCClassName === 'TNSWorkerNativeClassName', registered: NSClassFromString('TNSWorkerNativeClassName') !== null });"
+        });
+    });
+
     it('NativeClassExposedMethodsFromIOSOptions', function () {
         const ESDecoratedExposed = NativeClass({
             ios: {

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -62,6 +62,7 @@ require("./Marshalling/ProtocolTests");
 require("./Inheritance/InheritanceTests");
 require("./Inheritance/ProtocolImplementationTests");
 require("./Inheritance/TypeScriptTests");
+require("./Inheritance/ESClassTests");
 //
 require("./MethodCallsTests");
 //import "./FunctionsTests";

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -119,6 +119,7 @@ require("./Marshalling/ProtocolTests");
 require("./Inheritance/InheritanceTests");
 require("./Inheritance/ProtocolImplementationTests");
 require("./Inheritance/TypeScriptTests");
+require("./Inheritance/ESClassTests");
 //
 require("./MethodCallsTests");
 require("./StaleWrapperCacheTests");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,8 @@
-// Type declarations for the runtime's public `ns:` builtin modules — one
-// .d.ts per module, mirroring @types/node's layout and the "one module, one
-// source file" rule in docs/ns-builtin-modules.md. The declared surfaces must
-// stay in sync with that document (NsRuntimeTests.js / NsUtilTests.js assert
-// the export sets at runtime).
+// Type declarations for the runtime's public surfaces — `ns:` builtin modules
+// (one .d.ts per module, mirroring @types/node) and globals such as
+// NativeClass. The `ns:` surfaces must stay in sync with
+// docs/ns-builtin-modules.md (NsRuntimeTests.js / NsUtilTests.js assert the
+// export sets at runtime).
 //
 // `ns:` is not a resolvable package specifier, so these are ambient
 // declarations: they apply program-wide once this file is in the TypeScript
@@ -24,3 +24,4 @@
 
 /// <reference path="./ns-runtime.d.ts" />
 /// <reference path="./ns-util.d.ts" />
+/// <reference path="./ns-nativeclass.d.ts" />

--- a/types/ns-nativeclass.d.ts
+++ b/types/ns-nativeclass.d.ts
@@ -4,6 +4,8 @@
  *
  * `@NativeClass` and `@NativeClass({ ios: { ... } })` are both valid.
  * Passing the class directly (`NativeClass(MyClass)`) applies empty options.
+ * On worker isolates this is a no-op; only the main isolate registers
+ * native ES classes.
  */
 interface NativeClassIOSMethodSignature {
   returns?: any;

--- a/types/ns-nativeclass.d.ts
+++ b/types/ns-nativeclass.d.ts
@@ -1,0 +1,41 @@
+/**
+ * Decorates a class that extends a native type. All properties are optional.
+ * This runtime implements the `ios` side; `android` is accepted and ignored.
+ *
+ * `@NativeClass` and `@NativeClass({ ios: { ... } })` are both valid.
+ * Passing the class directly (`NativeClass(MyClass)`) applies empty options.
+ */
+interface NativeClassIOSMethodSignature {
+  returns?: any;
+  params?: any[];
+}
+
+interface NativeClassIOSOptions {
+  /**
+   * Objective-C class name to register eagerly. When omitted, the ES class
+   * name is used and registration stays lazy until first native use.
+   */
+  name?: string;
+  protocols?: any[];
+  /**
+   * Maps to `static ObjCExposedMethods`. Keys are Objective-C selectors.
+   */
+  methods?: { [selector: string]: NativeClassIOSMethodSignature };
+}
+
+interface NativeClassAndroidOptions {
+  name?: string;
+  interfaces?: any[];
+}
+
+interface NativeClassOptions {
+  ios?: NativeClassIOSOptions;
+  android?: NativeClassAndroidOptions;
+}
+
+declare function NativeClass<T extends { new (...args: any[]): {} }>(
+  constructor: T
+): T;
+declare function NativeClass(
+  options?: NativeClassOptions
+): <T extends { new (...args: any[]): {} }>(constructor: T) => T;


### PR DESCRIPTION
Makes plain ES2015+ classes that extend native types work directly on iOS, without requiring `@NativeClass` or ES5 downleveling:

```ts
class JSClass extends NSObject {
  description() {
    return 'hello from ES class';
  }
}
```

## Lazy registration

Construction is not the only way a class first crosses into native code. All of the following now trigger lazy registration, before any instance has ever been created:

```ts
class JSClass extends NSObject {}

someNativeMethod(JSClass);   // passed as a Class (or id) argument
JSClass.alloc().init();      // alloc before any construction
JSClass.new();               // inherited static factory
JSClass.someStaticMethod();  // inherited static method dispatch
JSClass.someStaticProperty;  // inherited static property get/set
```

## Instance identity Improvements

`new MyClass()` and native `[[MyClass.class() alloc] init…]` now produce the same kind of JS instance: a real construct of the ES class. Public fields, private fields (`#a`), and the constructor body run on both paths.

The constructor → `super()` loop is broken with an isolate-local adopt slot (`Caches::PendingESAdopt`):

1. Native already created object **N1**.
2. `CreateJsWrapper(N1)` stashes N1 and constructs `MyClass`.
3. `super()` binds `this` to N1 and does **not** `alloc` / `init` again.

`super({ argName: value })` stays the create-path initializer picker. Adopt ignores those args so the initializer that already ran (`init`, `initWithFrame:`, `initWithCoder:`) stays authoritative.

```ts
class MyClass extends UIView {
  #a = 1;
  constructor() {
    super({ frame: CGRectMake(0, 0) });
  }
  someMethod() {
    return this.#a;
  }
}

new MyClass().someMethod();          // 1
MyClass.alloc().init().someMethod(); // 1  (was TypeError: cannot read private member #a)
```

Not solved here (not deal-breakers):

- Constructors that require JS-only arguments cannot be invented on the native-born path (`CreateJsWrapper` constructs with zero args).
- JS-only methods still need `ObjCExposedMethods` / `NativeClass({ ios: { methods } })` to be callable via `objc_msgSend`.
- A constructor that throws after `super()` leaves a partial `Instances` mapping; a later wrap of the same `id` does not construct again.
- KVO / isa-swizzled first wrap still falls back to the pre-A empty wrapper.

## NativeClass decorator API

`@NativeClass` is no longer a no-op. Optional `ios` options map to the existing statics and can eagerly name the Objective-C class:

```ts
@NativeClass({
  ios: {
    name: 'MyNeatIOSClass',
    protocols: [UIDelegateAnything],
    methods: {
      'selectorWithX:andY:': {
        returns: interop.types.void,
        params: [interop.types.id, interop.types.id],
      },
    },
  },
  // here for example purposes - consolidated decorator for all platform annotations 
  android: {
    interfaces: [android.view.View],
    name: 'org.nativescript.example.CustomActivity',
  },
})
class MyClass extends UIView {}
```

- All properties are optional.
- `ios.protocols` → `static ObjCProtocols`
- `ios.methods` → `static ObjCExposedMethods`
- `ios.name` → `ObjCClassName` plus eager registration
- This runtime implements `ios` only; `android` is accepted and ignored
- Types: [`types/ns-nativeclass.d.ts`](https://github.com/NativeScript/ios/blob/feat/native-es-classes/types/ns-nativeclass.d.ts)

`@NativeClass` and `@NativeClass({ ios: { … } })` are both valid. Passing the class directly (`NativeClass(MyClass)`) applies empty options.

## Tests

See [`TestRunner/app/tests/Inheritance/ESClassTests.js`](https://github.com/NativeScript/ios/blob/feat/native-es-classes/TestRunner/app/tests/Inheritance/ESClassTests.js), including:

- `ESClassAllocInitRunsJsConstructor`
- `ESClassAllocInitPrivateFields`
- `ESClassAllocInitDoesNotDoubleAlloc`
- `ESClassSuperObjectTokensSelectInitializer`
- `ESClassAllocInitThrowingConstructor`
- `NativeClassDecoratorAppliesIOSOptions`
- `NativeClassEagerNameRegistersImmediately`
- `NativeClassExposedMethodsFromIOSOptions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `NativeClass` support for decorating JavaScript classes with native class names, protocols, interfaces, and exposed methods.
  * Added TypeScript declarations and configuration options for `NativeClass` on iOS and Android.
  * Improved interoperability between JavaScript subclasses and native classes, including inheritance, constructors, static members, properties, allocation, and class marshalling.
* **Bug Fixes**
  * Improved handling of `super()` construction and native object adoption for derived classes.
* **Tests**
  * Added comprehensive coverage for ES class inheritance and native integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->