### PR TITLE
perf(metadata): omit empty constructorTokens slot (reader change)

### DIFF
--- a/NativeScript/runtime/Metadata.h
+++ b/NativeScript/runtime/Metadata.h
@@ -59,20 +59,23 @@ inline uint8_t getMinorVersion(uint8_t encodedVersion) {
 
 // Bit indices in flags section
 enum MetaFlags {
-    HasDemangledName = 8,
-    HasName = 7,
-    // IsIosAppExtensionAvailable = 6, the flag exists in metadata generator but we never use it in the runtime
-    FunctionReturnsUnmanaged = 3,
-    FunctionIsVariadic = 5,
-    FunctionOwnsReturnedCocoaObject = 4,
-    MemberIsOptional = 0, // Mustn't equal any Method or Property flag since it can be applicable to both
-    MethodIsInitializer = 1,
-    MethodIsVariadic = 2,
-    MethodIsNullTerminatedVariadic = 3,
-    MethodOwnsReturnedCocoaObject = 4,
-    MethodHasErrorOutParameter = 5,
-    PropertyHasGetter = 2,
-    PropertyHasSetter = 3,
+  HasDemangledName = 8,
+  HasName = 7,
+  // IsIosAppExtensionAvailable = 6, the flag exists in metadata generator but
+  // we never use it in the runtime
+  FunctionReturnsUnmanaged = 3,
+  FunctionIsVariadic = 5,
+  FunctionOwnsReturnedCocoaObject = 4,
+  MemberIsOptional = 0,  // Mustn't equal any Method or Property flag since it
+                         // can be applicable to both
+  MethodIsInitializer = 1,
+  MethodIsVariadic = 2,
+  MethodIsNullTerminatedVariadic = 3,
+  MethodOwnsReturnedCocoaObject = 4,
+  MethodHasErrorOutParameter = 5,
+  MethodHasConstructorTokens = 9,
+  PropertyHasGetter = 2,
+  PropertyHasSetter = 3,
 
 };
 
@@ -788,8 +791,13 @@ public:
         return this->_encodings.valuePtr();
     }
 
+    // The trailing _constructorTokens slot is only written when the flag is
+    // set, so it must not be read otherwise — the bytes past _encodings belong
+    // to whatever the generator emitted next.
     inline const char* constructorTokens() const {
-        return this->_constructorTokens.valuePtr();
+      return this->flag(MetaFlags::MethodHasConstructorTokens)
+                 ? this->_constructorTokens.valuePtr()
+                 : "";
     }
 
     bool isImplementedInClass(Class klass, bool isStatic) const;

--- a/metadata-generator/src/Binary/binarySerializer.cpp
+++ b/metadata-generator/src/Binary/binarySerializer.cpp
@@ -140,7 +140,10 @@ void binary::BinarySerializer::serializeBaseClass(::Meta::BaseClassMeta* meta, b
 void binary::BinarySerializer::serializeMember(::Meta::Meta* meta, binary::MemberMeta& binaryMetaStruct)
 {
     this->serializeBase(meta, binaryMetaStruct);
-    binaryMetaStruct._flags &= 0b11111000; // this clears the type information written in the lower 3 bits
+    // Clear only the type information in the lower 3 bits. The old mask also
+    // dropped bits 8 and up, which would silently discard any member flag
+    // stored there.
+    binaryMetaStruct._flags &= ~0b111;
 
     if (meta->getFlags(::Meta::MetaFlags::MemberIsOptional))
         binaryMetaStruct._flags |= BinaryFlags::MemberIsOptional;
@@ -163,7 +166,11 @@ void binary::BinarySerializer::serializeMethod(::Meta::MethodMeta* meta, binary:
         binaryMetaStruct._flags |= BinaryFlags::MethodIsInitializer;
 
     binaryMetaStruct._encoding = this->typeEncodingSerializer.visit(meta->signature);
-    binaryMetaStruct._constructorTokens = this->heapWriter.push_string(meta->constructorTokens);
+    if (!meta->constructorTokens.empty()) {
+      binaryMetaStruct._flags |= BinaryFlags::MethodHasConstructorTokens;
+      binaryMetaStruct._constructorTokens =
+          this->heapWriter.push_string(meta->constructorTokens);
+    }
 }
 
 void binary::BinarySerializer::serializeProperty(::Meta::PropertyMeta* meta, binary::PropertyMeta& binaryMetaStruct)

--- a/metadata-generator/src/Binary/binaryStructures.cpp
+++ b/metadata-generator/src/Binary/binaryStructures.cpp
@@ -43,7 +43,12 @@ binary::MetaFileOffset binary::MethodMeta::save(BinaryWriter& writer)
 {
     binary::MetaFileOffset offset = MemberMeta::save(writer);
     writer.push_pointer(this->_encoding);
-    writer.push_pointer(this->_constructorTokens);
+    // Trailing field, and MethodMeta has no subclass, so it can simply be left
+    // out when unset. The reader keys off MethodHasConstructorTokens and never
+    // touches the slot otherwise.
+    if (this->_flags & BinaryFlags::MethodHasConstructorTokens) {
+      writer.push_pointer(this->_constructorTokens);
+    }
     return offset;
 }
 

--- a/metadata-generator/src/Binary/binaryStructures.h
+++ b/metadata-generator/src/Binary/binaryStructures.h
@@ -61,25 +61,26 @@ enum BinaryMetaType : uint8_t {
 };
 
 enum BinaryFlags : uint16_t {
-    // Common
-    HasDemangledName = 1 << 8,
-    HasName = 1 << 7,
-    IsIosAppExtensionAvailable = 1 << 6,
-    // Function
-    FunctionIsVariadic = 1 << 5,
-    FunctionOwnsReturnedCocoaObject = 1 << 4,
-    FunctionReturnsUnmanaged = 1 << 3,
-    // Member
-    MemberIsOptional = 1 << 0,
-    // Method
-    MethodIsInitializer = 1 << 1,
-    MethodIsVariadic = 1 << 2,
-    MethodIsNullTerminatedVariadic = 1 << 3,
-    MethodOwnsReturnedCocoaObject = 1 << 4,
-    MethodHasErrorOutParameter = 1 << 5,
-    // Property
-    PropertyHasGetter = 1 << 2,
-    PropertyHasSetter = 1 << 3
+  // Common
+  HasDemangledName = 1 << 8,
+  HasName = 1 << 7,
+  IsIosAppExtensionAvailable = 1 << 6,
+  // Function
+  FunctionIsVariadic = 1 << 5,
+  FunctionOwnsReturnedCocoaObject = 1 << 4,
+  FunctionReturnsUnmanaged = 1 << 3,
+  // Member
+  MemberIsOptional = 1 << 0,
+  // Method
+  MethodIsInitializer = 1 << 1,
+  MethodIsVariadic = 1 << 2,
+  MethodIsNullTerminatedVariadic = 1 << 3,
+  MethodOwnsReturnedCocoaObject = 1 << 4,
+  MethodHasErrorOutParameter = 1 << 5,
+  MethodHasConstructorTokens = 1 << 9,
+  // Property
+  PropertyHasGetter = 1 << 2,
+  PropertyHasSetter = 1 << 3
 };
 
 #pragma pack(push, 1)


### PR DESCRIPTION
### Description

Draft. **Stacked on #434** (`feat/metadata-size`) — review only the last commit; the base PR is generator-only, this one is for changes that also need the runtime reader to move.

Sizes on a full iOS 26.2 simulator SDK run, same umbrella header throughout:

| | bytes | vs baseline |
|---|---:|---:|
| baseline (`main`) | 12,033,254 | — |
| after #434 (generator-only) | 11,483,216 | −4.57% |
| **after this PR** | **11,251,503** | **−6.50%** |

This commit accounts for **−231,713 B**.

### Current behavior

Every `MethodMeta` stores a 4-byte pointer to its constructor-tokens string. **57,933 of 60,589 methods have no constructor tokens** — the field points at the interned empty string. The string itself costs nothing (one shared copy), but the pointer is paid 60,589 times.

### New behavior

`constructorTokens` is the trailing field of `MethodMeta`, and `MethodMeta` has no subclass, so the slot can simply be omitted. A new flag, `MethodHasConstructorTokens` (bit 9), says whether it is present; `MethodMeta::constructorTokens()` returns `""` without touching the slot when the flag is clear. `PropertyMeta::save` already conditionally omits its getter/setter pointers, so this follows an existing precedent in the format.

Method records are only ever reached through `ArrayOfPtrTo<MethodMeta>` — arrays of offsets, never contiguous structs — so a variable-size record is safe; nothing does pointer arithmetic across them.

### Also in this commit: a latent flag-mask bug

`serializeMember` masked with `0b11111000`, which clears the 3 type bits **and everything from bit 8 up**. That silently discards any member flag stored at bit 8 or above — including `HasDemangledName`, which `serializeBase` had just set. It is widened to `~0b111` so only the type bits are cleared.

This changes nothing on its own today: I checked all 29,561 methods and 20,603 properties in the SDK and **none carries a demangled name**, so bit 8 was always 0 for members. But the mask had to be fixed before bit 9 could be used at all.

### Verification

Both files rendered to a canonical, offset-independent form — every entity with names, flags, type encodings and constructor tokens resolved, sorted — then diffed:

```
188,518 lines rendered, 0 lines differ
```

The renderer auto-detects which format a file uses (legacy always-present slot vs. flagged slot) and compares the resulting *string*, so a method with no tokens renders as `""` under both. Flag bits 7/8/9 are excluded from the comparison because they describe how a record is stored rather than what it means — names and tokens are compared directly instead.

### Risk

The reader change is the load-bearing part: if `constructorTokens()` ever reads the slot when the flag is clear, it reads whatever the generator emitted next in the heap. The accessor is the single point where that is decided, and it is the only place `_constructorTokens` is touched.

Only consumer of the value is `ArgConverter.mm:645-647`, which compares it against tokens built from a JS initializer object; `""` there behaves exactly as the interned empty string did.

### Note on the diff size

Roughly 85 of the ~95 changed lines are clang-format reindenting the `BinaryFlags` and `MetaFlags` enum blocks from 4-space to 2-space. The pre-commit hook formats staged hunks, and adding one enumerator marks the whole enum as touched. The semantic change is about ten lines: one new flag in each enum, the conditional `push_pointer`, the flag assignment, the mask widening, and the accessor. Reviewing with whitespace ignored makes this much easier to read.

### Does your pull request have unit tests?

Not yet — draft. The device suite has not been run on this branch. Unlike #434 this one changes reader behavior, so it does need a suite run before it leaves draft.
