### PR TITLE
fix(runtime): free struct buffers marshalled from object literals when the call completes

### DIFF
--- a/NativeScript/runtime/FFICall.h
+++ b/NativeScript/runtime/FFICall.h
@@ -3,7 +3,9 @@
 
 #include <malloc/malloc.h>
 
+#include <cstdlib>
 #include <map>
+#include <vector>
 
 #include "DataWrapper.h"
 #include "Metadata.h"
@@ -92,10 +94,18 @@ class FFICall : public BaseCall {
   }
 
   ~FFICall() {
+    for (void* buffer : this->ownedBuffers_) {
+      std::free(buffer);
+    }
+
     if (this->useDynamicBuffer_) {
       free(this->buffer_);
     }
   }
+
+  // Ties a malloc'd argument buffer to this call: it stays valid until after
+  // ffi_call returns and the result has been read.
+  inline void OwnBuffer(void* buffer) { this->ownedBuffers_.push_back(buffer); }
 
   /**
    When calling this, always make another call to DisposeFFIType with the same
@@ -122,6 +132,7 @@ class FFICall : public BaseCall {
   static SpinMutex structInfosCacheMutex_;
   void** argsArray_;
   bool useDynamicBuffer_;
+  std::vector<void*> ownedBuffers_;
   uint8_t staticBuffer[512];
 };
 

--- a/NativeScript/runtime/Interop.h
+++ b/NativeScript/runtime/Interop.h
@@ -107,7 +107,8 @@ class Interop {
                              v8::Local<v8::Value> arg);
   static void WriteValue(v8::Local<v8::Context> context,
                          const TypeEncoding* typeEncoding, void* dest,
-                         v8::Local<v8::Value> arg);
+                         v8::Local<v8::Value> arg,
+                         FFICall* callOwner = nullptr);
   static id ToObject(v8::Local<v8::Context> context, v8::Local<v8::Value> arg);
   static v8::Local<v8::Value> GetPrimitiveReturnType(
       v8::Local<v8::Context> context, BinaryTypeEncodingType type,

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -148,7 +148,7 @@ void Interop::SetFFIParams(Local<Context> context, const TypeEncoding* typeEncod
     enc = enc->next();
     Local<Value> arg = args[i - initialParameterIndex];
     void* argBuffer = call->ArgumentBuffer(i);
-    Interop::WriteValue(context, enc, argBuffer, arg);
+    Interop::WriteValue(context, enc, argBuffer, arg, call);
   }
 }
 
@@ -236,7 +236,7 @@ void Interop::WriteTypeValue(Local<Context> context, BaseDataWrapper* typeWrappe
 }
 
 void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncoding, void* dest,
-                         Local<Value> arg) {
+                         Local<Value> arg, FFICall* callOwner) {
   Isolate* isolate = v8::Isolate::GetCurrent();
   ExecuteWriteValueDebugValidationsIfInDebug(context, typeEncoding, dest, arg);
   ValueCache argHelper(arg);
@@ -409,17 +409,15 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
         tns::Assert(meta != nullptr && meta->type() == MetaType::Struct, isolate);
         const StructMeta* structMeta = static_cast<const StructMeta*>(meta);
         StructInfo structInfo = FFICall::GetStructInfo(structMeta);
-        // TODO: How to free this?
-        // this is used when you have js obj and wants to pass the data as a struct ponter
-        // (MyStruct*) we create a new MyStruct with a snapshot of the jsObject and pass that in but
-        // when should we delete it? currently it's up to the function called to delete it we could
-        // delete after the function call, but if the fuction stores that then it's a memory leak we
-        // could also just store it as a wrapper in the object, binding it to the object lifecycle
-        // but that also means refactoring a lot of "if(wrapper == nullptr)" because essentially the
-        // wrapper should be treated as a nullptr, except when deating with
-        // StructDeclarationReference
+        // A plain JS object written into a MyStruct* slot is snapshotted into a fresh
+        // buffer. With an owner the callee only borrows it for the duration of the call.
+        // Without one (writes into an interop.Reference slot) the pointer is stored in
+        // memory that outlives any call, so the buffer must stay allocated.
         data = malloc(structInfo.FFIType()->size);
         Interop::InitializeStruct(context, data, structInfo.Fields(), arg);
+        if (callOwner != nullptr) {
+          callOwner->OwnBuffer(data);
+        }
       } else {
         if (wrapper == nullptr) {
           bool isArrayBuffer = false;

--- a/TestFixtures/TNSTestNativeCallbacks.h
+++ b/TestFixtures/TNSTestNativeCallbacks.h
@@ -58,6 +58,10 @@
 
 + (void)recordsPointer:(TNSSimpleStruct*)object;
 
+// Reads the pointee back out so callers can assert the marshalled values
+// without going through the shared log buffer.
++ (TNSSimpleStruct)recordsPointerEcho:(TNSSimpleStruct*)object;
+
 + (void)apiNSMutableArrayMethods:(NSMutableArray*)object;
 
 + (void)apiSwizzle:(TNSSwizzleKlass*)object;

--- a/TestFixtures/TNSTestNativeCallbacks.m
+++ b/TestFixtures/TNSTestNativeCallbacks.m
@@ -330,6 +330,10 @@
   TNSLog([NSString stringWithFormat:@"%d %d", object->x, object->y]);
 }
 
++ (TNSSimpleStruct)recordsPointerEcho:(TNSSimpleStruct*)object {
+  return *object;
+}
+
 + (void)apiNSMutableArrayMethods:(NSMutableArray*)object {
   [object addObject:@"b"];
   [object addObject:@"x"];

--- a/TestRunner/app/tests/Marshalling/RecordTests.js
+++ b/TestRunner/app/tests/Marshalling/RecordTests.js
@@ -358,4 +358,51 @@ describe(module.id, function () {
         TNSTestNativeCallbacks.recordsPointer(obj);
         expect(TNSGetOutput()).toBe("1 2");
     });
+
+    it("Marshalling struct pointers from object literals repeatedly", () => {
+        for (let i = 0; i < 1000; i++) {
+            const echoed = TNSTestNativeCallbacks.recordsPointerEcho({ x: i, y: i + 1 });
+            expect(echoed instanceof TNSSimpleStruct).toBe(true);
+            expect(echoed.x).toBe(i);
+            expect(echoed.y).toBe(i + 1);
+        }
+    });
+
+    it("Marshalling struct pointers from a wrapped struct leaves the wrapper's buffer intact", () => {
+        const record = new TNSSimpleStruct();
+        record.x = 3;
+        record.y = 4;
+
+        for (let i = 0; i < 100; i++) {
+            const echoed = TNSTestNativeCallbacks.recordsPointerEcho(record);
+            expect(echoed.x).toBe(3);
+            expect(echoed.y).toBe(4);
+        }
+
+        expect(record.x).toBe(3);
+        expect(record.y).toBe(4);
+    });
+
+    it("Marshalling struct pointers from an interop.Reference leaves the reference readable", () => {
+        const record = new TNSSimpleStruct();
+        record.x = 5;
+        record.y = 6;
+
+        const reference = new interop.Reference(record);
+
+        const echoed = TNSTestNativeCallbacks.recordsPointerEcho(reference);
+        expect(echoed.x).toBe(5);
+        expect(echoed.y).toBe(6);
+
+        expect(reference.value.x).toBe(5);
+        expect(reference.value.y).toBe(6);
+    });
+
+    it("Marshalling structs by value from object literals repeatedly", () => {
+        for (let i = 0; i < 1000; i++) {
+            const echoed = TNSTestNativeCallbacks.recordsSimpleStruct({ x: i, y: i + 1 });
+            expect(echoed.x).toBe(i);
+            expect(echoed.y).toBe(i + 1);
+        }
+    });
 });


### PR DESCRIPTION
## What changes

Passing a **plain JS object literal** where a native parameter expects a **pointer to a struct** (e.g. `CGPoint*`, `NSRange*`):

```js
someNativeFn({ x: 1, y: 2 }); // param is MyStruct*
```

previously snapshotted the literal into a `malloc`'d buffer that was **never freed** (the long-standing `// TODO: How to free this?` in `Interop::WriteValue`) — one leak per call. With this PR the buffer is owned by the `FFICall` driving the invocation and freed when the call completes (after `ffi_call` returns and the result is read).

Writes of literals into `MyStruct*`-typed slots of an `interop.Reference` are **unchanged**: that pointer is stored in memory that outlives any call, so those buffers deliberately remain unowned.

## The lifetime contract (new, documented behavior)

| You pass | Buffer lifetime | Use when |
|---|---|---|
| object literal `{x, y}` | **the call** (borrowed snapshot) | callee only reads during the call — the overwhelming case |
| struct instance (`CGPointMake(...)`, `new TNSSimpleStruct(...)`) | as long as the JS object lives | callee keeps the pointer — *you* keep the object |
| `interop.alloc(...)` (+ `interop.Reference`) | manual (`interop.free` or never) | callee takes ownership / frees it itself |

## ⚠️ Behavior change & risk — please test in real apps before merging

This is a deliberate behavior change with a known hazard class: **code that passes a literal and relies on native retaining that pointer past the call** worked before *only because of the leak* (the buffer was accidentally immortal). Under this PR such code gets a dangling pointer at call end — a use-after-free instead of a leak. Symmetrically, an API whose contract is "callee frees the pointer" would now double-free; `interop.alloc` is the correct form there.

Mitigating data — a survey of NativeScript core (`packages/core` + test apps):

- **Zero** occurrences of the literal-as-struct-pointer pattern. Every struct literal in core feeds a *by-value* parameter (unaffected).
- The **single** genuine struct-pointer call in core (`sockaddr` → `SCNetworkReachabilityCreateWithAddress`, `connectivity/index.ios.ts`) already uses `new interop.Reference(sockaddr, {...})` — a different, unaffected path.
- All other `interop.Reference` uses are scalar out-params (`CGFloat*`, `BOOL*`, `NSError**`).

So exposure is limited to third-party plugins / app code using a pattern core never uses. Still: **this should soak in real apps** (ideally ones heavy on CoreGraphics/CoreText/AV struct-pointer APIs) before it ships, and the release notes should state the new lifetime rule.

## Implementation

- `FFICall` gains `OwnBuffer(void*)` + an owned-buffer list freed in its destructor (stack-scoped at all three drive sites: `CallInitializer`, `CallFunctionInternal`, block invoke — verified the destructor runs after the result is read).
- `Interop::WriteValue` takes an optional `FFICall* callOwner = nullptr`; **only** `SetFFIParams` passes it. All nine other call sites — including nested ref/out-param initialization and `Reference.cpp` slot writes — stay owner-less on purpose (audited).
- New fixture `+[TNSTestNativeCallbacks recordsPointerEcho:]` (returns the pointee) to allow per-iteration value assertions.

## Tests

New specs in `Marshalling/RecordTests.js`:

- literal → struct-pointer, 1000 iterations, values asserted every iteration (guards premature free/corruption);
- wrapped struct instance → pointer param: wrapper's own buffer must survive (not call-owned);
- `interop.Reference` → pointer param: reference stays readable after the call;
- literal → *by-value* struct, 1000 iterations, pinned to the (allocation-free) by-value path.

Full suite passes. The leak itself is verified fixed out-of-band with the Instruments Leaks template — this path was the last remaining entry from the leaks run that 8080bc06 addressed.
