### PR TITLE
perf: convert strings across the V8/Obj-C bridge without the UTF-8 round trip

### DIFF
--- a/NativeScript/runtime/ArgConverter.h
+++ b/NativeScript/runtime/ArgConverter.h
@@ -66,7 +66,7 @@ class ArgConverter {
   // recycled the address and give it a foreign prototype.
   static std::shared_ptr<v8::Persistent<v8::Value>> FindCachedInstance(
       v8::Isolate* isolate, const std::shared_ptr<Caches>& cache, id target);
-  static const Meta* GetMeta(std::string name);
+  static const Meta* GetMeta(const std::string& name);
   static const ProtocolMeta* FindProtocolMeta(Protocol* protocol);
   static void MethodCallback(ffi_cif* cif, void* retValue, void** argValues,
                              void* userData);

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -1013,7 +1013,7 @@ const Meta* ArgConverter::FindMeta(Class klass, const TypeEncoding* typeEncoding
   return nullptr;
 }
 
-const Meta* ArgConverter::GetMeta(std::string name) {
+const Meta* ArgConverter::GetMeta(const std::string& name) {
   bool found;
   const Meta* meta = Caches::Metadata->Get(name, found);
   if (meta != nullptr || found) {

--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -61,9 +61,8 @@ Local<Value> ArgConverter::Invoke(Local<Context> context, Class klass, Local<Obj
       ObjCDataWrapper* objcWrapper = static_cast<ObjCDataWrapper*>(wrapper);
       target = objcWrapper->Data();
 
-      std::string className = object_getClassName(target);
       auto cache = Caches::Get(isolate);
-      auto it = cache->ClassPrototypes.find(className);
+      auto it = cache->ClassPrototypes.find(std::string_view(object_getClassName(target)));
       // For extended classes we will call the base method
       callSuper = isMethodCallback && it != cache->ClassPrototypes.end();
     } else {
@@ -910,8 +909,7 @@ Local<Value> ArgConverter::CreateJsWrapper(Local<Context> context, BaseDataWrapp
   Class klass = [target class];
   const Meta* meta = FindMeta(klass, typeEncoding);
   if (meta != nullptr) {
-    std::string className = object_getClassName(target);
-    auto it = cache->ClassPrototypes.find(className);
+    auto it = cache->ClassPrototypes.find(std::string_view(object_getClassName(target)));
     if (it != cache->ClassPrototypes.end()) {
       // for debugging rlv cell handling:
       // NSString* message = [NSString stringWithFormat:@"ArgConverter::CreateJsWrapper FindMeta:

--- a/NativeScript/runtime/Caches.h
+++ b/NativeScript/runtime/Caches.h
@@ -2,6 +2,7 @@
 #define Caches_h
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "Common.h"
@@ -15,6 +16,23 @@ struct StructInfo;
 struct ObjectWeakCallbackState;
 class PromiseRejectionTracker;
 class IsolateTracked;
+
+// Declaring both halves transparent lets robin_hood probe a map keyed by
+// std::string with a string_view, so callers holding a const char* from the
+// Obj-C runtime do not have to allocate one just to look up.
+struct TransparentStringHash {
+  using is_transparent = void;
+  size_t operator()(std::string_view key) const {
+    return robin_hood::hash_bytes(key.data(), key.size());
+  }
+};
+
+struct TransparentStringEqual {
+  using is_transparent = void;
+  bool operator()(std::string_view lhs, std::string_view rhs) const {
+    return lhs == rhs;
+  }
+};
 
 struct pair_hash {
   template <class T1, class T2>
@@ -101,7 +119,8 @@ class Caches {
                             std::unique_ptr<v8::Persistent<v8::Value>>>
       Prototypes;
   robin_hood::unordered_map<std::string,
-                            std::unique_ptr<v8::Persistent<v8::Object>>>
+                            std::unique_ptr<v8::Persistent<v8::Object>>,
+                            TransparentStringHash, TransparentStringEqual>
       ClassPrototypes;
   robin_hood::unordered_map<
       const BaseClassMeta*,

--- a/NativeScript/runtime/ConcurrentMap.h
+++ b/NativeScript/runtime/ConcurrentMap.h
@@ -9,36 +9,36 @@ namespace tns {
 template<class TKey, class TValue>
 class ConcurrentMap {
 public:
-    inline void Insert(TKey& key, TValue value) {
-        std::lock_guard<std::mutex> writerLock(this->containerMutex_);
-        this->container_[key] = value;
-    }
+ inline void Insert(const TKey& key, TValue value) {
+   std::lock_guard<std::mutex> writerLock(this->containerMutex_);
+   this->container_[key] = value;
+ }
 
-    inline TValue Get(TKey& key) {
-        bool found;
-        return this->Get(key, found);
-    }
+ inline TValue Get(const TKey& key) {
+   bool found;
+   return this->Get(key, found);
+ }
 
-    inline TValue Get(TKey& key, bool& found) {
-        std::lock_guard<std::mutex> writerLock(this->containerMutex_);
-        auto it = this->container_.find(key);
-        found = it != this->container_.end();
-        if (found) {
-            return it->second;
-        }
-        return nullptr;
-    }
+ inline TValue Get(const TKey& key, bool& found) {
+   std::lock_guard<std::mutex> writerLock(this->containerMutex_);
+   auto it = this->container_.find(key);
+   found = it != this->container_.end();
+   if (found) {
+     return it->second;
+   }
+   return nullptr;
+ }
 
-    inline bool ContainsKey(TKey& key) {
-        std::lock_guard<std::mutex> writerLock(this->containerMutex_);
-        auto it = this->container_.find(key);
-        return it != this->container_.end();
-    }
+ inline bool ContainsKey(const TKey& key) {
+   std::lock_guard<std::mutex> writerLock(this->containerMutex_);
+   auto it = this->container_.find(key);
+   return it != this->container_.end();
+ }
 
-    inline void Remove(TKey& key) {
-        std::lock_guard<std::mutex> writerLock(this->containerMutex_);
-        this->container_.erase(key);
-    }
+ inline void Remove(const TKey& key) {
+   std::lock_guard<std::mutex> writerLock(this->containerMutex_);
+   this->container_.erase(key);
+ }
 
     inline void ForEach(const std::function<bool(TKey&, TValue&)>& func) {
         std::lock_guard<std::mutex> writerLock(this->containerMutex_);

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -162,6 +162,13 @@ inline std::string ToString(v8::Isolate* isolate, const v8::Local<v8::Value>& va
 }
 
 #ifdef __OBJC__
+// Encodes via V8 rather than -UTF8String, which returns nil for a string holding
+// a lone surrogate — leaving callers to construct a std::string from nullptr.
+// The unpaired half becomes U+FFFD, since it has no UTF-8 spelling.
+inline std::string ToString(v8::Isolate* isolate, const NSString* value) {
+  return tns::ToString(isolate, tns::ToV8String(isolate, value));
+}
+
 inline NSString* ToNSString(const std::string& v) {
   return [[[NSString alloc] initWithBytes:v.c_str() length:v.length()
                                  encoding:NSUTF8StringEncoding] S_AUTORELEASE];

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -42,34 +42,59 @@ inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const char* value,
       .ToLocalChecked();
 }
 #ifdef __OBJC__
+// Both sides store text as either 8-bit or UTF-16, never UTF-8, so the buffer is
+// handed to V8 in whichever width CFString already holds. Going through
+// -UTF8String instead would encode the string twice (once for the bytes, once
+// for -lengthOfBytesUsingEncoding:), allocate, and return nil for strings
+// containing a lone surrogate — silently turning them into "".
 inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const NSString* value) {
-  /*
-   // TODO: profile if this is faster
-   // maybe have multiple conversion
-   if([value fastestEncoding] == NSUTF16StringEncoding) {
-      uint16_t static_buffer[256];
-      uint16_t* targetBuffer = static_buffer;
-      bool isDynamic = false;
-      auto length = [value
-  maximumLengthOfBytesUsingEncoding:NSUTF16StringEncoding]; auto numberOfBytes =
-  length * sizeof(uint16_t); if (length > 256) { targetBuffer =
-  (uint16_t*)malloc(numberOfBytes); isDynamic = true;
-      }
-      NSUInteger usedLength = 0;
-      NSRange range = NSMakeRange(0, [value length]);
-      [value getBytes:targetBuffer maxLength:numberOfBytes
-  usedLength:&usedLength encoding:NSUTF16StringEncoding options:0 range:range
-  remainingRange:NULL];
-
-      auto result = v8::String::NewFromTwoByte(isolate, targetBuffer,
-  v8::NewStringType::kNormal, (int)[value length]).ToLocalChecked(); if
-  (isDynamic) { free(targetBuffer);
-      }
-      return result;
+  if (value == nil) {
+    return v8::String::Empty(isolate);
   }
-   */
-  return v8::String::NewFromUtf8(isolate, [value UTF8String], v8::NewStringType::kNormal,
-                                 (int)[value lengthOfBytesUsingEncoding:NSUTF8StringEncoding])
+
+  CFStringRef str = (__bridge CFStringRef)value;
+  CFIndex length = CFStringGetLength(str);
+  if (length == 0) {
+    return v8::String::Empty(isolate);
+  }
+
+  // An ASCII pointer is handed back only when every code unit is < 0x80, so the
+  // code unit count doubles as the byte count.
+  if (const char* ascii = CFStringGetCStringPtr(str, kCFStringEncodingASCII)) {
+    return v8::String::NewFromOneByte(isolate, reinterpret_cast<const uint8_t*>(ascii),
+                                      v8::NewStringType::kNormal, (int)length)
+        .ToLocalChecked();
+  }
+
+  if (const UniChar* utf16 = CFStringGetCharactersPtr(str)) {
+    return v8::String::NewFromTwoByte(isolate, reinterpret_cast<const uint16_t*>(utf16),
+                                      v8::NewStringType::kNormal, (int)length)
+        .ToLocalChecked();
+  }
+
+  // Tagged pointers and some bridged strings expose neither buffer, so the
+  // contents have to be copied out. The narrow attempt writes at most `length`
+  // bytes, which always fits the UTF-16-sized buffer.
+  constexpr CFIndex kStackUnits = 256;
+  uint16_t stackBuffer[kStackUnits];
+  std::vector<uint16_t> heapBuffer;
+  uint16_t* buffer = stackBuffer;
+  if (length > kStackUnits) {
+    heapBuffer.resize((size_t)length);
+    buffer = heapBuffer.data();
+  }
+
+  CFRange range = CFRangeMake(0, length);
+  CFIndex usedLength = 0;
+  if (CFStringGetBytes(str, range, kCFStringEncodingASCII, 0, false,
+                       reinterpret_cast<UInt8*>(buffer), length, &usedLength) == length) {
+    return v8::String::NewFromOneByte(isolate, reinterpret_cast<const uint8_t*>(buffer),
+                                      v8::NewStringType::kNormal, (int)length)
+        .ToLocalChecked();
+  }
+
+  CFStringGetCharacters(str, range, reinterpret_cast<UniChar*>(buffer));
+  return v8::String::NewFromTwoByte(isolate, buffer, v8::NewStringType::kNormal, (int)length)
       .ToLocalChecked();
 }
 #endif

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -98,24 +98,60 @@ inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const NSString* va
       .ToLocalChecked();
 }
 #endif
-inline std::string ToString(v8::Isolate* isolate, const v8::Local<v8::Value>& value) {
+// Unwraps a value to the v8::String the text conversions below read from.
+// A throwing toString() is swallowed rather than left pending, which is the
+// contract v8::String::Utf8Value offered and callers were written against.
+inline bool ToStringLocal(v8::Isolate* isolate, const v8::Local<v8::Value>& value,
+                          v8::Local<v8::String>& out) {
   if (value.IsEmpty()) {
-    return std::string();
+    return false;
+  }
+
+  if (value->IsString()) {
+    out = value.As<v8::String>();
+    return true;
   }
 
   if (value->IsStringObject()) {
-    v8::Local<v8::String> obj = value.As<v8::StringObject>()->ValueOf();
-    return tns::ToString(isolate, obj);
+    out = value.As<v8::StringObject>()->ValueOf();
+    return true;
   }
 
-  v8::String::Utf8Value result(isolate, value);
+  v8::TryCatch tc(isolate);
+  return value->ToString(isolate->GetCurrentContext()).ToLocal(&out);
+}
 
-  const char* val = *result;
-  if (val == nullptr) {
+inline std::string ToString(v8::Isolate* isolate, const v8::Local<v8::Value>& value) {
+  v8::Local<v8::String> str;
+  if (!ToStringLocal(isolate, value, str)) {
     return std::string();
   }
 
-  return std::string(*result, result.length());
+  {
+    v8::String::ValueView view(isolate, str);
+    if (view.is_one_byte()) {
+      const uint8_t* data = view.data8();
+      uint32_t length = view.length();
+      uint32_t i = 0;
+      while (i < length && data[i] < 0x80) {
+        i++;
+      }
+      // Pure ASCII already is its own UTF-8 encoding, so it can be copied
+      // straight out. A one-byte string with a high byte is Latin-1 and still
+      // needs widening, which the encode below handles.
+      if (i == length) {
+        return std::string(reinterpret_cast<const char*>(data), length);
+      }
+    }
+  }
+
+  size_t length = str->Utf8LengthV2(isolate);
+  std::string result(length, '\0');
+  if (length > 0) {
+    str->WriteUtf8V2(isolate, result.data(), length, v8::String::WriteFlags::kReplaceInvalidUtf8);
+  }
+
+  return result;
 }
 
 #ifdef __OBJC__

--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -41,6 +41,13 @@ inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const char* value,
   return v8::String::NewFromUtf8(isolate, value, v8::NewStringType::kNormal, length)
       .ToLocalChecked();
 }
+
+// Without this overload a bare `const char*` — every string literal, every
+// c_str(), every jsName() — picks the std::string one and pays for a temporary
+// just to reach V8.
+inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const char* value) {
+  return v8::String::NewFromUtf8(isolate, value).ToLocalChecked();
+}
 #ifdef __OBJC__
 // Both sides store text as either 8-bit or UTF-16, never UTF-8, so the buffer is
 // handed to V8 in whichever width CFString already holds. Going through
@@ -225,8 +232,6 @@ inline bool ToBool(const v8::Local<v8::Value>& value) {
 
   return result;
 }
-std::vector<uint16_t> ToVector(const std::string& value);
-
 bool Exists(const char* fullPath);
 v8::Local<v8::String> ReadModule(v8::Isolate* isolate, const std::string& filePath);
 const char* ReadText(const std::string& filePath, long& length, bool& isNew);

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -8,9 +8,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <atomic>
-#include <codecvt>
 #include <fstream>
-#include <locale>
 #include <sstream>
 #include "Caches.h"
 #include "ErrorEvents.h"
@@ -52,18 +50,6 @@ std::u16string tns::ToUtf16String(Isolate* isolate, const Local<Value>& value) {
   }
 
   return std::u16string((const char16_t*)result.data16(), result.length());
-}
-
-std::vector<uint16_t> tns::ToVector(const std::string& value) {
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  // FIXME: std::codecvt_utf8_utf16 is deprecated
-  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
-  std::u16string value16 = convert.from_bytes(value);
-
-  const uint16_t* begin = reinterpret_cast<uint16_t const*>(value16.data());
-  const uint16_t* end = reinterpret_cast<uint16_t const*>(value16.data() + value16.size());
-  std::vector<uint16_t> vector(begin, end);
-  return vector;
 }
 
 bool tns::Exists(const char* fullPath) {

--- a/NativeScript/runtime/InlineFunctions.cpp
+++ b/NativeScript/runtime/InlineFunctions.cpp
@@ -17,7 +17,7 @@ void InlineFunctions::Init(Local<Context> context) {
   }
 }
 
-bool InlineFunctions::IsGlobalFunction(std::string name) {
+bool InlineFunctions::IsGlobalFunction(const std::string& name) {
   return name == "CGPointMake" || name == "CGRectMake" ||
          name == "CGSizeMake" || name == "UIEdgeInsetsMake" ||
          name == "NSMakeRange" || name == "__decorate" || name == "__param" ||

--- a/NativeScript/runtime/InlineFunctions.h
+++ b/NativeScript/runtime/InlineFunctions.h
@@ -8,7 +8,7 @@ namespace tns {
 class InlineFunctions {
 public:
     static void Init(v8::Local<v8::Context> context);
-    static bool IsGlobalFunction(std::string name);
+    static bool IsGlobalFunction(const std::string& name);
 };
 
 }

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -262,9 +262,7 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
   } else if (argHelper.isString() &&
              typeEncoding->type == BinaryTypeEncodingType::SelectorEncoding) {
     std::string str = tns::ToString(isolate, arg);
-    NSString* selStr = [NSString stringWithUTF8String:str.c_str()];
-    SEL selector = NSSelectorFromString(selStr);
-    Interop::SetValue(dest, selector);
+    Interop::SetValue(dest, sel_registerName(str.c_str()));
   } else if (typeEncoding->type == BinaryTypeEncodingType::CStringEncoding) {
     if (arg->IsString()) {
       const char* value = nullptr;
@@ -314,12 +312,21 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
     }
   } else if (argHelper.isString() &&
              typeEncoding->type == BinaryTypeEncodingType::UnicharEncoding) {
-    v8::String::Utf8Value utf8Value(isolate, arg);
-    std::vector<uint16_t> vector = tns::ToVector(*utf8Value);
-    if (vector.size() > 1) {
+    Local<v8::String> str;
+    uint32_t length = 0;
+    unichar c = 0;
+    if (tns::ToStringLocal(isolate, arg, str)) {
+      // Scoped so the view's no-GC window closes before anything can throw.
+      v8::String::ValueView view(isolate, str);
+      length = view.length();
+      if (length == 1) {
+        c = view.is_one_byte() ? view.data8()[0] : view.data16()[0];
+      }
+    }
+
+    if (length > 1) {
       throw NativeScriptException("Only one character string can be converted to unichar.");
     }
-    unichar c = (vector.size() == 0) ? 0 : vector[0];
     Interop::SetValue(dest, c);
   } else if (argHelper.isString() &&
              (typeEncoding->type == BinaryTypeEncodingType::InterfaceDeclarationReference ||
@@ -980,8 +987,7 @@ Local<Value> Interop::GetResult(Local<Context> context, const TypeEncoding* type
       return Null(isolate);
     }
 
-    NSString* selStr = NSStringFromSelector(result);
-    return tns::ToV8String(isolate, [selStr UTF8String]);
+    return tns::ToV8String(isolate, sel_getName(result));
   }
 
   if (typeEncoding->type == BinaryTypeEncodingType::ProtocolEncoding) {
@@ -1355,18 +1361,10 @@ Local<Value> Interop::GetPrimitiveReturnType(Local<Context> context, BinaryTypeE
   }
 
   if (type == BinaryTypeEncodingType::UnicharEncoding) {
-    unichar result = call->GetResult<unichar>();
-    char chars[2];
-
-    if (result > 127) {
-      chars[0] = (result >> 8) & (1 << 8) - 1;
-      chars[1] = result & (1 << 8) - 1;
-    } else {
-      chars[0] = result;
-      chars[1] = 0;
-    }
-
-    return tns::ToV8String(isolate, chars);
+    // A unichar is a single UTF-16 code unit, so it goes over as one.
+    uint16_t result = call->GetResult<unichar>();
+    return v8::String::NewFromTwoByte(isolate, &result, v8::NewStringType::kNormal, 1)
+        .ToLocalChecked();
   }
 
   if (type == BinaryTypeEncodingType::UCharEncoding) {

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1668,13 +1668,13 @@ Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {
 
     NSString* nsName = [e name];
     NSString* nsReason = [e reason];
-    std::string message =
-        nsReason ? [nsReason UTF8String] : (nsName ? [nsName UTF8String] : "NSException");
+    Local<v8::String> messageV8 = tns::ToV8String(isolate, nsReason ?: (nsName ?: @"NSException"));
+    std::string message = tns::ToString(isolate, messageV8);
 
-    Local<Value> jsErrVal = Exception::Error(tns::ToV8String(isolate, message));
+    Local<Value> jsErrVal = Exception::Error(messageV8);
     if (jsErrVal.IsEmpty() || !jsErrVal->IsObject()) {
       // Fallback: keep the description-only behavior if Error creation fails.
-      throw NativeScriptException([[e description] UTF8String]);
+      throw NativeScriptException(tns::ToString(isolate, [e description]));
     }
 
     Local<Object> jsErrObj = jsErrVal.As<Object>();
@@ -1712,7 +1712,7 @@ Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {
       if (jsErrVal.IsEmpty() || !jsErrVal->IsObject()) {
         // Fallback: if for some reason we cannot create an Error object, throw a generic
         // NativeScriptException
-        throw NativeScriptException([[error localizedDescription] UTF8String]);
+        throw NativeScriptException(tns::ToString(isolate, [error localizedDescription]));
       }
 
       Local<Object> jsErrObj = jsErrVal.As<Object>();

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1679,15 +1679,12 @@ Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {
 
     Local<Object> jsErrObj = jsErrVal.As<Object>();
     if (nsName != nil) {
-      jsErrObj
-          ->Set(context, tns::ToV8String(isolate, "name"),
-                tns::ToV8String(isolate, [nsName UTF8String]))
+      jsErrObj->Set(context, tns::ToV8String(isolate, "name"), tns::ToV8String(isolate, nsName))
           .FromMaybe(false);
     }
     if (nsReason != nil) {
       jsErrObj
-          ->Set(context, tns::ToV8String(isolate, "message"),
-                tns::ToV8String(isolate, [nsReason UTF8String]))
+          ->Set(context, tns::ToV8String(isolate, "message"), tns::ToV8String(isolate, nsReason))
           .FromMaybe(false);
     }
 
@@ -1711,7 +1708,7 @@ Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {
       Local<Context> context = isolate->GetCurrentContext();
 
       Local<Value> jsErrVal =
-          Exception::Error(tns::ToV8String(isolate, [[error localizedDescription] UTF8String]));
+          Exception::Error(tns::ToV8String(isolate, [error localizedDescription]));
       if (jsErrVal.IsEmpty() || !jsErrVal->IsObject()) {
         // Fallback: if for some reason we cannot create an Error object, throw a generic
         // NativeScriptException
@@ -1728,7 +1725,7 @@ Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {
       if (error.domain) {
         jsErrObj
             ->Set(context, tns::ToV8String(isolate, "domain"),
-                  tns::ToV8String(isolate, [error.domain UTF8String]))
+                  tns::ToV8String(isolate, error.domain))
             .FromMaybe(false);
       } else {
         jsErrObj->Set(context, tns::ToV8String(isolate, "domain"), Null(isolate)).FromMaybe(false);

--- a/NativeScript/runtime/MetadataBuilder.h
+++ b/NativeScript/runtime/MetadataBuilder.h
@@ -69,7 +69,7 @@ class MetadataBuilder {
                                            const MethodMeta* meta,
                                            v8::Local<v8::Object> receiver,
                                            V8Args& args,
-                                           std::string containingClass,
+                                           const std::string& containingClass,
                                            bool isMethodCallback);
   static void RegisterAllocMethod(
       v8::Isolate* isolate, v8::Local<v8::FunctionTemplate> ctorFuncTemplate,

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -764,21 +764,25 @@ void MetadataBuilder::MethodCallback(const FunctionCallbackInfo<Value>& info) {
   bool instanceMethod = info.This()->InternalFieldCount() > 0;
   V8FunctionCallbackArgs args(info);
 
-  std::string className = item->className_;
+  // Only the class-side call rewrites the name, so the common path reads
+  // item->className_ in place rather than copying it on every invocation.
+  const std::string* className = &item->className_;
+  std::string classWrapperName;
 
   Local<Object> thiz = info.This();
   if (thiz->IsFunction()) {
     if (BaseDataWrapper* wrapper = tns::GetValue(isolate, thiz)) {
       ObjCClassWrapper* classWrapper = static_cast<ObjCClassWrapper*>(wrapper);
-      className = class_getName(classWrapper->Klass());
+      classWrapperName = class_getName(classWrapper->Klass());
+      className = &classWrapperName;
     }
   }
 
   Local<Context> context = isolate->GetCurrentContext();
   Local<Value> result =
       instanceMethod
-          ? MetadataBuilder::InvokeMethod(context, item->meta_, info.This(), args, className, true)
-          : MetadataBuilder::InvokeMethod(context, item->meta_, Local<Object>(), args, className,
+          ? MetadataBuilder::InvokeMethod(context, item->meta_, info.This(), args, *className, true)
+          : MetadataBuilder::InvokeMethod(context, item->meta_, Local<Object>(), args, *className,
                                           true);
 
   if (!result.IsEmpty()) {
@@ -967,7 +971,8 @@ void MetadataBuilder::DefineFunctionLengthProperty(Local<Context> context,
 
 Local<Value> MetadataBuilder::InvokeMethod(Local<Context> context, const MethodMeta* meta,
                                            Local<Object> receiver, V8Args& args,
-                                           std::string containingClass, bool isMethodCallback) {
+                                           const std::string& containingClass,
+                                           bool isMethodCallback) {
   Class klass = objc_getClass(containingClass.c_str());
   // TODO: Find out if the isMethodCallback property can be determined based on a
   // UITableViewController.prototype.viewDidLoad.call(this) or super.viewDidLoad() call

--- a/NativeScript/runtime/MetadataBuilder.mm
+++ b/NativeScript/runtime/MetadataBuilder.mm
@@ -482,8 +482,7 @@ void MetadataBuilder::ToStringFunctionCallback(const FunctionCallbackInfo<Value>
     return;
   }
 
-  std::string description = [[target description] UTF8String];
-  Local<v8::String> returnValue = tns::ToV8String(info.GetIsolate(), description);
+  Local<v8::String> returnValue = tns::ToV8String(info.GetIsolate(), [target description]);
   info.GetReturnValue().Set(returnValue);
 }
 

--- a/NativeScript/runtime/SymbolIterator.mm
+++ b/NativeScript/runtime/SymbolIterator.mm
@@ -86,7 +86,7 @@ void SymbolIterator::NextCallback(const v8::FunctionCallbackInfo<v8::Value>& arg
     if ([item isKindOfClass:[NSNumber class]]) {
       val = Number::New(isolate, [item doubleValue]);
     } else if ([item isKindOfClass:[NSString class]]) {
-      val = tns::ToV8String(isolate, [item UTF8String]);
+      val = tns::ToV8String(isolate, (NSString*)item);
     } else {
       auto wrapper = new ObjCDataWrapper(item);
       val = ArgConverter::CreateJsWrapper(context, wrapper, Local<Object>());

--- a/TestRunner/app/tests/Marshalling/NSStringTests.js
+++ b/TestRunner/app/tests/Marshalling/NSStringTests.js
@@ -39,6 +39,46 @@ describe(module.id, function () {
         expect(instance.valueForKey('x')).toBe(data);
     });
 
+    function roundTrip(value) {
+        var JSObject = NSObject.extend({
+            'x': function () {
+                return this._x;
+            }, 'setX:': function (x) {
+                this._x = x;
+            }
+        }, {
+            exposedMethods: {
+                x: { returns: NSString },
+                'setX:': { returns: interop.types.void, params: [NSString] }
+            }
+        });
+
+        var instance = JSObject.alloc().init();
+        instance.setValueForKey(value, 'x');
+        return instance.valueForKey('x');
+    }
+
+    it("Marshals NSString with a lone surrogate", function () {
+        const data = 'a' + String.fromCharCode(0xD800) + 'b';
+        expect(roundTrip(data)).toBe(data);
+    });
+
+    it("Marshals NSString across both storage widths", function () {
+        // ASCII, Latin-1 and non-BMP exercise the one-byte, two-byte and
+        // surrogate-pair paths respectively.
+        expect(roundTrip('plain ascii')).toBe('plain ascii');
+        expect(roundTrip('café naïve')).toBe('café naïve');
+        expect(roundTrip('你好世界')).toBe('你好世界');
+        expect(roundTrip('emoji 👋🏽 here')).toBe('emoji 👋🏽 here');
+    });
+
+    it("Marshals NSString longer than the conversion stack buffer", function () {
+        const ascii = 'a'.repeat(1000);
+        const wide = '𝄞'.repeat(1000);
+        expect(roundTrip(ascii)).toBe(ascii);
+        expect(roundTrip(wide)).toBe(wide);
+    });
+
     it("String", function () {
         var str = NSString.string();
         expect(str.isKindOfClass(NSString)).toBe(true);

--- a/TestRunner/app/tests/Marshalling/Primitives/Instance.js
+++ b/TestRunner/app/tests/Marshalling/Primitives/Instance.js
@@ -231,6 +231,12 @@ describe(module.id, function () {
         // Both outcomes are acceptable depending on build configuration
         expect(threw === true || threw === false).toBe(true);
     });
+
+    it("InstanceMethodWithNonAsciiUnichar", function () {
+        var instance = TNSPrimitives.alloc().init();
+        expect(instance.methodWithUnichar('é')).toBe('é');
+        expect(instance.methodWithUnichar('✓')).toBe('✓');
+    });
     
     it("InstanceMethodWithNSNumber1", function () {
         var result = TNSPrimitives.alloc().init().methodWithNSNumber(0);


### PR DESCRIPTION
## Current behavior

Both V8 and CFString/NSString store text as **either 8-bit or UTF-16, never UTF-8** — V8 as `SeqOneByteString` (Latin-1) or `SeqTwoByteString`, CFString as an 8-bit backing store, a UTF-16 backing store, or a tagged pointer. The runtime nevertheless routed several conversions through UTF-8, which costs an encode on one side and a decode on the other, plus an allocation in between, to move data between two representations that already match.

`ToNSString` (V8 → NSString) was already width-preserving. The other direction was not:

```objc
return v8::String::NewFromUtf8(isolate, [value UTF8String], kNormal,
                               (int)[value lengthOfBytesUsingEncoding:NSUTF8StringEncoding])
```

That is three passes — `-UTF8String` encodes and mallocs an autoreleased buffer, `-lengthOfBytesUsingEncoding:` encodes the whole string a *second* time purely to count bytes, and V8 then decodes UTF-8 back into its own representation. A commented-out sketch of the UTF-16 fast path had been sitting above it with `// TODO: profile if this is faster`.

## New behavior

Conversions hand over the buffer at its existing width. Five commits, each independently reviewable:

| commit | change |
|---|---|
| `1efc9436` | `ToV8String(NSString*)`: ASCII interior pointer → `NewFromOneByte`, UTF-16 interior pointer → `NewFromTwoByte`, otherwise one copy into a stack buffer |
| `dd6c6758` | `tns::ToString`: `ValueView` with a pure-ASCII fast path instead of `String::Utf8Value` + a second copy |
| `1ed65716` | missing `const char*` overload; selectors via `sel_registerName`/`sel_getName`; `unichar` via `ValueView`; `ToVector` and `<codecvt>` removed |
| `0e935971` | transparent hashing for `ClassPrototypes`; no per-call class-name copies on the invoke path |
| `1922d1a9` | NSString exception/description text no longer routed through `-UTF8String` |

### Measured

Foundation-side cost, `-O2` on arm64, 300k iterations. V8's own copy is unchanged and excluded, so end-to-end this is largest for short strings and settles around 3–8× for multi-KB ones:

| NSString | before | after |
|---|---|---|
| ASCII, 15 chars | 47.8 ns | 8.2 ns |
| ASCII, 4000 chars | 1040 ns | 8.0 ns |
| non-ASCII, 17 chars | 148 ns | 7.1 ns |
| CJK, 400 chars | 1893 ns | 7.3 ns |
| tagged pointer (no interior pointer available) | 54.2 ns | 6.2 ns |

It also removes one malloc per conversion. `-UTF8String` allocated on every call for everything except constant literals — 10,061 mallocs per 10k calls, ~880 KB held until the autorelease pool drained.

### Bugs fixed along the way

1. **Lone surrogates were silently dropped.** `-UTF8String` returns `nil` for a string containing an unpaired surrogate and `-lengthOfBytesUsingEncoding:` returns 0, which V8's `length == 0` branch turns into `""`. A lone surrogate therefore did not survive JS → native → JS. The reverse direction had already been fixed for exactly this; the bridge is now symmetric.

2. **The `unichar` return path read out of bounds.** It packed the code unit into a `char[2]` with no room for a terminator and passed it to `std::string`, which read past the array. For values above 127 it also wrote the high byte first, so a `unichar` of `0xE9` produced a leading NUL and the call returned `""` rather than `"é"`. Existing coverage only passed ASCII `'i'`.

3. **`nil` from `-UTF8String` was strlen'd** at the NSException, NSError, fast-enumeration and object-description sites.

## Testing

`./run_tests.sh` green at every commit: **1196 tests on main → 1200 here, 0 failures.** Four new specs — NSString round trips for a lone surrogate, for both storage widths (ASCII / Latin-1 / CJK / non-BMP), for strings longer than the conversion stack buffer, and a non-ASCII `unichar` round trip.

Independently reviewed for `ValueView` lifetime (no V8 allocation, throw, or pointer escape inside a no-GC scope), fallback buffer arithmetic, the blast radius of the new `const char*` overload across every affected call site, transparent-hash consistency, and pointer lifetime in `MethodCallback`.

Two caveats worth stating plainly:

- The timings above are **Foundation-side microbenchmarks, not end-to-end runtime numbers.** An in-runtime bridge benchmark would be needed to quantify the real-world effect.
- I was not able to demonstrate the lone-surrogate test going **red** on the pre-fix code at suite level — two attempts wedged on the known 600s Jasmine timeout (#420) rather than reporting. The mechanism is established directly instead: `-UTF8String` returns `NULL` (measured), `-lengthOfBytesUsingEncoding:` returns 0 (measured), and `NEW_STRING` maps `length == 0` to `String::Empty` (`v8/src/api/api.cc:7568`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of native and JavaScript strings, including empty strings, non-ASCII characters, surrogate pairs, and invalid sequences.
  * Fixed handling of Unicode characters passed through character-based APIs.
  * Improved conversion of native errors and object descriptions into JavaScript strings.

* **Performance**
  * Reduced unnecessary string copying during runtime lookups and native-to-JavaScript conversions.

* **Tests**
  * Added coverage for Unicode, Latin-1, non-BMP, long strings, surrogate pairs, and various native string storage formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->