### PR TITLE
fix(metadata-generator): emit UIKit metadata for Mac Catalyst

### DIFF
--- a/metadata-generator/build-step-metadata-generator.py
+++ b/metadata-generator/build-step-metadata-generator.py
@@ -85,13 +85,23 @@ conf_build_dir = env("CONFIGURATION_BUILD_DIR")
 sdk_root = env("SDKROOT")
 src_root = env("SRCROOT")
 deployment_target_flag_name = env_or_empty("DEPLOYMENT_TARGET_CLANG_FLAG_NAME") or default_deployment_target_flag_name
-deployment_target = env(env_or_empty("DEPLOYMENT_TARGET_CLANG_ENV_NAME") or default_deployment_target_clang_env_name)
+# Xcode does not export MACCATALYST_DEPLOYMENT_TARGET unless the project sets it,
+# so fall back to the iOS deployment target rather than dying with a KeyError.
+deployment_target = env_or_none(env_or_empty("DEPLOYMENT_TARGET_CLANG_ENV_NAME") or default_deployment_target_clang_env_name) \
+    or env("IPHONEOS_DEPLOYMENT_TARGET")
 std = env("GCC_C_LANGUAGE_STANDARD")
 header_search_paths = env_or_empty("HEADER_SEARCH_PATHS")
 header_search_paths_parsed = map_and_list((lambda s: "-I" + s), shlex.split(header_search_paths))
 framework_search_paths = shlex.split(env_or_empty("FRAMEWORK_SEARCH_PATHS"))
 # Add extra framework search path for newer Xcode versions
 framework_search_paths.append(os.path.join(sdk_root, "System/Library/SubFrameworks"))
+if effective_platform_name == "-maccatalyst":
+    # UIKit and the rest of the iOS-flavoured frameworks live under iOSSupport in
+    # the macOS SDK. Xcode passes these to the real compile via -iframework, which
+    # never reaches FRAMEWORK_SEARCH_PATHS, so without them the generated metadata
+    # contains no UIKit at all ("ReferenceError: UIDevice is not defined").
+    framework_search_paths.append(os.path.join(sdk_root, "System/iOSSupport/System/Library/Frameworks"))
+    framework_search_paths.append(os.path.join(sdk_root, "System/iOSSupport/System/Library/SubFrameworks"))
 framework_search_paths_parsed = map_and_list((lambda s: "-F" + s), framework_search_paths)
 other_cflags = env_or_empty("OTHER_CFLAGS")
 other_cflags_parsed = shlex.split(other_cflags)


### PR DESCRIPTION
## Summary

Two defects in `build-step-metadata-generator.py` stop a Mac Catalyst build from producing usable metadata. Both were found by building a real app for `platform=macOS,variant=Mac Catalyst` and fixing whatever failed next.

- **Generation crashes before it starts.** With `EFFECTIVE_PLATFORM_NAME=-maccatalyst` the script looks up `MACCATALYST_DEPLOYMENT_TARGET`, which Xcode does not export unless the project sets it explicitly, so it dies with `KeyError: 'MACCATALYST_DEPLOYMENT_TARGET'`. It now falls back to `IPHONEOS_DEPLOYMENT_TARGET`.

- **The generated metadata contains no UIKit.** UIKit and the other iOS-flavoured frameworks live under `System/iOSSupport` in the macOS SDK. Xcode passes those to the real compile with `-iframework`, which never reaches `FRAMEWORK_SEARCH_PATHS`, so the generator parses the macOS SDK with no UIKit in scope and emits metadata without it. Every UIKit class then fails at runtime with `ReferenceError: UIDevice is not defined` — the app dies during `require()` of the first module touching UIKit. Those two search paths are now added for `-maccatalyst` only.

## Testing

Built a real app (OSS Weather) as a Mac Catalyst app on Apple Silicon. With both fixes it builds, signs and launches as a native macOS app — menu bar, resizable window, network and CoreLocation working.

Symbols in the generated Mac Catalyst metadata, before and after:

| symbol | before | after |
|---|---|---|
| `UIDevice` | 0 | 2 |
| `UIContentSizeCategoryExtraSmall` | 0 | 1 |

iOS device and simulator builds are unaffected — the new search paths are behind the `-maccatalyst` check, and the deployment-target change is a fallback that only fires when the platform-specific variable is absent.

## Note for reviewers

The `IS_UIKITFORMAC` check in `generate_metadata` is dead code: Xcode's variable has been `IS_MACCATALYST` for several releases, so that branch never runs and the `else` branch builds `arm64-apple-ios<sdk>-macabi`, which is what actually works today. I left it alone rather than switch to an untested code path, but it is worth a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment metadata generation now uses a fallback deployment target when a platform-specific value is unavailable.
  * macCatalyst builds can now locate iOS frameworks and subframeworks correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->