### PR TITLE
perf(metadata): small size reductions in metadata.bin

### DIFF
--- a/NativeScript/runtime/Metadata.h
+++ b/NativeScript/runtime/Metadata.h
@@ -59,20 +59,23 @@ inline uint8_t getMinorVersion(uint8_t encodedVersion) {
 
 // Bit indices in flags section
 enum MetaFlags {
-    HasDemangledName = 8,
-    HasName = 7,
-    // IsIosAppExtensionAvailable = 6, the flag exists in metadata generator but we never use it in the runtime
-    FunctionReturnsUnmanaged = 3,
-    FunctionIsVariadic = 5,
-    FunctionOwnsReturnedCocoaObject = 4,
-    MemberIsOptional = 0, // Mustn't equal any Method or Property flag since it can be applicable to both
-    MethodIsInitializer = 1,
-    MethodIsVariadic = 2,
-    MethodIsNullTerminatedVariadic = 3,
-    MethodOwnsReturnedCocoaObject = 4,
-    MethodHasErrorOutParameter = 5,
-    PropertyHasGetter = 2,
-    PropertyHasSetter = 3,
+  HasDemangledName = 8,
+  HasName = 7,
+  // IsIosAppExtensionAvailable = 6, the flag exists in metadata generator but
+  // we never use it in the runtime
+  FunctionReturnsUnmanaged = 3,
+  FunctionIsVariadic = 5,
+  FunctionOwnsReturnedCocoaObject = 4,
+  MemberIsOptional = 0,  // Mustn't equal any Method or Property flag since it
+                         // can be applicable to both
+  MethodIsInitializer = 1,
+  MethodIsVariadic = 2,
+  MethodIsNullTerminatedVariadic = 3,
+  MethodOwnsReturnedCocoaObject = 4,
+  MethodHasErrorOutParameter = 5,
+  MethodHasConstructorTokens = 9,
+  PropertyHasGetter = 2,
+  PropertyHasSetter = 3,
 
 };
 
@@ -788,8 +791,13 @@ public:
         return this->_encodings.valuePtr();
     }
 
+    // The trailing _constructorTokens slot is only written when the flag is
+    // set, so it must not be read otherwise — the bytes past _encodings belong
+    // to whatever the generator emitted next.
     inline const char* constructorTokens() const {
-        return this->_constructorTokens.valuePtr();
+      return this->flag(MetaFlags::MethodHasConstructorTokens)
+                 ? this->_constructorTokens.valuePtr()
+                 : "";
     }
 
     bool isImplementedInClass(Class klass, bool isStatic) const;

--- a/metadata-generator/src/Binary/binarySerializer.cpp
+++ b/metadata-generator/src/Binary/binarySerializer.cpp
@@ -140,7 +140,10 @@ void binary::BinarySerializer::serializeBaseClass(::Meta::BaseClassMeta* meta, b
 void binary::BinarySerializer::serializeMember(::Meta::Meta* meta, binary::MemberMeta& binaryMetaStruct)
 {
     this->serializeBase(meta, binaryMetaStruct);
-    binaryMetaStruct._flags &= 0b11111000; // this clears the type information written in the lower 3 bits
+    // Clear only the type information in the lower 3 bits. The old mask also
+    // dropped bits 8 and up, which would silently discard any member flag
+    // stored there.
+    binaryMetaStruct._flags &= ~0b111;
 
     if (meta->getFlags(::Meta::MetaFlags::MemberIsOptional))
         binaryMetaStruct._flags |= BinaryFlags::MemberIsOptional;
@@ -163,7 +166,11 @@ void binary::BinarySerializer::serializeMethod(::Meta::MethodMeta* meta, binary:
         binaryMetaStruct._flags |= BinaryFlags::MethodIsInitializer;
 
     binaryMetaStruct._encoding = this->typeEncodingSerializer.visit(meta->signature);
-    binaryMetaStruct._constructorTokens = this->heapWriter.push_string(meta->constructorTokens);
+    if (!meta->constructorTokens.empty()) {
+      binaryMetaStruct._flags |= BinaryFlags::MethodHasConstructorTokens;
+      binaryMetaStruct._constructorTokens =
+          this->heapWriter.push_string(meta->constructorTokens);
+    }
 }
 
 void binary::BinarySerializer::serializeProperty(::Meta::PropertyMeta* meta, binary::PropertyMeta& binaryMetaStruct)

--- a/metadata-generator/src/Binary/binaryStructures.cpp
+++ b/metadata-generator/src/Binary/binaryStructures.cpp
@@ -43,7 +43,12 @@ binary::MetaFileOffset binary::MethodMeta::save(BinaryWriter& writer)
 {
     binary::MetaFileOffset offset = MemberMeta::save(writer);
     writer.push_pointer(this->_encoding);
-    writer.push_pointer(this->_constructorTokens);
+    // Trailing field, and MethodMeta has no subclass, so it can simply be left
+    // out when unset. The reader keys off MethodHasConstructorTokens and never
+    // touches the slot otherwise.
+    if (this->_flags & BinaryFlags::MethodHasConstructorTokens) {
+      writer.push_pointer(this->_constructorTokens);
+    }
     return offset;
 }
 

--- a/metadata-generator/src/Binary/binaryStructures.h
+++ b/metadata-generator/src/Binary/binaryStructures.h
@@ -61,25 +61,26 @@ enum BinaryMetaType : uint8_t {
 };
 
 enum BinaryFlags : uint16_t {
-    // Common
-    HasDemangledName = 1 << 8,
-    HasName = 1 << 7,
-    IsIosAppExtensionAvailable = 1 << 6,
-    // Function
-    FunctionIsVariadic = 1 << 5,
-    FunctionOwnsReturnedCocoaObject = 1 << 4,
-    FunctionReturnsUnmanaged = 1 << 3,
-    // Member
-    MemberIsOptional = 1 << 0,
-    // Method
-    MethodIsInitializer = 1 << 1,
-    MethodIsVariadic = 1 << 2,
-    MethodIsNullTerminatedVariadic = 1 << 3,
-    MethodOwnsReturnedCocoaObject = 1 << 4,
-    MethodHasErrorOutParameter = 1 << 5,
-    // Property
-    PropertyHasGetter = 1 << 2,
-    PropertyHasSetter = 1 << 3
+  // Common
+  HasDemangledName = 1 << 8,
+  HasName = 1 << 7,
+  IsIosAppExtensionAvailable = 1 << 6,
+  // Function
+  FunctionIsVariadic = 1 << 5,
+  FunctionOwnsReturnedCocoaObject = 1 << 4,
+  FunctionReturnsUnmanaged = 1 << 3,
+  // Member
+  MemberIsOptional = 1 << 0,
+  // Method
+  MethodIsInitializer = 1 << 1,
+  MethodIsVariadic = 1 << 2,
+  MethodIsNullTerminatedVariadic = 1 << 3,
+  MethodOwnsReturnedCocoaObject = 1 << 4,
+  MethodHasErrorOutParameter = 1 << 5,
+  MethodHasConstructorTokens = 1 << 9,
+  // Property
+  PropertyHasGetter = 1 << 2,
+  PropertyHasSetter = 1 << 3
 };
 
 #pragma pack(push, 1)

--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
@@ -17,7 +17,10 @@ namespace binary {
 class BinaryTypeEncodingSerializer
     : public ::Meta::TypeVisitor<unique_ptr<binary::TypeEncoding> > {
  private:
-  BinaryWriter _heapWriter;
+  // Must alias the serializer's writer, not copy it: BinaryWriter owns the
+  // string-interning map, and a copy interns into a second map, emitting a
+  // duplicate copy of every string reachable from both paths.
+  BinaryWriter& _heapWriter;
 
   unique_ptr<TypeEncoding> serializeRecordEncoding(
       const binary::BinaryTypeEncodingType encodingType,

--- a/metadata-generator/src/Binary/binaryWriter.cpp
+++ b/metadata-generator/src/Binary/binaryWriter.cpp
@@ -45,11 +45,23 @@ binary::MetaFileOffset binary::BinaryWriter::push_arrayCount(MetaArrayCount coun
 
 binary::MetaFileOffset binary::BinaryWriter::push_binaryArray(std::vector<binary::MetaFileOffset>& binaryArray)
 {
+  // Empty arrays carry no payload, so every one of them can share a single
+  // count-of-zero in the heap. Offset 0 is the null sentinel and the heap
+  // reserves a marker byte there, so a real array never lands on it.
+  if (binaryArray.empty() && this->emptyArrayOffset != 0) {
+    return this->emptyArrayOffset;
+  }
+
     binary::MetaFileOffset offset = this->_stream->position();
     this->push_arrayCount((binary::MetaArrayCount)binaryArray.size());
     for (binary::MetaFileOffset element : binaryArray) {
         this->push_pointer(element);
     }
+
+    if (binaryArray.empty()) {
+      this->emptyArrayOffset = offset;
+    }
+
     return offset;
 }
 

--- a/metadata-generator/src/Binary/binaryWriter.h
+++ b/metadata-generator/src/Binary/binaryWriter.h
@@ -14,6 +14,7 @@ namespace binary {
 class BinaryWriter : public BinaryOperation {
 private:
     std::map<std::string, MetaFileOffset> uniqueStrings;
+    MetaFileOffset emptyArrayOffset = 0;
 
     MetaFileOffset push_number(long number, int bytesCount);
 


### PR DESCRIPTION
### Description

Draft. Three small, self-contained reductions in the size of `metadata-<arch>.bin`. Each is independent and could be dropped on its own. The larger structural changes are stacked on top of this branch: **#435**.

No framework filtering, and no change to what's exposed to JS.

Sizes on a full iOS 26.2 simulator SDK run, same umbrella header throughout, same declaration count (63,878 declarations from 197 modules):

| | bytes | vs baseline |
|---|---:|---:|
| baseline (`main`) | 12,033,254 | — |
| + shared interning map | 11,930,… | |
| + shared empty array | 11,483,216 | −4.57% |
| + constructorTokens elision | **11,251,503** | **−6.50%** |

### 1. The string-interning map was split in two

`BinaryTypeEncodingSerializer` held its `BinaryWriter` **by value**. The writer owns the interning map, so the copy interned into a second map, and every string reachable from both the meta path and the type-encoding path was written to the heap twice. Measured: **4,519 strings stored at two offsets, and 100% of them were the cross-path case** — e.g. `MTRRefrigeratorAndTemperatureControlledCabinetMode…`, `ASAccountAuthenticationModificationController…`.

Fixed by making `_heapWriter` a reference.

### 2. Empty binary arrays were never shared

`push_binaryArray` writes a count then the elements; for an empty vector that's four zero bytes, and nothing deduplicated them. The file contained **95,253 distinct empty arrays**, overwhelmingly empty protocol lists hanging off interface-reference type encodings — 106,989 array references resolved to 106,989 distinct offsets, i.e. zero sharing of any kind.

The writer now remembers the first empty array and returns that offset for every subsequent one. Offset 0 stays a valid null sentinel: the heap reserves a marker byte at position 0 (`metaFile.h:46`), so no real array can land there.

These two compound — sharing the writer also merges the empty-array interning — which is why they save 550 KB together against ~490 KB measured separately.

### 3. `constructorTokens` is stored even when empty

**57,933 of 60,589 methods have no constructor tokens.** The string costs nothing (one interned empty copy), but the 4-byte pointer is paid by every method.

It is the trailing field of `MethodMeta`, which has no subclass, so the slot is now omitted and gated on a new `MethodHasConstructorTokens` flag (bit 9); `MethodMeta::constructorTokens()` returns `""` without touching the slot when the flag is clear. `PropertyMeta::save` already conditionally omits its getter/setter pointers, so this follows existing precedent. Method records are only ever reached through `ArrayOfPtrTo<MethodMeta>` — arrays of offsets, never contiguous structs — so a variable-size record is safe.

**This one also fixes a latent flag-mask bug.** `serializeMember` masked with `0b11111000`, clearing the 3 type bits *and everything from bit 8 up* — silently discarding any member flag stored there, including the `HasDemangledName` that `serializeBase` had just set. Widened to `~0b111`. It is inert today (no method or property in the SDK carries a demangled name — I checked all 29,561 and 20,603 of them), but it had to be fixed before bit 9 was usable.

This is the only one of the three that changes the runtime reader.

### Verification

Both files rendered to a canonical, offset-independent form — every interface, protocol, method, property, struct, enum, function, var and module, with all names, flags, type encodings and constructor tokens resolved and sorted — then diffed:

```
188,518 lines rendered, 0 lines differ
```

The renderer auto-detects which on-disk format a file uses (legacy always-present tokens slot vs. flagged slot) and compares the resulting *string*, so a method with no tokens renders identically under both. Flag bits 7/8/9 are excluded from the comparison because they describe how a record is stored rather than what it means; names and token values are compared directly instead.

### Note on the diff size

Most of the changed lines are clang-format reindenting the `BinaryFlags` and `MetaFlags` enum blocks from 4-space to 2-space — the pre-commit hook formats staged hunks, and adding one enumerator marks the whole enum as touched. Reviewing with whitespace ignored (`-w`) reduces this to about 30 lines and makes it much easier to read.

### Explicitly not doing

Excluding frameworks from generation. Blacklisting `Matter` alone is worth 3.87 MB (31% of the file), and the mechanism already exists end to end — `App_Resources/iOS/native-api-usage.json` → the CLI writes `platforms/ios/{whitelist,blacklist}.mdg` → `build-step-metadata-generator.py` passes them to the generator. That is an app-level decision, not a runtime one.

### Does your pull request have unit tests?

Not yet — draft. The device suite has not been run on this branch. Changes 1 and 2 are byte-layout only and covered by the semantic diff above; change 3 alters reader behavior and does need a suite run before this leaves draft.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata serialization by preserving member flags and writing constructor metadata only when available.
  * Fixed metadata reading so absent constructor information returns an empty value.
  * Improved consistency when handling repeated empty arrays.

* **Performance**
  * Reduced redundant binary data and improved reuse of shared serialized strings.

* **Maintenance**
  * Reformatted metadata flag declarations for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->