### PR TITLE
fix: stop over-releasing objects wrapped from a raw pointer

### DIFF
--- a/NativeScript/runtime/ArgConverter.h
+++ b/NativeScript/runtime/ArgConverter.h
@@ -58,6 +58,14 @@ class ArgConverter {
       v8::Local<v8::Context> context);
   static const Meta* FindMeta(Class klass,
                               const TypeEncoding* typeEncoding = nullptr);
+  // Looks up the JS wrapper cached for `target` in Caches::Instances, dropping
+  // the entry and reporting a miss when it no longer describes the object at
+  // that address. Every read of Instances that hands the wrapper straight back
+  // to JS must go through here: entries are keyed on the raw pointer, so an
+  // entry that outlived its object would otherwise alias whatever allocation
+  // recycled the address and give it a foreign prototype.
+  static std::shared_ptr<v8::Persistent<v8::Value>> FindCachedInstance(
+      v8::Isolate* isolate, const std::shared_ptr<Caches>& cache, id target);
   static const Meta* GetMeta(std::string name);
   static const ProtocolMeta* FindProtocolMeta(Protocol* protocol);
   static void MethodCallback(ffi_cif* cif, void* retValue, void** argValues,

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -559,12 +559,21 @@ void ArgConverter::ConstructObject(Local<Context> context, const FunctionCallbac
   tns::Assert(klass != nullptr, isolate);
 
   id result = nil;
+  // A Caches::Instances entry owns exactly one reference to the object it maps
+  // (ObjectManager::DisposeValue gives it back, and ClassBuilder's swizzled
+  // retain/release read a retainCount of 1 as "only the map holds this"), so
+  // this function must hand the entry a +1 and no more. Tracks whether `result`
+  // already carries one: the alloc/init paths do, a pointer handed in from JS
+  // does not. Constructing from a pointer is non-consuming — interop.handleof
+  // hands out a retain-neutral address, and a +1 reaches JS as an Unmanaged to
+  // be claimed with takeRetainedValue — so that path takes its own reference.
+  bool resultIsOwned = false;
 
   if (info.Length() == 1) {
     BaseDataWrapper* wrapper = tns::GetValue(isolate, info[0]);
     if (wrapper != nullptr && wrapper->Type() == WrapperType::Pointer) {
       PointerWrapper* pointerWrapper = static_cast<PointerWrapper*>(wrapper);
-      result = CFBridgingRelease(pointerWrapper->Data());
+      result = (__bridge id)pointerWrapper->Data();
     }
   }
 
@@ -583,17 +592,24 @@ void ArgConverter::ConstructObject(Local<Context> context, const FunctionCallbac
 
     V8VectorArgs vectorArgs(args);
     result = Interop::CallInitializer(context, initializer, result, klass, vectorArgs);
+    resultIsOwned = true;
   }
 
   if (result == nil) {
     result = [[klass alloc] init];
+    resultIsOwned = true;
   }
 
   auto cache = Caches::Get(isolate);
-  auto it = cache->Instances.find(result);
-  if (it != cache->Instances.end()) {
-    Local<Value> obj = it->second->Get(isolate);
-    info.GetReturnValue().Set(obj);
+  auto poInstance = ArgConverter::FindCachedInstance(isolate, cache, result);
+  if (poInstance != nullptr) {
+    // An initializer that answered with an already wrapped object (a singleton,
+    // a tagged pointer, a cached cluster instance) leaves us holding a +1 the
+    // existing entry has no use for.
+    if (resultIsOwned) {
+      [result release];
+    }
+    info.GetReturnValue().Set(poInstance->Get(isolate));
   } else {
     ObjCDataWrapper* wrapper = new ObjCDataWrapper(result);
     Local<Object> thiz = info.This();
@@ -601,7 +617,9 @@ void ArgConverter::ConstructObject(Local<Context> context, const FunctionCallbac
     tns::SetValue(isolate, thiz, wrapper);
     std::shared_ptr<Persistent<Value>> poThiz = ObjectManager::Register(context, thiz);
     cache->Instances.emplace(result, poThiz);
-    // [result retain];
+    if (!resultIsOwned) {
+      [result retain];
+    }
   }
 }
 
@@ -933,6 +951,30 @@ Local<Value> ArgConverter::CreateJsWrapper(Local<Context> context, BaseDataWrapp
   }
 
   return receiver;
+}
+
+std::shared_ptr<Persistent<Value>> ArgConverter::FindCachedInstance(
+    Isolate* isolate, const std::shared_ptr<Caches>& cache, id target) {
+  auto it = cache->Instances.find(target);
+  if (it == cache->Instances.end()) {
+    return nullptr;
+  }
+
+  BaseDataWrapper* wrapper = tns::GetValue(isolate, it->second->Get(isolate));
+  if (wrapper != nullptr && wrapper->Type() == WrapperType::ObjCObject) {
+    Class expected = static_cast<ObjCDataWrapper*>(wrapper)->Klass();
+    // A KVO-style isa swizzle replaces the class in place but keeps -class
+    // answering the original, so only an address that now belongs to a
+    // different object fails both comparisons. Dropping such an entry turns a
+    // wrapper that would otherwise be handed out with the wrong prototype into
+    // a plain cache miss, which rebuilds it correctly.
+    if (expected != nil && object_getClass(target) != expected && [target class] != expected) {
+      cache->Instances.erase(it);
+      return nullptr;
+    }
+  }
+
+  return it->second;
 }
 
 const Meta* ArgConverter::FindMeta(Class klass, const TypeEncoding* typeEncoding) {

--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -1,6 +1,8 @@
 #ifndef DataWrapper_h
 #define DataWrapper_h
 
+#include <objc/runtime.h>
+
 #include <functional>
 #include <mutex>
 #include <thread>
@@ -365,7 +367,9 @@ class UnmanagedTypeWrapper : public BaseDataWrapper {
 class ObjCDataWrapper : public BaseDataWrapper {
  public:
   ObjCDataWrapper(id data, const TypeEncoding* typeEncoding = nullptr)
-      : data_(data), typeEncoding_(typeEncoding) {}
+      : data_(data),
+        typeEncoding_(typeEncoding),
+        klass_(object_getClass(data)) {}
 
   const WrapperType Type() { return WrapperType::ObjCObject; }
 
@@ -373,9 +377,15 @@ class ObjCDataWrapper : public BaseDataWrapper {
 
   const TypeEncoding* TypeEncoding() { return this->typeEncoding_; }
 
+  // The class Data() had when this wrapper was built. Data() alone cannot tell
+  // whether the wrapper still describes the object living at that address, so
+  // anything keyed on the raw pointer needs this to detect a recycled slot.
+  Class Klass() { return this->klass_; }
+
  private:
   id data_;
   const tns::TypeEncoding* typeEncoding_;
+  Class klass_;
 };
 
 class ObjCClassWrapper : public BaseDataWrapper {

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1244,9 +1244,9 @@ Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* type
     }
 
     auto cache = Caches::Get(isolate);
-    auto it = cache->Instances.find(result);
-    if (it != cache->Instances.end()) {
-      return it->second->Get(isolate);
+    auto poInstance = ArgConverter::FindCachedInstance(isolate, cache, result);
+    if (poInstance != nullptr) {
+      return poInstance->Get(isolate);
     }
 
     // For NSProxy we will try to read the metadata from

--- a/NativeScript/runtime/ObjectManager.mm
+++ b/NativeScript/runtime/ObjectManager.mm
@@ -204,7 +204,16 @@ bool ObjectManager::DisposeValue(Isolate* isolate, Local<Value> value, bool isFi
       ObjCDataWrapper* objCObjectWrapper = static_cast<ObjCDataWrapper*>(wrapper);
       id target = objCObjectWrapper->Data();
       if (target != nil) {
-        cache->Instances.erase(target);
+        // Instances is keyed on the raw address, so an entry rebuilt for a
+        // later object living there must survive this wrapper going away —
+        // only the entry that still points back at this object is ours.
+        auto it = cache->Instances.find(target);
+        if (it != cache->Instances.end()) {
+          Local<Value> cached = it->second->Get(isolate);
+          if (cached.IsEmpty() || cached == value) {
+            cache->Instances.erase(it);
+          }
+        }
         [target release];
       }
       break;

--- a/TestRunner/app/tests/StaleWrapperCacheTests.js
+++ b/TestRunner/app/tests/StaleWrapperCacheTests.js
@@ -1,0 +1,44 @@
+describe("Instance cache staleness", function () {
+    var ITERATIONS = 100;
+
+    // NSObject (isa only) and TNSBaseInterface (isa + two ints) both land in the
+    // 16-byte malloc bucket, so a TNSBaseInterface allocated after an NSObject is
+    // freed can be handed the very same address.
+    it("never hands out a wrapper built for an object that no longer lives at that address", function (done) {
+        for (var i = 0; i < ITERATIONS; i++) {
+            var original = NSObject.alloc().init();
+            var alias = new NSObject(interop.handleof(original));
+            if (i === 0) {
+                expect(alias).toBe(original);
+            }
+            original = null;
+            alias = null;
+        }
+
+        // An address can only be recycled once the runloop has drained its
+        // autorelease pool, so the reallocation half has to run in a later turn.
+        setTimeout(function () {
+            var wrongPrototype = 0;
+            var missingMethod = 0;
+            var instances = [];
+
+            for (var j = 0; j < ITERATIONS; j++) {
+                var instance = TNSBaseInterface.alloc().init();
+                instances.push(instance);
+
+                if (Object.getPrototypeOf(instance) !== TNSBaseInterface.prototype) {
+                    wrongPrototype++;
+                }
+                if (typeof instance.baseProtocolMethod2Optional !== "function") {
+                    missingMethod++;
+                }
+            }
+
+            expect(wrongPrototype).toBe(0, "instances built on a reused address got a foreign prototype");
+            expect(missingMethod).toBe(0, "instances built on a reused address lost their protocol methods");
+
+            instances = null;
+            done();
+        }, 0);
+    });
+});

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -121,6 +121,7 @@ require("./Inheritance/ProtocolImplementationTests");
 require("./Inheritance/TypeScriptTests");
 //
 require("./MethodCallsTests");
+require("./StaleWrapperCacheTests");
 //import "./FunctionsTests";
 require("./VersionDiffTests");
 require("./ObjCConstructors");


### PR DESCRIPTION
Fixes the intermittent `MethodCallsTests.js` failures (`Base_InstanceBaseProtocolMethod2Optional` "is not a function", `Derived_DerivedProtocolProperty1` setter not observed) — which turned out to be the benign symptom of a latent use-after-free.

## Root cause

`new SomeClass(pointer)` (e.g. `new NSObject(interop.handleof(x))`, exercised by `ReferenceTests.js`) ran `CFBridgingRelease` on the incoming pointer — under this non-ARC target that autoreleases a reference JS never owned (`interop.handleof` is retain-neutral). The over-released object deallocs at pool drain while its `Caches::Instances` entry (keyed by raw pointer, erased only at V8 GC finalization) survives on the freed address. A later `alloc` in the same malloc size class can reuse that address, and the cache hit at `Interop.mm` returned the stale wrapper verbatim — wrong prototype, missing methods. Self-limiting (the colliding object then owns the slot), hence "fails once, passes on rerun". Worse: the stale entry's eventual finalizer does `[ptr release]` on freed, possibly reused memory.

With a targeted regression loop the bug is not a flake at all: **99/100 iterations** produced a wrong-prototype wrapper on unfixed code, and the unfixed run also reproduced `Derived_DerivedProtocolProperty1` organically.

## The fix

- **Ownership** (`ArgConverter::ConstructObject`): the pointer path uses a plain `__bridge` conversion (non-consuming), and a `resultIsOwned` flag makes every path hand the `Instances` entry exactly one owned reference — alloc/init paths donate alloc's +1 (preserving the leak fix from `1129d15f`), the pointer path takes its own retain. The non-consuming contract is the historically intended one: `interop.handleof` has been retain-neutral since 2019, and real +1 handoffs already have dedicated mechanisms (`ownsReturnedCocoaObject`, `Unmanaged.takeRetainedValue`). Restored invariant, stated at the site: an `Instances` entry owns exactly one reference to the object it maps.
- **Stale-hit guard** (`ArgConverter::FindCachedInstance`, used by both previously-blind hit sites): a pointer-compare of `object_getClass` against the class recorded in the wrapper at construction (KVO-tolerant via a `-class` fallback); a mismatch erases the entry and rebuilds — converting any future staleness into a self-healing miss, matching the one lookup path that already re-resolved.
- **Reciprocal erase** (`ObjectManager::DisposeValue`): only the entry that still points back at the wrapper being disposed is erased, so an entry rebuilt by the guard survives its predecessor's finalizer.
- Bonus: an initializer answering with an already-cached object (singletons, class clusters) previously leaked the surplus +1 on the cache-hit path; it is now released.

## Tests

New `TestRunner/app/tests/StaleWrapperCacheTests.js`: loops pointer-construction over short-lived objects, yields the runloop, then loops `TNSBaseInterface.alloc().init()` asserting prototype identity and method presence. Red on unfixed code (99/100), green with the fix.

Full suite on the rebased branch (on top of #430/#431): **1070 tests, 0 failures, 11 pre-existing skips**, plus two full green runs pre-rebase. Every remaining `Caches::Instances` access site was audited — the unguarded ones all resolve objects provably alive at that instant.