### PR TITLE
fix: add buffer-length check in unzip.cpp

### DIFF
--- a/TKLiveSync/unzip.cpp
+++ b/TKLiveSync/unzip.cpp
@@ -25,6 +25,26 @@ static void mkdir_rec(const char* dir)
     mkdir(opath, S_IRWXU);
 }
 
+// ZIP entry names are untrusted input: reject absolute paths and ".."
+// components so extraction can never write outside `destination`.
+static bool is_safe_entry_name(const char* name)
+{
+    if (name == nullptr || *name == '\0' || *name == '/')
+        return false;
+
+    for (const char* p = name; *p;) {
+        const char* component = p;
+        while (*p && *p != '/')
+            p++;
+        if (p - component == 2 && component[0] == '.' && component[1] == '.')
+            return false;
+        if (*p == '/')
+            p++;
+    }
+
+    return true;
+}
+
 int64_t unzip(const char* syncZipPath, const char* destination)
 {
     int err = 0;
@@ -39,6 +59,9 @@ int64_t unzip(const char* syncZipPath, const char* destination)
     for (zip_int64_t i = 0; i < num; i++) {
         zip_stat_index(z, i, ZIP_STAT_MTIME, &sb);
         auto name = sb.name;
+
+        if (!is_safe_entry_name(name))
+            continue;
 
         std::string assetFullname{ destination };
         assetFullname.append("/");

--- a/TKLiveSync/unzip.cpp
+++ b/TKLiveSync/unzip.cpp
@@ -46,7 +46,7 @@ int64_t unzip(const char* syncZipPath, const char* destination)
         assetFullname.append("/");
         assetFullname.append(name);
 
-        strcpy(pathcopy, name);
+        snprintf(pathcopy, PATH_MAX, "%s", name);
         auto path = dirname(pathcopy);
         std::string dirFullname(destination);
         dirFullname.append("/");

--- a/TKLiveSync/unzip.cpp
+++ b/TKLiveSync/unzip.cpp
@@ -1,7 +1,6 @@
 #include "unzip.h"
 #include "libzip/zip.h"
 #include <assert.h>
-#include <libgen.h>
 #include <limits.h>
 #include <string>
 #include <sys/stat.h>
@@ -36,7 +35,6 @@ int64_t unzip(const char* syncZipPath, const char* destination)
     struct zip_stat sb;
     struct zip_file* zf;
     char buf[65536];
-    auto pathcopy = new char[PATH_MAX];
 
     for (zip_int64_t i = 0; i < num; i++) {
         zip_stat_index(z, i, ZIP_STAT_MTIME, &sb);
@@ -46,12 +44,15 @@ int64_t unzip(const char* syncZipPath, const char* destination)
         assetFullname.append("/");
         assetFullname.append(name);
 
-        snprintf(pathcopy, PATH_MAX, "%s", name);
-        auto path = dirname(pathcopy);
-        std::string dirFullname(destination);
-        dirFullname.append("/");
-        dirFullname.append(path);
-        mkdir_rec(dirFullname.c_str());
+        std::string entryName{ name };
+        auto separator = entryName.find_last_of('/');
+
+        if (separator != std::string::npos) {
+            std::string dirFullname{ destination };
+            dirFullname.append("/");
+            dirFullname.append(entryName.substr(0, separator));
+            mkdir_rec(dirFullname.c_str());
+        }
 
         zf = zip_fopen_index(z, i, 0);
         assert(zf != nullptr);
@@ -72,7 +73,6 @@ int64_t unzip(const char* syncZipPath, const char* destination)
 
         zip_fclose(zf);
     }
-    delete[] pathcopy;
     zip_close(z);
 
     return num;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `TKLiveSync/unzip.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `TKLiveSync/unzip.cpp:49` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-120 |

**Description**: A PATH_MAX-sized heap buffer (pathcopy) receives ZIP entry names via strcpy() without bounds checking. ZIP specification allows entry names up to 65535 bytes, far exceeding typical PATH_MAX values (4096 or 1024). This creates a classic buffer overflow where crafted long filenames overflow the heap buffer.

## Evidence

**Exploitation scenario**: Attacker creates a ZIP archive with an entry name longer than PATH_MAX bytes.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `TKLiveSync/unzip.cpp`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP extraction reliability by rejecting empty, absolute, or unsafe entry paths.
  * Handled directory paths more safely during extraction.
  * Avoided unnecessary directory creation when entries do not include a parent directory.

* **Refactor**
  * Simplified archive path handling for improved stability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->