### PR TITLE
perf(metadata): reference interfaces by class-name index

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -500,8 +500,7 @@ void ArgConverter::SetValue(Local<Context> context, void* retValue, Local<Value>
         return;
     }
   } else if (value->IsString()) {
-    if (type == BinaryTypeEncodingType::IdEncoding ||
-        type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+    if (type == BinaryTypeEncodingType::IdEncoding || typeEncoding->isInterfaceReference()) {
       id data = tns::ToNSString(isolate, value);
       // this feels wrong but follows the other CFBridgingRetain calls
       // and also solves a leak
@@ -511,7 +510,7 @@ void ArgConverter::SetValue(Local<Context> context, void* retValue, Local<Value>
       return;
     }
   } else if (value->IsObject()) {
-    if (type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
+    if (typeEncoding->isInterfaceReference() ||
         type == BinaryTypeEncodingType::InstanceTypeEncoding ||
         type == BinaryTypeEncodingType::IdEncoding) {
       BaseDataWrapper* baseWrapper = tns::GetValue(isolate, value);
@@ -720,8 +719,8 @@ bool ArgConverter::CanInvoke(Local<Context> context, const TypeEncoding* typeEnc
   }
 
   Isolate* isolate = v8::Isolate::GetCurrent();
-  if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-    const char* name = typeEncoding->details.declarationReference.name.valuePtr();
+  if (typeEncoding->isInterfaceReference()) {
+    const char* name = typeEncoding->interfaceName();
     if (strcmp(name, "NSNumber") == 0 && tns::IsNumber(arg)) {
       return true;
     }
@@ -978,9 +977,8 @@ std::shared_ptr<Persistent<Value>> ArgConverter::FindCachedInstance(
 }
 
 const Meta* ArgConverter::FindMeta(Class klass, const TypeEncoding* typeEncoding) {
-  if (typeEncoding != nullptr &&
-      typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-    const char* name = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
+  if (typeEncoding != nullptr && typeEncoding->isInterfaceReference()) {
+    const char* name = typeEncoding->interfaceName();
     const Meta* result = GetMeta(name);
     if (result != nullptr && result->type() == MetaType::Interface) {
       return result;
@@ -1259,11 +1257,11 @@ bool ArgConverter::IsErrorOutParameter(const TypeEncoding* typeEncoding) {
   }
 
   const TypeEncoding* innerTypeEncoding = typeEncoding->details.pointer.getInnerType();
-  if (innerTypeEncoding->type != BinaryTypeEncodingType::InterfaceDeclarationReference) {
+  if (!innerTypeEncoding->isInterfaceReference()) {
     return false;
   }
 
-  const char* name = innerTypeEncoding->details.declarationReference.name.valuePtr();
+  const char* name = innerTypeEncoding->interfaceName();
   if (name == nullptr) {
     return false;
   }

--- a/NativeScript/runtime/ClassBuilder.mm
+++ b/NativeScript/runtime/ClassBuilder.mm
@@ -537,6 +537,7 @@ std::string ClassBuilder::GetTypeEncoding(const TypeEncoding* typeEncoding) {
     }
     case BinaryTypeEncodingType::ProtocolEncoding:
     case BinaryTypeEncodingType::InterfaceDeclarationReference:
+    case BinaryTypeEncodingType::InterfaceIndexReference:
     case BinaryTypeEncodingType::InstanceTypeEncoding:
     case BinaryTypeEncodingType::IdEncoding: {
       return "@";

--- a/NativeScript/runtime/FFICall.cpp
+++ b/NativeScript/runtime/FFICall.cpp
@@ -12,6 +12,7 @@ ffi_type* FFICall::GetArgumentType(const TypeEncoding* typeEncoding, bool isStru
         }
         case BinaryTypeEncodingType::IdEncoding:
         case BinaryTypeEncodingType::InterfaceDeclarationReference:
+        case BinaryTypeEncodingType::InterfaceIndexReference:
         case BinaryTypeEncodingType::InstanceTypeEncoding:
         case BinaryTypeEncodingType::SelectorEncoding:
         case BinaryTypeEncodingType::BlockEncoding:

--- a/NativeScript/runtime/FFICall.cpp
+++ b/NativeScript/runtime/FFICall.cpp
@@ -278,10 +278,11 @@ StructInfo FFICall::GetStructInfo(size_t fieldsCount, const TypeEncoding* fieldE
 }
 
 ParametrizedCall* ParametrizedCall::Get(const TypeEncoding* typeEncoding, const int initialParameterIndex, const int argsCount) {
-    auto it = callsCache_.find(typeEncoding);
-    if (it != callsCache_.end()) {
-        return it->second;
-    }
+  CallKey key{typeEncoding, initialParameterIndex, argsCount};
+  auto it = callsCache_.find(key);
+  if (it != callsCache_.end()) {
+    return it->second;
+  }
 
     const ffi_type** parameterTypesFFITypes = new const ffi_type*[argsCount]();
     ffi_type* returnType = FFICall::GetArgumentType(typeEncoding);
@@ -301,12 +302,14 @@ ParametrizedCall* ParametrizedCall::Get(const TypeEncoding* typeEncoding, const 
     tns::Assert(status == FFI_OK);
 
     ParametrizedCall* call = new ParametrizedCall(cif);
-    callsCache_.emplace(typeEncoding, call);
+    callsCache_.emplace(key, call);
 
     return call;
 }
 
-robin_hood::unordered_map<const TypeEncoding*, ParametrizedCall*> ParametrizedCall::callsCache_;
+robin_hood::unordered_map<ParametrizedCall::CallKey, ParametrizedCall*,
+                          ParametrizedCall::CallKeyHash>
+    ParametrizedCall::callsCache_;
 robin_hood::unordered_map<std::string, StructInfo> FFICall::structInfosCache_;
 
 }

--- a/NativeScript/runtime/FFICall.h
+++ b/NativeScript/runtime/FFICall.h
@@ -67,7 +67,31 @@ class ParametrizedCall {
   std::vector<size_t> ArgValueOffsets;
 
  private:
-  static robin_hood::unordered_map<const TypeEncoding*, ParametrizedCall*>
+  // The cif is built from the encoding *and* the two counts, so all three
+  // identify it. Keying on the encoding alone aliases distinct call shapes onto
+  // one cif, which mis-describes the stack rather than failing outright.
+  struct CallKey {
+    const TypeEncoding* encoding;
+    int initialParameterIndex;
+    int argsCount;
+
+    bool operator==(const CallKey& other) const {
+      return encoding == other.encoding &&
+             initialParameterIndex == other.initialParameterIndex &&
+             argsCount == other.argsCount;
+    }
+  };
+
+  struct CallKeyHash {
+    size_t operator()(const CallKey& key) const {
+      size_t hash = robin_hood::hash<const void*>()(key.encoding);
+      hash = hash * 31 + static_cast<size_t>(key.initialParameterIndex);
+      hash = hash * 31 + static_cast<size_t>(key.argsCount);
+      return hash;
+    }
+  };
+
+  static robin_hood::unordered_map<CallKey, ParametrizedCall*, CallKeyHash>
       callsCache_;
 };
 

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -153,8 +153,8 @@ void Interop::SetFFIParams(Local<Context> context, const TypeEncoding* typeEncod
 }
 
 bool Interop::isRefTypeEqual(const TypeEncoding* typeEncoding, const char* clazz) {
-  std::string n(&typeEncoding->details.interfaceDeclarationReference.name.value());
-  return n.compare(clazz) == 0;
+  const char* name = typeEncoding->interfaceName();
+  return name != nullptr && std::string(name).compare(clazz) == 0;
 }
 
 // this is experimental. Maybe we can have something like this to wrap all Local<Value> to avoid
@@ -246,8 +246,7 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
     FFICall::DisposeFFIType(ffiType, typeEncoding);
     memset(dest, 0, size);
   } else if (argHelper.isBool()) {
-    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference &&
-        isRefTypeEqual(typeEncoding, "NSNumber")) {
+    if (typeEncoding->isInterfaceReference() && isRefTypeEqual(typeEncoding, "NSNumber")) {
       bool value = tns::ToBool(arg);
       NSNumber* num = [NSNumber numberWithBool:value];
       Interop::SetValue(dest, num);
@@ -321,15 +320,14 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
     }
     unichar c = (vector.size() == 0) ? 0 : vector[0];
     Interop::SetValue(dest, c);
-  } else if (argHelper.isString() &&
-             (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
-              typeEncoding->type == BinaryTypeEncodingType::IdEncoding)) {
+  } else if (argHelper.isString() && (typeEncoding->isInterfaceReference() ||
+                                      typeEncoding->type == BinaryTypeEncodingType::IdEncoding)) {
     NSString* result = tns::ToNSString(isolate, arg);
     Interop::SetValue(dest, result);
   } else if (Interop::IsNumbericType(typeEncoding->type) || tns::IsNumber(arg)) {
     double value = tns::ToNumber(isolate, arg);
 
-    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
+    if (typeEncoding->isInterfaceReference() ||
         typeEncoding->type == BinaryTypeEncodingType::IdEncoding) {
       // NSNumber
       NSNumber* num = [NSNumber numberWithDouble:value];
@@ -657,8 +655,8 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
     }
 
     bool isNSArray = false;
-    if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-      std::string name = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
+    if (typeEncoding->isInterfaceReference()) {
+      std::string name = typeEncoding->interfaceName();
       isNSArray = name == "NSArray";
     }
 
@@ -1189,7 +1187,7 @@ Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* type
     return instance;
   }
 
-  if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
+  if (typeEncoding->isInterfaceReference() ||
       typeEncoding->type == BinaryTypeEncodingType::IdEncoding ||
       typeEncoding->type == BinaryTypeEncodingType::InstanceTypeEncoding) {
     id result = call->GetResult<id>();
@@ -1222,8 +1220,8 @@ Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* type
     }
 
     if (marshalToPrimitive && [result isKindOfClass:[NSString class]]) {
-      if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
-        const char* returnClassName = typeEncoding->details.declarationReference.name.valuePtr();
+      if (typeEncoding->isInterfaceReference()) {
+        const char* returnClassName = typeEncoding->interfaceName();
         Class returnClass = objc_getClass(returnClassName);
         if (returnClass != nil && returnClass == [NSMutableString class]) {
           marshalToPrimitive = false;
@@ -1249,9 +1247,9 @@ Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* type
       return poInstance->Get(isolate);
     }
 
-    // For NSProxy we will try to read the metadata from
-    // typeEncoding->details.interfaceDeclarationReference.name because class_getSuperclass will
-    // directly return NSProxy and thus missing to attach all instance members
+    // For NSProxy we will try to read the metadata from the encoding's interface name because
+    // class_getSuperclass will directly return NSProxy and thus missing to attach all instance
+    // members
     const TypeEncoding* te = [result isProxy] ? typeEncoding : nullptr;
 
     ObjCDataWrapper* wrapper = new ObjCDataWrapper(result, te);
@@ -1398,9 +1396,7 @@ std::vector<std::string> Interop::GetAdditionalProtocols(const TypeEncoding* typ
       const char* protocolName = (*it).valuePtr();
       additionalProtocols.push_back(protocolName);
     }
-  } else if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference &&
-             typeEncoding->details.interfaceDeclarationReference._protocols.offset > 0) {
-    PtrTo<Array<String>> protocols = typeEncoding->details.interfaceDeclarationReference._protocols;
+  } else if (const Array<String>* protocols = typeEncoding->interfaceProtocols()) {
     for (auto it = protocols->begin(); it != protocols->end(); it++) {
       const char* protocolName = (*it).valuePtr();
       additionalProtocols.push_back(protocolName);
@@ -1767,9 +1763,9 @@ void ExecuteWriteValueValidationsAndStopExecutionAndLogStackTrace(Local<Context>
                                                                   const TypeEncoding* typeEncoding,
                                                                   void* dest, Local<Value> arg) {
   Isolate* isolate = v8::Isolate::GetCurrent();
-  std::string destName = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
   Local<Value> originArg = arg;
-  if (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference) {
+  if (typeEncoding->isInterfaceReference()) {
+    std::string destName = typeEncoding->interfaceName();
     if (originArg->IsObject()) {
       Local<Object> originObj = originArg.As<Object>();
       if ((originObj->IsArrayBuffer() || originObj->IsArrayBufferView() ||
@@ -1791,7 +1787,7 @@ void ExecuteWriteValueValidationsAndStopExecutionAndLogStackTrace(Local<Context>
 }
 
 bool IsTypeEncondingHandldedByDebugMessages(const TypeEncoding* typeEncoding) {
-  if (typeEncoding->type != BinaryTypeEncodingType::InterfaceDeclarationReference &&
+  if (!typeEncoding->isInterfaceReference() &&
       typeEncoding->type != BinaryTypeEncodingType::StructDeclarationReference &&
       typeEncoding->type != BinaryTypeEncodingType::IdEncoding) {
     return true;
@@ -1803,7 +1799,9 @@ bool IsTypeEncondingHandldedByDebugMessages(const TypeEncoding* typeEncoding) {
 void LogWriteValueTraceMessage(Local<Context> context, const TypeEncoding* typeEncoding, void* dest,
                                Local<Value> arg) {
   Isolate* isolate = v8::Isolate::GetCurrent();
-  std::string destName = typeEncoding->details.interfaceDeclarationReference.name.valuePtr();
+  std::string destName = typeEncoding->isInterfaceReference()
+                             ? typeEncoding->interfaceName()
+                             : typeEncoding->details.declarationReference.name.valuePtr();
   std::string originName = tns::ToString(isolate, arg);
   if (originName == "") {
     // empty string

--- a/NativeScript/runtime/Metadata.h
+++ b/NativeScript/runtime/Metadata.h
@@ -100,40 +100,46 @@ enum MemberType {
 };
 
 enum BinaryTypeEncodingType : uint8_t {
-    VoidEncoding,
-    BoolEncoding,
-    ShortEncoding,
-    UShortEncoding,
-    IntEncoding,
-    UIntEncoding,
-    LongEncoding,
-    ULongEncoding,
-    LongLongEncoding,
-    ULongLongEncoding,
-    CharEncoding,
-    UCharEncoding,
-    UnicharEncoding,
-    CharSEncoding,
-    CStringEncoding,
-    FloatEncoding,
-    DoubleEncoding,
-    InterfaceDeclarationReference,
-    StructDeclarationReference,
-    UnionDeclarationReference,
-    PointerEncoding,
-    VaListEncoding,
-    SelectorEncoding,
-    ClassEncoding,
-    ProtocolEncoding,
-    InstanceTypeEncoding,
-    IdEncoding,
-    ConstantArrayEncoding,
-    IncompleteArrayEncoding,
-    FunctionPointerEncoding,
-    BlockEncoding,
-    AnonymousStructEncoding,
-    AnonymousUnionEncoding,
-    ExtVectorEncoding
+  VoidEncoding,
+  BoolEncoding,
+  ShortEncoding,
+  UShortEncoding,
+  IntEncoding,
+  UIntEncoding,
+  LongEncoding,
+  ULongEncoding,
+  LongLongEncoding,
+  ULongLongEncoding,
+  CharEncoding,
+  UCharEncoding,
+  UnicharEncoding,
+  CharSEncoding,
+  CStringEncoding,
+  FloatEncoding,
+  DoubleEncoding,
+  InterfaceDeclarationReference,
+  StructDeclarationReference,
+  UnionDeclarationReference,
+  PointerEncoding,
+  VaListEncoding,
+  SelectorEncoding,
+  ClassEncoding,
+  ProtocolEncoding,
+  InstanceTypeEncoding,
+  IdEncoding,
+  ConstantArrayEncoding,
+  IncompleteArrayEncoding,
+  FunctionPointerEncoding,
+  BlockEncoding,
+  AnonymousStructEncoding,
+  AnonymousUnionEncoding,
+  ExtVectorEncoding,
+  // Same meaning as InterfaceDeclarationReference with an empty protocol list,
+  // but names the class by index into MetaFile::classNames() instead of
+  // carrying a name pointer and a protocols pointer. Positionally mirrored in
+  // the generator's binary::BinaryTypeEncodingType — append only, never
+  // reorder.
+  InterfaceIndexReference
 };
 
 #pragma pack(push, 1)
@@ -324,6 +330,14 @@ struct ModuleTable {
     }
 };
 
+/// Class names referenced by InterfaceIndexReference encodings, so a reference
+/// costs a 2-byte index instead of a 4-byte name pointer.
+struct ClassNameTable {
+  Array<String> names;
+
+  int sizeInBytes() const { return names.sizeInBytes(); }
+};
+
 struct MetaFile {
 private:
     GlobalTable<GlobalTableType::ByJsName> _globalTableJs;
@@ -332,6 +346,11 @@ public:
     static MetaFile* instance();
 
     static MetaFile* setInstance(void* metadataPtr);
+
+    /// Resolved once by setInstance. Locating the table means walking every
+    /// preceding table, which is too much work to repeat per marshalled
+    /// argument.
+    static const ClassNameTable* classNames();
 
     const GlobalTable<GlobalTableType::ByJsName>* globalTableJs() const {
         return &this->_globalTableJs;
@@ -352,9 +371,15 @@ public:
         return reinterpret_cast<const ModuleTable*>(offset(gt, gt->sizeInBytes()));
     }
 
+    const ClassNameTable* classNamesTable() const {
+      const ModuleTable* mt = this->topLevelModulesTable();
+      return reinterpret_cast<const ClassNameTable*>(
+          offset(mt, mt->sizeInBytes()));
+    }
+
     const void* heap() const {
-        const ModuleTable* mt = this->topLevelModulesTable();
-        return offset(mt, mt->sizeInBytes());
+      const ClassNameTable* ct = this->classNamesTable();
+      return offset(ct, ct->sizeInBytes());
     }
 };
 
@@ -426,6 +451,9 @@ union TypeEncodingDetails {
         String name;
         PtrTo<Array<String>> _protocols;
     } interfaceDeclarationReference;
+    struct InterfaceIndexReferenceDetails {
+      uint16_t index;
+    } interfaceIndexReference;
     struct PointerDetails {
         const TypeEncoding* getInnerType() const {
             return reinterpret_cast<const TypeEncoding*>(this);
@@ -451,6 +479,39 @@ union TypeEncodingDetails {
 struct TypeEncoding {
     BinaryTypeEncodingType type;
     TypeEncodingDetails details;
+
+    /// An interface reference has two spellings; test with this rather than
+    /// comparing against InterfaceDeclarationReference, or the indexed form
+    /// silently falls through to whatever the default branch does.
+    bool isInterfaceReference() const {
+      return this->type ==
+                 BinaryTypeEncodingType::InterfaceDeclarationReference ||
+             this->type == BinaryTypeEncodingType::InterfaceIndexReference;
+    }
+
+    /// Referenced class name, for either spelling. nullptr if not an interface
+    /// reference.
+    const char* interfaceName() const {
+      switch (this->type) {
+        case BinaryTypeEncodingType::InterfaceDeclarationReference:
+          return this->details.interfaceDeclarationReference.name.valuePtr();
+        case BinaryTypeEncodingType::InterfaceIndexReference:
+          return MetaFile::classNames()
+              ->names[this->details.interfaceIndexReference.index]
+              .valuePtr();
+        default:
+          return nullptr;
+      }
+    }
+
+    /// Conformed protocols, for either spelling. The indexed form only encodes
+    /// references that had none, so it reports an empty list.
+    const Array<String>* interfaceProtocols() const {
+      return this->type == BinaryTypeEncodingType::InterfaceDeclarationReference
+                 ? this->details.interfaceDeclarationReference._protocols
+                       .valuePtr()
+                 : nullptr;
+    }
 
     const TypeEncoding* next() const {
         const TypeEncoding* afterTypePtr = reinterpret_cast<const TypeEncoding*>(offset(this, sizeof(type)));
@@ -487,6 +548,11 @@ struct TypeEncoding {
         }
         case BinaryTypeEncodingType::InterfaceDeclarationReference: {
             return reinterpret_cast<const TypeEncoding*>(offset(afterTypePtr, sizeof(TypeEncodingDetails::InterfaceDeclarationReferenceDetails)));
+        }
+        case BinaryTypeEncodingType::InterfaceIndexReference: {
+          return reinterpret_cast<const TypeEncoding*>(offset(
+              afterTypePtr,
+              sizeof(TypeEncodingDetails::InterfaceIndexReferenceDetails)));
         }
         case BinaryTypeEncodingType::StructDeclarationReference:
         case BinaryTypeEncodingType::UnionDeclarationReference: {

--- a/NativeScript/runtime/Metadata.h
+++ b/NativeScript/runtime/Metadata.h
@@ -74,6 +74,7 @@ enum MetaFlags {
   MethodOwnsReturnedCocoaObject = 4,
   MethodHasErrorOutParameter = 5,
   MethodHasConstructorTokens = 9,
+  JsCodeIsEnumTable = 10,
   PropertyHasGetter = 2,
   PropertyHasSetter = 3,
 
@@ -773,14 +774,29 @@ public:
     }
 };
 
+struct EnumField {
+  String name;
+  int64_t value;
+};
+
 struct JsCodeMeta : Meta {
 
 private:
     String _jsCode;
 
 public:
+ /// Enums carry a name/value table here instead of JS source; the two are
+ /// mutually exclusive, so check this before reading either.
+ inline bool isEnumTable() const {
+   return this->flag(MetaFlags::JsCodeIsEnumTable);
+ }
+
     inline const char* jsCode() const {
         return _jsCode.valuePtr();
+    }
+
+    inline const Array<EnumField>* enumFields() const {
+      return reinterpret_cast<const Array<EnumField>*>(_jsCode.valuePtr());
     }
 };
 

--- a/NativeScript/runtime/Metadata.h
+++ b/NativeScript/runtime/Metadata.h
@@ -59,20 +59,23 @@ inline uint8_t getMinorVersion(uint8_t encodedVersion) {
 
 // Bit indices in flags section
 enum MetaFlags {
-    HasDemangledName = 8,
-    HasName = 7,
-    // IsIosAppExtensionAvailable = 6, the flag exists in metadata generator but we never use it in the runtime
-    FunctionReturnsUnmanaged = 3,
-    FunctionIsVariadic = 5,
-    FunctionOwnsReturnedCocoaObject = 4,
-    MemberIsOptional = 0, // Mustn't equal any Method or Property flag since it can be applicable to both
-    MethodIsInitializer = 1,
-    MethodIsVariadic = 2,
-    MethodIsNullTerminatedVariadic = 3,
-    MethodOwnsReturnedCocoaObject = 4,
-    MethodHasErrorOutParameter = 5,
-    PropertyHasGetter = 2,
-    PropertyHasSetter = 3,
+  HasDemangledName = 8,
+  HasName = 7,
+  // IsIosAppExtensionAvailable = 6, the flag exists in metadata generator but
+  // we never use it in the runtime
+  FunctionReturnsUnmanaged = 3,
+  FunctionIsVariadic = 5,
+  FunctionOwnsReturnedCocoaObject = 4,
+  MemberIsOptional = 0,  // Mustn't equal any Method or Property flag since it
+                         // can be applicable to both
+  MethodIsInitializer = 1,
+  MethodIsVariadic = 2,
+  MethodIsNullTerminatedVariadic = 3,
+  MethodOwnsReturnedCocoaObject = 4,
+  MethodHasErrorOutParameter = 5,
+  MethodHasConstructorTokens = 9,
+  PropertyHasGetter = 2,
+  PropertyHasSetter = 3,
 
 };
 
@@ -788,8 +791,13 @@ public:
         return this->_encodings.valuePtr();
     }
 
+    // The trailing _constructorTokens slot is only written when the flag is
+    // set, so it must not be read otherwise — the bytes past _encodings belong
+    // to whatever the generator emitted next.
     inline const char* constructorTokens() const {
-        return this->_constructorTokens.valuePtr();
+      return this->flag(MetaFlags::MethodHasConstructorTokens)
+                 ? this->_constructorTokens.valuePtr()
+                 : "";
     }
 
     bool isImplementedInClass(Class klass, bool isStatic) const;

--- a/NativeScript/runtime/Metadata.mm
+++ b/NativeScript/runtime/Metadata.mm
@@ -324,8 +324,13 @@ static MetaFile* metaFileInstance(nullptr);
 
 MetaFile* MetaFile::instance() { return metaFileInstance; }
 
+static const ClassNameTable* classNamesInstance = nullptr;
+
+const ClassNameTable* MetaFile::classNames() { return classNamesInstance; }
+
 MetaFile* MetaFile::setInstance(void* metadataPtr) {
   metaFileInstance = reinterpret_cast<MetaFile*>(metadataPtr);
+  classNamesInstance = metaFileInstance->classNamesTable();
   return metaFileInstance;
 }
 }  // namespace tns

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -134,16 +134,33 @@ v8::Intercepted MetadataBuilder::GlobalPropertyGetter(Local<v8::Name> property,
     info.GetReturnValue().Set(result);
   } else if (meta->type() == MetaType::JsCode) {
     const JsCodeMeta* jsCodeMeta = static_cast<const JsCodeMeta*>(meta);
-    std::string jsCode = jsCodeMeta->jsCode();
-    Local<Script> script;
-    if (!Script::Compile(context, tns::ToV8String(isolate, jsCode)).ToLocal(&script)) {
-      tns::Assert(false, isolate);
-    }
-    tns::Assert(!script.IsEmpty(), isolate);
-
     Local<Value> result;
-    if (!script->Run(context).ToLocal(&result)) {
-      tns::Assert(false, isolate);
+    if (jsCodeMeta->isEnumTable()) {
+      // Mirrors __tsEnum: a bidirectional map, built in stored order so that
+      // when several names share a value the last one wins the reverse entry.
+      Local<Object> enumObject = Object::New(isolate);
+      const Array<EnumField>* fields = jsCodeMeta->enumFields();
+      for (int i = 0; i < fields->count; i++) {
+        const EnumField& field = (*fields)[i];
+        Local<Value> name = tns::ToV8String(isolate, field.name.valuePtr());
+        Local<Value> value = Number::New(isolate, static_cast<double>(field.value));
+        if (enumObject->Set(context, name, value).IsNothing() ||
+            enumObject->Set(context, value, name).IsNothing()) {
+          tns::Assert(false, isolate);
+        }
+      }
+      result = enumObject;
+    } else {
+      std::string jsCode = jsCodeMeta->jsCode();
+      Local<Script> script;
+      if (!Script::Compile(context, tns::ToV8String(isolate, jsCode)).ToLocal(&script)) {
+        tns::Assert(false, isolate);
+      }
+      tns::Assert(!script.IsEmpty(), isolate);
+
+      if (!script->Run(context).ToLocal(&result)) {
+        tns::Assert(false, isolate);
+      }
     }
     // Memoize the evaluated value as a real own property: the interceptor is
     // registered kNonMasking, so later reads of this global bypass it (and the

--- a/metadata-generator/src/Binary/binarySerializer.cpp
+++ b/metadata-generator/src/Binary/binarySerializer.cpp
@@ -413,21 +413,28 @@ void binary::BinarySerializer::visit(::Meta::EnumMeta* meta)
     binary::JsCodeMeta binaryStruct;
     serializeBase(meta, binaryStruct);
 
-    // generate JsCode from enum names and values
-    std::ostringstream jsCodeStream;
-    jsCodeStream << "__tsEnum({";
-    bool isFirstField = true;
-    for (::Meta::EnumField& field : meta->swiftNameFields) {
-        jsCodeStream << (isFirstField ? "" : ",") << "\"" << field.name << "\":" << field.value;
-        isFirstField = false;
-    }
-    for (::Meta::EnumField& field : meta->fullNameFields) {
-        jsCodeStream << (isFirstField ? "" : ",") << "\"" << field.name << "\":" << field.value;
-        isFirstField = false;
-    }
-    jsCodeStream << "})";
+    // Names are interned, so the great majority cost nothing here: the same
+    // strings already back this enum's constants as standalone globals.
+    std::vector<std::pair<MetaFileOffset, int64_t>> entries;
+    auto addFields = [&](std::vector<::Meta::EnumField>& fields) {
+      for (::Meta::EnumField& field : fields) {
+        // Values that would not fit signed are already emitted signed by
+        // MetaFactory, so this round-trips the full range.
+        entries.emplace_back(
+            this->heapWriter.push_string(field.name),
+            (int64_t)std::strtoll(field.value.c_str(), nullptr, 10));
+      }
+    };
+    addFields(meta->swiftNameFields);
+    addFields(meta->fullNameFields);
 
-    binaryStruct._jsCode = this->heapWriter.push_string(jsCodeStream.str());
+    binaryStruct._flags |= BinaryFlags::JsCodeIsEnumTable;
+    binaryStruct._jsCode =
+        this->heapWriter.push_arrayCount((MetaArrayCount)entries.size());
+    for (std::pair<MetaFileOffset, int64_t>& entry : entries) {
+      this->heapWriter.push_pointer(entry.first);
+      this->heapWriter.push_long(entry.second);
+    }
     this->file->registerInGlobalTables(*meta, binaryStruct.save(this->heapWriter));
 }
 

--- a/metadata-generator/src/Binary/binarySerializer.cpp
+++ b/metadata-generator/src/Binary/binarySerializer.cpp
@@ -140,7 +140,10 @@ void binary::BinarySerializer::serializeBaseClass(::Meta::BaseClassMeta* meta, b
 void binary::BinarySerializer::serializeMember(::Meta::Meta* meta, binary::MemberMeta& binaryMetaStruct)
 {
     this->serializeBase(meta, binaryMetaStruct);
-    binaryMetaStruct._flags &= 0b11111000; // this clears the type information written in the lower 3 bits
+    // Clear only the type information in the lower 3 bits. The old mask also
+    // dropped bits 8 and up, which would silently discard any member flag
+    // stored there.
+    binaryMetaStruct._flags &= ~0b111;
 
     if (meta->getFlags(::Meta::MetaFlags::MemberIsOptional))
         binaryMetaStruct._flags |= BinaryFlags::MemberIsOptional;
@@ -163,7 +166,11 @@ void binary::BinarySerializer::serializeMethod(::Meta::MethodMeta* meta, binary:
         binaryMetaStruct._flags |= BinaryFlags::MethodIsInitializer;
 
     binaryMetaStruct._encoding = this->typeEncodingSerializer.visit(meta->signature);
-    binaryMetaStruct._constructorTokens = this->heapWriter.push_string(meta->constructorTokens);
+    if (!meta->constructorTokens.empty()) {
+      binaryMetaStruct._flags |= BinaryFlags::MethodHasConstructorTokens;
+      binaryMetaStruct._constructorTokens =
+          this->heapWriter.push_string(meta->constructorTokens);
+    }
 }
 
 void binary::BinarySerializer::serializeProperty(::Meta::PropertyMeta* meta, binary::PropertyMeta& binaryMetaStruct)

--- a/metadata-generator/src/Binary/binarySerializer.h
+++ b/metadata-generator/src/Binary/binarySerializer.h
@@ -33,12 +33,11 @@ private:
     void serializeLibrary(clang::Module::LinkLibrary* library, binary::LibraryMeta& binaryLib);
 
 public:
-    BinarySerializer(MetaFile* file)
-        : heapWriter(file->heap_writer())
-        , typeEncodingSerializer(heapWriter)
-    {
-        this->file = file;
-    }
+ BinarySerializer(MetaFile* file)
+     : heapWriter(file->heap_writer()),
+       typeEncodingSerializer(heapWriter, file) {
+   this->file = file;
+ }
 
     void serializeContainer(std::vector<std::pair<clang::Module*, std::vector< ::Meta::Meta*> > >& container);
 

--- a/metadata-generator/src/Binary/binaryStructures.cpp
+++ b/metadata-generator/src/Binary/binaryStructures.cpp
@@ -43,7 +43,12 @@ binary::MetaFileOffset binary::MethodMeta::save(BinaryWriter& writer)
 {
     binary::MetaFileOffset offset = MemberMeta::save(writer);
     writer.push_pointer(this->_encoding);
-    writer.push_pointer(this->_constructorTokens);
+    // Trailing field, and MethodMeta has no subclass, so it can simply be left
+    // out when unset. The reader keys off MethodHasConstructorTokens and never
+    // touches the slot otherwise.
+    if (this->_flags & BinaryFlags::MethodHasConstructorTokens) {
+      writer.push_pointer(this->_constructorTokens);
+    }
     return offset;
 }
 

--- a/metadata-generator/src/Binary/binaryStructures.cpp
+++ b/metadata-generator/src/Binary/binaryStructures.cpp
@@ -140,6 +140,15 @@ binary::MetaFileOffset binary::DeclarationReferenceEncoding::save(binary::Binary
     return offset;
 }
 
+binary::MetaFileOffset binary::InterfaceIndexReferenceEncoding::save(
+    binary::BinaryWriter& writer) {
+  binary::MetaFileOffset offset = TypeEncoding::save(writer);
+  // push_short only fixes the width; push_number masks each byte, so the full
+  // uint16 range round-trips regardless of the signed parameter type.
+  writer.push_short((int16_t)this->_index);
+  return offset;
+}
+
 binary::MetaFileOffset binary::InterfaceDeclarationReferenceEncoding::save(binary::BinaryWriter& writer)
 {
     binary::MetaFileOffset offset = DeclarationReferenceEncoding::save(writer);

--- a/metadata-generator/src/Binary/binaryStructures.h
+++ b/metadata-generator/src/Binary/binaryStructures.h
@@ -12,40 +12,43 @@ class MetaFile;
 class BinaryWriter;
 
 enum BinaryTypeEncodingType : uint8_t {
-    Void,
-    Bool,
-    Short,
-    UShort,
-    Int,
-    UInt,
-    Long,
-    ULong,
-    LongLong,
-    ULongLong,
-    Char,
-    UChar,
-    Unichar,
-    CharS,
-    CString,
-    Float,
-    Double,
-    InterfaceDeclarationReference,
-    StructDeclarationReference,
-    UnionDeclarationReference,
-    Pointer,
-    VaList,
-    Selector,
-    Class,
-    ProtocolType,
-    InstanceType,
-    Id,
-    ConstantArray,
-    IncompleteArray,
-    FunctionPointer,
-    Block,
-    AnonymousStruct,
-    AnonymousUnion,
-    Vector
+  Void,
+  Bool,
+  Short,
+  UShort,
+  Int,
+  UInt,
+  Long,
+  ULong,
+  LongLong,
+  ULongLong,
+  Char,
+  UChar,
+  Unichar,
+  CharS,
+  CString,
+  Float,
+  Double,
+  InterfaceDeclarationReference,
+  StructDeclarationReference,
+  UnionDeclarationReference,
+  Pointer,
+  VaList,
+  Selector,
+  Class,
+  ProtocolType,
+  InstanceType,
+  Id,
+  ConstantArray,
+  IncompleteArray,
+  FunctionPointer,
+  Block,
+  AnonymousStruct,
+  AnonymousUnion,
+  Vector,
+  // Mirrors tns::BinaryTypeEncodingType in the runtime's Metadata.h by
+  // position — append only, never reorder.
+  InterfaceIndexReference
 };
 
 // BinaryMetaType values must not exceed
@@ -318,6 +321,16 @@ public:
     MetaFileOffset _name;
     
     virtual MetaFileOffset save(BinaryWriter& writer) override;
+};
+
+struct InterfaceIndexReferenceEncoding : public TypeEncoding {
+ public:
+  InterfaceIndexReferenceEncoding()
+      : TypeEncoding(BinaryTypeEncodingType::InterfaceIndexReference) {}
+
+  uint16_t _index = 0;
+
+  virtual MetaFileOffset save(BinaryWriter& writer) override;
 };
 
 struct InterfaceDeclarationReferenceEncoding : public DeclarationReferenceEncoding {

--- a/metadata-generator/src/Binary/binaryStructures.h
+++ b/metadata-generator/src/Binary/binaryStructures.h
@@ -61,25 +61,26 @@ enum BinaryMetaType : uint8_t {
 };
 
 enum BinaryFlags : uint16_t {
-    // Common
-    HasDemangledName = 1 << 8,
-    HasName = 1 << 7,
-    IsIosAppExtensionAvailable = 1 << 6,
-    // Function
-    FunctionIsVariadic = 1 << 5,
-    FunctionOwnsReturnedCocoaObject = 1 << 4,
-    FunctionReturnsUnmanaged = 1 << 3,
-    // Member
-    MemberIsOptional = 1 << 0,
-    // Method
-    MethodIsInitializer = 1 << 1,
-    MethodIsVariadic = 1 << 2,
-    MethodIsNullTerminatedVariadic = 1 << 3,
-    MethodOwnsReturnedCocoaObject = 1 << 4,
-    MethodHasErrorOutParameter = 1 << 5,
-    // Property
-    PropertyHasGetter = 1 << 2,
-    PropertyHasSetter = 1 << 3
+  // Common
+  HasDemangledName = 1 << 8,
+  HasName = 1 << 7,
+  IsIosAppExtensionAvailable = 1 << 6,
+  // Function
+  FunctionIsVariadic = 1 << 5,
+  FunctionOwnsReturnedCocoaObject = 1 << 4,
+  FunctionReturnsUnmanaged = 1 << 3,
+  // Member
+  MemberIsOptional = 1 << 0,
+  // Method
+  MethodIsInitializer = 1 << 1,
+  MethodIsVariadic = 1 << 2,
+  MethodIsNullTerminatedVariadic = 1 << 3,
+  MethodOwnsReturnedCocoaObject = 1 << 4,
+  MethodHasErrorOutParameter = 1 << 5,
+  MethodHasConstructorTokens = 1 << 9,
+  // Property
+  PropertyHasGetter = 1 << 2,
+  PropertyHasSetter = 1 << 3
 };
 
 #pragma pack(push, 1)

--- a/metadata-generator/src/Binary/binaryStructures.h
+++ b/metadata-generator/src/Binary/binaryStructures.h
@@ -81,6 +81,9 @@ enum BinaryFlags : uint16_t {
   MethodOwnsReturnedCocoaObject = 1 << 4,
   MethodHasErrorOutParameter = 1 << 5,
   MethodHasConstructorTokens = 1 << 9,
+  // JsCode
+  // Marks _jsCode as a binary name/value table rather than a JS source string.
+  JsCodeIsEnumTable = 1 << 10,
   // Property
   PropertyHasGetter = 1 << 2,
   PropertyHasSetter = 1 << 3

--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
@@ -3,6 +3,23 @@
 #include <llvm/ADT/STLExtras.h>
 
 #include "../Meta/MetaEntities.h"
+#include "metaFile.h"
+
+// An interface reference with no protocols is by far the common case, so it is
+// encoded as a 2-byte index into the class name table instead of a name pointer
+// plus a protocols pointer. Falls back to the pointer form if the table is
+// full.
+static unique_ptr<binary::TypeEncoding> makeIndexedInterface(
+    binary::MetaFile* file, binary::BinaryWriter& writer,
+    const std::string& name) {
+  uint16_t index = 0;
+  if (file == nullptr || !file->internClassName(name, writer, index)) {
+    return nullptr;
+  }
+  auto* s = new binary::InterfaceIndexReferenceEncoding();
+  s->_index = index;
+  return unique_ptr<binary::TypeEncoding>(s);
+}
 
 binary::MetaFileOffset binary::BinaryTypeEncodingSerializer::visit(
     std::vector< ::Meta::Type*>& types) {
@@ -179,6 +196,13 @@ binary::BinaryTypeEncodingSerializer::visitIncompleteArray(
 unique_ptr<binary::TypeEncoding>
 binary::BinaryTypeEncodingSerializer::visitInterface(
     const ::Meta::InterfaceType& type) {
+  if (type.protocols.empty()) {
+    if (auto indexed = makeIndexedInterface(this->_file, this->_heapWriter,
+                                            type.interface->name)) {
+      return indexed;
+    }
+  }
+
   auto* s = new binary::InterfaceDeclarationReferenceEncoding();
   s->_name = this->_heapWriter.push_string(type.interface->name);
 
@@ -202,6 +226,11 @@ binary::BinaryTypeEncodingSerializer::visitBridgedInterface(
                                   "BridgedInterfaceType with name '") +
                       type.name + "'.");
   }
+  if (auto indexed = makeIndexedInterface(this->_file, this->_heapWriter,
+                                          type.bridgedInterface->name)) {
+    return indexed;
+  }
+
   auto s = new binary::InterfaceDeclarationReferenceEncoding();
   s->_name = this->_heapWriter.push_string(type.bridgedInterface->name);
 

--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.cpp
@@ -29,10 +29,28 @@ binary::MetaFileOffset binary::BinaryTypeEncodingSerializer::visit(
     binaryEncodings.push_back(std::move(binaryEncoding));
   }
 
-  binary::MetaFileOffset offset =
-      this->_heapWriter.push_arrayCount(types.size());
+  // Serialize to scratch first so identical lists can share one copy. Nothing
+  // in the bytes depends on where the list lands, so they are interchangeable.
+  auto scratch = std::make_shared<utils::MemoryStream>();
+  binary::BinaryWriter scratchWriter(scratch);
+  scratchWriter.push_arrayCount(types.size());
   for (unique_ptr<binary::TypeEncoding>& binaryEncoding : binaryEncodings) {
-    binaryEncoding->save(this->_heapWriter);
+    binaryEncoding->save(scratchWriter);
+  }
+  std::string bytes(scratch->begin(), scratch->end());
+
+  binary::MetaFileOffset offset = 0;
+  if (this->_file != nullptr &&
+      this->_file->tryGetEncodingList(bytes, offset)) {
+    return offset;
+  }
+
+  offset = this->_heapWriter.currentPosition();
+  for (char byte : bytes) {
+    this->_heapWriter.push_byte((uint8_t)byte);
+  }
+  if (this->_file != nullptr) {
+    this->_file->recordEncodingList(bytes, offset);
   }
   return offset;
 }

--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
@@ -17,7 +17,10 @@ namespace binary {
 class BinaryTypeEncodingSerializer
     : public ::Meta::TypeVisitor<unique_ptr<binary::TypeEncoding> > {
  private:
-  BinaryWriter _heapWriter;
+  // Must alias the serializer's writer, not copy it: BinaryWriter owns the
+  // string-interning map, and a copy interns into a second map, emitting a
+  // duplicate copy of every string reachable from both paths.
+  BinaryWriter& _heapWriter;
 
   unique_ptr<TypeEncoding> serializeRecordEncoding(
       const binary::BinaryTypeEncodingType encodingType,

--- a/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
+++ b/metadata-generator/src/Binary/binaryTypeEncodingSerializer.h
@@ -21,14 +21,15 @@ class BinaryTypeEncodingSerializer
   // string-interning map, and a copy interns into a second map, emitting a
   // duplicate copy of every string reachable from both paths.
   BinaryWriter& _heapWriter;
+  MetaFile* _file;
 
   unique_ptr<TypeEncoding> serializeRecordEncoding(
       const binary::BinaryTypeEncodingType encodingType,
       const std::vector< ::Meta::RecordField>& fields);
 
  public:
-  BinaryTypeEncodingSerializer(BinaryWriter& heapWriter)
-      : _heapWriter(heapWriter) {}
+  BinaryTypeEncodingSerializer(BinaryWriter& heapWriter, MetaFile* file)
+      : _heapWriter(heapWriter), _file(file) {}
 
   MetaFileOffset visit(std::vector< ::Meta::Type*>& types);
 

--- a/metadata-generator/src/Binary/binaryWriter.cpp
+++ b/metadata-generator/src/Binary/binaryWriter.cpp
@@ -4,10 +4,12 @@ binary::MetaFileOffset binary::BinaryWriter::push_number(long number, int bytesC
 {
     binary::MetaFileOffset offset = this->_stream->position();
 
+    // Shift the value, not a 32-bit mask: `255 << pad` overflows int once pad
+    // reaches 24, so anything past the fourth byte came out as zero.
+    uint64_t bits = (uint64_t)number;
     for (int i = 0; i < bytesCount; i++) {
-        int pad = 8 * i;
-        uint8_t current = (uint8_t)((number & (255 << pad)) >> pad);
-        this->_stream->push_byte(current);
+      uint8_t current = (uint8_t)((bits >> (8 * i)) & 0xFF);
+      this->_stream->push_byte(current);
     }
 
     return offset;
@@ -68,6 +70,10 @@ binary::MetaFileOffset binary::BinaryWriter::push_binaryArray(
 binary::MetaFileOffset binary::BinaryWriter::push_int(int32_t value)
 {
     return this->push_number(value, 4);
+}
+
+binary::MetaFileOffset binary::BinaryWriter::push_long(int64_t value) {
+  return this->push_number(value, 8);
 }
 
 binary::MetaFileOffset binary::BinaryWriter::push_short(int16_t value)

--- a/metadata-generator/src/Binary/binaryWriter.cpp
+++ b/metadata-generator/src/Binary/binaryWriter.cpp
@@ -45,11 +45,23 @@ binary::MetaFileOffset binary::BinaryWriter::push_arrayCount(MetaArrayCount coun
 
 binary::MetaFileOffset binary::BinaryWriter::push_binaryArray(std::vector<binary::MetaFileOffset>& binaryArray)
 {
+  // Empty arrays carry no payload, so every one of them can share a single
+  // count-of-zero in the heap. Offset 0 is the null sentinel and the heap
+  // reserves a marker byte there, so a real array never lands on it.
+  if (binaryArray.empty() && this->emptyArrayOffset != 0) {
+    return this->emptyArrayOffset;
+  }
+
     binary::MetaFileOffset offset = this->_stream->position();
     this->push_arrayCount((binary::MetaArrayCount)binaryArray.size());
     for (binary::MetaFileOffset element : binaryArray) {
         this->push_pointer(element);
     }
+
+    if (binaryArray.empty()) {
+      this->emptyArrayOffset = offset;
+    }
+
     return offset;
 }
 

--- a/metadata-generator/src/Binary/binaryWriter.cpp
+++ b/metadata-generator/src/Binary/binaryWriter.cpp
@@ -43,12 +43,12 @@ binary::MetaFileOffset binary::BinaryWriter::push_arrayCount(MetaArrayCount coun
     return this->push_number(count, sizeof(MetaArrayCount));
 }
 
-binary::MetaFileOffset binary::BinaryWriter::push_binaryArray(std::vector<binary::MetaFileOffset>& binaryArray)
-{
+binary::MetaFileOffset binary::BinaryWriter::push_binaryArray(
+    std::vector<binary::MetaFileOffset>& binaryArray, bool shouldIntern) {
   // Empty arrays carry no payload, so every one of them can share a single
   // count-of-zero in the heap. Offset 0 is the null sentinel and the heap
   // reserves a marker byte there, so a real array never lands on it.
-  if (binaryArray.empty() && this->emptyArrayOffset != 0) {
+  if (shouldIntern && binaryArray.empty() && this->emptyArrayOffset != 0) {
     return this->emptyArrayOffset;
   }
 
@@ -58,7 +58,7 @@ binary::MetaFileOffset binary::BinaryWriter::push_binaryArray(std::vector<binary
         this->push_pointer(element);
     }
 
-    if (binaryArray.empty()) {
+    if (shouldIntern && binaryArray.empty()) {
       this->emptyArrayOffset = offset;
     }
 

--- a/metadata-generator/src/Binary/binaryWriter.h
+++ b/metadata-generator/src/Binary/binaryWriter.h
@@ -14,6 +14,7 @@ namespace binary {
 class BinaryWriter : public BinaryOperation {
 private:
     std::map<std::string, MetaFileOffset> uniqueStrings;
+    MetaFileOffset emptyArrayOffset = 0;
 
     MetaFileOffset push_number(long number, int bytesCount);
 

--- a/metadata-generator/src/Binary/binaryWriter.h
+++ b/metadata-generator/src/Binary/binaryWriter.h
@@ -55,11 +55,15 @@ public:
     MetaFileOffset push_arrayCount(MetaArrayCount count);
 
     /*
-         * \brief Writes a binary array
-         * A binary array is a collection of offsets
-         * \param binaryArray
-         */
-    MetaFileOffset push_binaryArray(std::vector<MetaFileOffset>& binaryArray);
+     * \brief Writes a binary array
+     * A binary array is a collection of offsets
+     * \param binaryArray
+     * \param shouldIntern Whether an empty array may reuse a previously
+     *        written one. Only safe where the array is reached by offset;
+     *        pass \c false when writing a table that is located positionally.
+     */
+    MetaFileOffset push_binaryArray(std::vector<MetaFileOffset>& binaryArray,
+                                    bool shouldIntern = true);
 
     /*
          * \brief Writes a 4 byte integer.

--- a/metadata-generator/src/Binary/binaryWriter.h
+++ b/metadata-generator/src/Binary/binaryWriter.h
@@ -72,6 +72,12 @@ public:
     MetaFileOffset push_int(int32_t value);
 
     /*
+     * \brief Writes an 8 byte integer.
+     * \param value
+     */
+    MetaFileOffset push_long(int64_t value);
+
+    /*
          * \brief Writes a 2 byte short.
          * \param value
          */

--- a/metadata-generator/src/Binary/metaFile.cpp
+++ b/metadata-generator/src/Binary/metaFile.cpp
@@ -35,6 +35,26 @@ binary::MetaFileOffset binary::MetaFile::getFromTopLevelModulesTable(const std::
     return (it != this->_topLevelModules.end()) ? it->second : 0;
 }
 
+bool binary::MetaFile::internClassName(const std::string& name,
+                                       binary::BinaryWriter& heapWriter,
+                                       uint16_t& index) {
+  auto it = this->_classNameIndices.find(name);
+  if (it != this->_classNameIndices.end()) {
+    index = it->second;
+    return true;
+  }
+
+  // The index is serialized as uint16, so the table cannot grow past 2^16.
+  if (this->_classNames.size() > UINT16_MAX) {
+    return false;
+  }
+
+  index = (uint16_t)this->_classNames.size();
+  this->_classNames.push_back(heapWriter.push_string(name));
+  this->_classNameIndices.emplace(name, index);
+  return true;
+}
+
 binary::BinaryWriter binary::MetaFile::heap_writer()
 {
     return binary::BinaryWriter(this->_heap);
@@ -58,18 +78,26 @@ void binary::MetaFile::save(std::shared_ptr<utils::Stream> stream)
     BinaryWriter globalTableStreamWriter = BinaryWriter(stream);
     BinaryWriter heapWriter = this->heap_writer();
     std::vector<binary::MetaFileOffset> jsOffsets = this->_globalTableSymbolsJs->serialize(heapWriter);
-    globalTableStreamWriter.push_binaryArray(jsOffsets);
+    globalTableStreamWriter.push_binaryArray(jsOffsets, /*shouldIntern*/ false);
 
     std::vector<binary::MetaFileOffset> nativeProtocolOffsets = this->_globalTableSymbolsNativeProtocols->serialize(heapWriter);
-    globalTableStreamWriter.push_binaryArray(nativeProtocolOffsets);
+    globalTableStreamWriter.push_binaryArray(nativeProtocolOffsets,
+                                             /*shouldIntern*/ false);
 
     std::vector<binary::MetaFileOffset> nativeInterfaceOffsets = this->_globalTableSymbolsNativeInterfaces->serialize(heapWriter);
-    globalTableStreamWriter.push_binaryArray(nativeInterfaceOffsets);
+    globalTableStreamWriter.push_binaryArray(nativeInterfaceOffsets,
+                                             /*shouldIntern*/ false);
 
     std::vector<MetaFileOffset> modulesOffsets;
     for (std::pair<std::string, MetaFileOffset> pair : this->_topLevelModules)
         modulesOffsets.push_back(pair.second);
-    globalTableStreamWriter.push_binaryArray(modulesOffsets);
+    globalTableStreamWriter.push_binaryArray(modulesOffsets,
+                                             /*shouldIntern*/ false);
+
+    // Must stay the last table before the heap: the runtime locates the heap by
+    // walking these tables in order (MetaFile::heap in Metadata.h).
+    globalTableStreamWriter.push_binaryArray(this->_classNames,
+                                             /*shouldIntern*/ false);
 
     // dump heap
     for (auto byteIter = this->_heap->begin(); byteIter != this->_heap->end(); ++byteIter) {

--- a/metadata-generator/src/Binary/metaFile.cpp
+++ b/metadata-generator/src/Binary/metaFile.cpp
@@ -55,6 +55,21 @@ bool binary::MetaFile::internClassName(const std::string& name,
   return true;
 }
 
+bool binary::MetaFile::tryGetEncodingList(const std::string& bytes,
+                                          binary::MetaFileOffset& offset) {
+  auto it = this->_encodingLists.find(bytes);
+  if (it == this->_encodingLists.end()) {
+    return false;
+  }
+  offset = it->second;
+  return true;
+}
+
+void binary::MetaFile::recordEncodingList(const std::string& bytes,
+                                          binary::MetaFileOffset offset) {
+  this->_encodingLists.emplace(bytes, offset);
+}
+
 binary::BinaryWriter binary::MetaFile::heap_writer()
 {
     return binary::BinaryWriter(this->_heap);

--- a/metadata-generator/src/Binary/metaFile.h
+++ b/metadata-generator/src/Binary/metaFile.h
@@ -33,6 +33,10 @@ private:
     // order, alongside the reverse map used to assign those indices.
     std::vector<MetaFileOffset> _classNames;
     std::map<std::string, uint16_t> _classNameIndices;
+    // Serialized encoding lists keyed by their exact bytes. The bytes hold
+    // absolute heap offsets but none that depend on where the list itself
+    // lands, so identical lists are interchangeable.
+    std::map<std::string, MetaFileOffset> _encodingLists;
     std::shared_ptr<utils::MemoryStream> _heap;
 
 public:
@@ -101,6 +105,19 @@ public:
      */
     bool internClassName(const std::string& name, BinaryWriter& heapWriter,
                          uint16_t& index);
+
+    /// type encodings
+    /*
+     * \brief Looks up an already-written encoding list with identical bytes.
+     * \return true and sets \c offset when one exists
+     */
+    bool tryGetEncodingList(const std::string& bytes, MetaFileOffset& offset);
+
+    /*
+     * \brief Records the offset an encoding list was written at, so identical
+     *        lists can share it.
+     */
+    void recordEncodingList(const std::string& bytes, MetaFileOffset offset);
 
     /// heap
     /*

--- a/metadata-generator/src/Binary/metaFile.h
+++ b/metadata-generator/src/Binary/metaFile.h
@@ -29,6 +29,10 @@ private:
     std::unique_ptr<BinaryHashtable> _globalTableSymbolsNativeInterfaces;
 
     std::map<std::string, MetaFileOffset> _topLevelModules;
+    // Class names referenced by InterfaceIndexReference encodings, in index
+    // order, alongside the reverse map used to assign those indices.
+    std::vector<MetaFileOffset> _classNames;
+    std::map<std::string, uint16_t> _classNameIndices;
     std::shared_ptr<utils::MemoryStream> _heap;
 
 public:
@@ -84,6 +88,19 @@ public:
          * \return The offset in the heap
          */
     binary::MetaFileOffset getFromTopLevelModulesTable(const std::string& moduleName);
+
+    /// class name table
+    /*
+     * \brief Interns a class name and returns its index in the class name
+     * table.
+     * \param name The native class name
+     * \param heapWriter Writer used to intern the name string in the heap
+     * \param index Receives the assigned index
+     * \return false if the table is full, in which case the caller must fall
+     *         back to an encoding that carries a name pointer
+     */
+    bool internClassName(const std::string& name, BinaryWriter& heapWriter,
+                         uint16_t& index);
 
     /// heap
     /*


### PR DESCRIPTION
### Description

Draft, **stacked on #434** — review only the last commit. #434 holds the small self-contained wins; this branch is for structural format changes, the ones that reshape a record rather than eliding a field.

| | bytes | vs baseline |
|---|---:|---:|
| baseline (`main`) | 12,033,254 | — |
| after #434 | 11,251,503 | −6.50% |
| **after this PR** | **10,734,555** | **−10.79%** |

This commit accounts for **−516,948 B**.

### Current behavior

An interface reference inside a type encoding costs 9 bytes: a 1-byte tag, a 4-byte name pointer, and a 4-byte pointer to its protocol list.

Across the SDK there are **92,844** such references, of which **88,172 carry no protocols at all** — and they name only **2,960 distinct classes**. So the overwhelmingly common case pays 8 bytes of pointers to say "NSString, no protocols", over and over.

### New behavior

A new `InterfaceIndexReference` tag encodes the class as a `uint16` index into a new class-name table: **3 bytes instead of 9**. References that genuinely carry protocols keep the existing form, so nothing is lost.

The table is written between the module table and the heap. It costs 11,844 bytes (2,960 entries + count), which is already netted out of the figure above.

There is a fallback: `internClassName` returns false once the table would exceed `UINT16_MAX`, and the generator emits the old pointer form instead. So a hypothetically enormous SDK degrades in size rather than corrupting.

### Reader changes

`TypeEncoding` gains three helpers, and **all 16 call sites** across `Interop.mm`, `ArgConverter.mm`, `ClassBuilder.mm` and `FFICall.cpp` now go through them:

- `isInterfaceReference()` — true for both spellings. This is the important one: a site that keeps comparing against `InterfaceDeclarationReference` alone would silently drop the indexed form into whatever its default branch does, mis-marshalling an argument with no crash to point at it.
- `interfaceName()` — resolves the name for either spelling.
- `interfaceProtocols()` — returns `nullptr` for the indexed form, which by construction has none.

`MetaFile::classNames()` is resolved once in `setInstance` rather than per lookup, because locating the table means walking every preceding table and two of the converted sites are on hot marshalling paths.

### Also here: hardening the empty-array interning from #434

#434 made `push_binaryArray` reuse a single empty array. That is safe in the heap, where arrays are reached by offset, but **wrong for the header tables**, which the runtime locates positionally by walking `sizeInBytes()`. Interning one there would shift every table after it, including the heap pointer.

It could not actually trigger in #434 — bucket arrays are never empty (the hashtable floors at 100 buckets) and only one other header array existed. Adding a fifth table makes two-empties reachable, so `push_binaryArray` now takes an explicit `shouldIntern`, and all five header writes pass `false`.

### Verification

Both files rendered to a canonical, offset-independent form and diffed:

```
188,518 lines rendered, 0 lines differ
```

The renderer auto-detects the extra root table (the heap always opens with a 0 marker byte, so a nonzero word in that position is the class-name count) and renders an indexed reference identically to a protocol-less pointer reference — so if the two ever disagreed on the resolved class name, it would show up as a diff rather than being masked.

I also checked the emitted table directly: 2,960 entries, all offsets distinct, first names resolving to `NSString`, `NSUUID`, `ARAnchor`, …, and the heap marker byte still at offset 0.

### Build status

The `NativeScript` target **compiles cleanly** with these changes — every source file, including all 16 converted call sites. The link step fails in my worktree on `-lzip`, a prebuilt artifact the worktree does not have; that is environmental and unrelated. The device suite has not been run.

### Still to come on this branch

| change | saves | notes |
|---|---:|---|
| enum `__tsEnum(...)` → binary name/value table | ~0.66 MB | 92% of that section is duplicated member names and JSON punctuation; `swiftNameFields[i]` is a literal suffix of `fullNameFields[i]` (`MetaFactory.cpp:412-418`) and both are written. Must preserve insertion order — `__tsEnum` builds a bidirectional map whose reverse entries are last-write-wins |
| method encoding-list count is derivable | ~0.24 MB | `count == 1 + colons(selector)`, 0 mismatches across all 60,589 methods |
| `_introduced` → flag bits | ~0.15 MB | only 92 distinct values; needs 7 bits, and bit 9 is now taken, so this needs bits 10–15 plus reclaiming bit 6 (`IsIosAppExtensionAvailable`, which the runtime never reads) |
| dedupe identical type-encoding blobs | ~0.19 MB | **blocked**: `ParametrizedCall::Get` (`FFICall.cpp:279-306`) keys its `ffi_cif` cache on the `TypeEncoding` pointer alone while callers pass different `initialParameterIndex`/`argsCount`. Latent only because no two declarations share a blob today; deduping aliases them and silently builds the wrong cif. Re-key the cache first |

Deriving method `jsName` (~1.42 MB, the single biggest lever) stays deferred pending a decision on `Meta::jsName()`'s signature — see #434 for the detail. Performance is not the blocker there; the API shape is.

### Does your pull request have unit tests?

Not yet — draft. This changes reader behavior, so the device suite must run before it leaves draft.
