### PR TITLE
fix: delete self-owned URL wrappers at isolate teardown

### DIFF
--- a/NativeScript/runtime/Caches.h
+++ b/NativeScript/runtime/Caches.h
@@ -14,6 +14,7 @@ namespace tns {
 struct StructInfo;
 struct ObjectWeakCallbackState;
 class PromiseRejectionTracker;
+class IsolateTracked;
 
 struct pair_hash {
   template <class T1, class T2>
@@ -128,6 +129,11 @@ class Caches {
   robin_hood::unordered_map<const void*,
                             std::shared_ptr<v8::Persistent<v8::Object>>>
       PointerInstances;
+
+  // Live IsolateTracked instances (URL, URLSearchParams, URLPattern). Their
+  // weak-callback finalizers never fire at isolate disposal, so teardown
+  // sweeps this set to delete whatever GC didn't get to.
+  robin_hood::unordered_set<IsolateTracked*> TrackedInstances;
 
   std::function<v8::Local<v8::FunctionTemplate>(
       v8::Local<v8::Context>, const BaseClassMeta*, KnownUnknownClassPair,

--- a/NativeScript/runtime/IsolateTracked.h
+++ b/NativeScript/runtime/IsolateTracked.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "Caches.h"
+#include "Common.h"
+
+namespace tns {
+
+// Base for self-owned C++ objects whose lifetime is bound to a single JS
+// object through a weak handle. Instances die in exactly two places: the GC
+// finalizer, or SweepAll at isolate teardown — weak callbacks never fire at
+// isolate disposal, so anything still registered there must be deleted
+// explicitly or it leaks. Never delete a bound instance directly; both
+// deletion paths own the registry bookkeeping.
+class IsolateTracked {
+ public:
+  virtual ~IsolateTracked() = default;
+
+  void BindFinalizer(v8::Isolate* isolate,
+                     const v8::Local<v8::Object>& object) {
+    v8::HandleScope scopedHandle(isolate);
+    weakHandle_.Reset(isolate, object);
+    weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
+    if (cache != nullptr) {
+      cache->TrackedInstances.insert(this);
+    }
+  }
+
+  // Runs in ~Runtime under the Locker, while the isolate is still alive —
+  // destructors may Reset v8::Global handles but must not create new ones.
+  static void SweepAll(v8::Isolate* isolate) {
+    std::shared_ptr<Caches> cache = Caches::Get(isolate);
+    if (cache == nullptr) {
+      return;
+    }
+    // Detach the set first so destructors can't mutate it mid-walk.
+    auto survivors = std::move(cache->TrackedInstances);
+    cache->TrackedInstances.clear();
+    for (IsolateTracked* instance : survivors) {
+      delete instance;
+    }
+  }
+
+ private:
+  static void Finalizer(const v8::WeakCallbackInfo<IsolateTracked>& data) {
+    IsolateTracked* self = data.GetParameter();
+    std::shared_ptr<Caches> cache = Caches::Get(data.GetIsolate());
+    if (cache != nullptr) {
+      cache->TrackedInstances.erase(self);
+    }
+    delete self;
+  }
+
+  v8::Global<v8::Object> weakHandle_;
+};
+
+}  // namespace tns

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -11,6 +11,7 @@
 #include "Helpers.h"
 #include "InlineFunctions.h"
 #include "Interop.h"
+#include "IsolateTracked.h"
 #include "NativeScriptException.h"
 #include "ObjectManager.h"
 #include "Performance.h"
@@ -232,6 +233,7 @@ Runtime::~Runtime() {
     g_moduleRegistry.clear();
 
     ObjectManager::DisposeAllRegistered(isolate_);
+    IsolateTracked::SweepAll(isolate_);
 
     if (IsRuntimeWorker()) {
       auto currentWorker =

--- a/NativeScript/runtime/URLImpl.h
+++ b/NativeScript/runtime/URLImpl.h
@@ -7,11 +7,12 @@
 #include <vector>
 
 #include "Common.h"
+#include "IsolateTracked.h"
 #include "ada/ada.h"
 
 using namespace ada;
 namespace tns {
-class URLImpl {
+class URLImpl : public IsolateTracked {
  public:
   URLImpl(url_aggregator url);
 
@@ -99,21 +100,7 @@ class URLImpl {
 
   static void CanParse(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  void BindFinalizer(v8::Isolate* isolate,
-                     const v8::Local<v8::Object>& object) {
-    v8::HandleScope scopedHandle(isolate);
-    weakHandle_.Reset(isolate, object);
-    weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
-  }
-
-  static void Finalizer(const v8::WeakCallbackInfo<URLImpl>& data) {
-    auto* pThis = data.GetParameter();
-    pThis->weakHandle_.Reset();
-    delete pThis;
-  }
-
  private:
   url_aggregator url_;
-  v8::Global<v8::Object> weakHandle_;
 };
 }  // namespace tns

--- a/NativeScript/runtime/URLPatternImpl.h
+++ b/NativeScript/runtime/URLPatternImpl.h
@@ -5,6 +5,7 @@
 
 #include "Common.h"
 #include "Helpers.h"
+#include "IsolateTracked.h"
 #include "ada/ada.h"
 using namespace ada;
 namespace tns {
@@ -22,7 +23,7 @@ class v8_regex_provider {
   static bool regex_match(std::string_view input, const regex_type& pattern);
 };
 
-class URLPatternImpl {
+class URLPatternImpl : public IsolateTracked {
  public:
   URLPatternImpl(url_pattern<v8_regex_provider> pattern);
 
@@ -69,22 +70,8 @@ class URLPatternImpl {
 
   static void Exec(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  void BindFinalizer(v8::Isolate* isolate,
-                     const v8::Local<v8::Object>& object) {
-    v8::HandleScope scopedHandle(isolate);
-    weakHandle_.Reset(isolate, object);
-    weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
-  }
-
-  static void Finalizer(const v8::WeakCallbackInfo<URLPatternImpl>& data) {
-    auto* pThis = data.GetParameter();
-    pThis->weakHandle_.Reset();
-    delete pThis;
-  }
-
  private:
   url_pattern<v8_regex_provider> pattern_;
-  v8::Global<v8::Object> weakHandle_;
 
   static std::optional<ada::url_pattern_init> ParseInput(
       v8::Isolate* isolate, const v8::Local<v8::Value>& input);

--- a/NativeScript/runtime/URLSearchParamsImpl.h
+++ b/NativeScript/runtime/URLSearchParamsImpl.h
@@ -4,11 +4,12 @@
 #pragma once
 
 #include "Common.h"
+#include "IsolateTracked.h"
 #include "ada/ada.h"
 
 namespace tns {
 
-class URLSearchParamsImpl {
+class URLSearchParamsImpl : public IsolateTracked {
  public:
   URLSearchParamsImpl(ada::url_search_params params);
 
@@ -50,22 +51,8 @@ class URLSearchParamsImpl {
 
   static void Values(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  void BindFinalizer(v8::Isolate* isolate,
-                     const v8::Local<v8::Object>& object) {
-    v8::HandleScope scopedHandle(isolate);
-    weakHandle_.Reset(isolate, object);
-    weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
-  }
-
-  static void Finalizer(const v8::WeakCallbackInfo<URLSearchParamsImpl>& data) {
-    auto* pThis = data.GetParameter();
-    pThis->weakHandle_.Reset();
-    delete pThis;
-  }
-
  private:
   ada::url_search_params params_;
-  v8::Global<v8::Object> weakHandle_;
 };
 
 }  // namespace tns


### PR DESCRIPTION
## Problem

`URLImpl`, `URLSearchParamsImpl` and `URLPatternImpl` free themselves from a `SetWeak(kParameter)` finalizer. Weak callbacks never fire at isolate disposal, and these objects are not in any of the `Caches` structures that `ObjectManager::DisposeAllRegistered` walks — so every instance still alive when a `Runtime` is destroyed (e.g. a worker isolate shutting down) leaked its ada state, and for `URLPattern` also its compiled `v8::Global<RegExp>` handles.

## Fix

- New `IsolateTracked` base class absorbs the three identical copy-pasted weak-handle/finalizer blocks and registers each instance in a per-isolate `robin_hood::unordered_set` on `Caches`.
- Deletion happens in exactly two places, and both own the registry bookkeeping: the GC finalizer (erase + delete, same idiom as `ObjectManager::FinalizerCallback`), and `IsolateTracked::SweepAll` in `~Runtime` (detach-the-set-first then delete survivors, same idiom as `DisposeAllRegistered`). The sweep runs under the `Locker` while the isolate is alive, so destructors may reset their `v8::Global` handles.
- Net-negative diff in the three headers; call sites are unchanged.

The base deliberately mirrors the cppgc contract (registered at bind, destructor is the sole cleanup point, never deleted directly), so a later cppgc conversion is a base-class swap (`v8::Object::Wrappable` + `Object::Wrap<tag>`) plus deleting the registry.

Not included: ExtVector — its instances are already enrolled via `ObjectManager::Register` in `Interop::GetResult`, so its disposal path is live and there is nothing to fix.

## Testing

Full simulator suite green (zero failures across all suites, including the URL/URLSearchParams/URLPattern suites).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of URL-related objects when a JavaScript runtime is shut down.
  * Added consistent lifecycle tracking for URLs, URL patterns, and URL search parameters.
  * Reduced the risk of lingering resources or cleanup errors during runtime teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->