### PR TITLE
fix(runtime): drain autoreleased objects on worker threads per callout

### DIFF
--- a/NativeScript/runtime/EventLoop.mm
+++ b/NativeScript/runtime/EventLoop.mm
@@ -20,10 +20,16 @@ const CFTimeInterval kNeverFireInterval = 1.0e10;
 // a CFRunLoop callback frame. Deliberately no catch(...): on Darwin it would
 // also swallow NSExceptions, and bare entries (which may @throw on purpose)
 // never come through here anyway.
+// The pool scopes autoreleased objects to the callout: worker threads have no
+// UIKit observer draining once per run-loop pass, so without it they would
+// accumulate until the worker dies. Bare entries stay unwrapped - an
+// @throw must not unwind through a pool this code owns.
 template <typename F>
 void RunGuarded(F&& body) {
   try {
-    body();
+    @autoreleasepool {
+      body();
+    }
   } catch (tns::NativeScriptException& ex) {
     Log(@"NativeScript: uncaught NativeScriptException in event loop task: %s",
         ex.getMessage().c_str());

--- a/NativeScript/runtime/WorkerWrapper.mm
+++ b/NativeScript/runtime/WorkerWrapper.mm
@@ -147,13 +147,22 @@ void WorkerWrapper::BackgroundLooper(std::function<Isolate*()> func) {
         runLoop,
         [](void* info) {
           WorkerWrapper* w = static_cast<WorkerWrapper*>(info);
-          w->DrainPendingTasks();
+          // Autoreleased objects die with the callout; a worker has no UIKit
+          // observer draining a pool per run-loop pass.
+          @autoreleasepool {
+            w->DrainPendingTasks();
+          }
         },
         this);
 
-    this->workerIsolate_ = func();
+    // Autoreleased objects created during the boot phase (isolate creation and
+    // entry-script evaluation run before the loop starts) otherwise accumulate
+    // until the worker dies - the backing NSOperation's pool is the only drain.
+    @autoreleasepool {
+      this->workerIsolate_ = func();
 
-    this->DrainPendingTasks();
+      this->DrainPendingTasks();
+    }
 
     // check again as it could terminate before this
     if (!this->isTerminating_) {
@@ -161,22 +170,24 @@ void WorkerWrapper::BackgroundLooper(std::function<Isolate*()> func) {
     }
   }
 
-  // The inspector must be gone before the Runtime (and with it the isolate)
-  // is deleted below.
-  this->DestroyInspector();
+  @autoreleasepool {  // teardown garbage drains before the thread is gone
+    // The inspector must be gone before the Runtime (and with it the isolate)
+    // is deleted below.
+    this->DestroyInspector();
 
-  this->isDisposed_ = true;
-  Runtime* runtime = Runtime::GetCurrentRuntime();
-  if (runtime != nullptr) {
-    delete runtime;
-  } else {
-    // Runtime was never created (worker terminated before initialization).
-    // The runtime destructor normally handles this cleanup, so do it here.
-    int workerId = this->workerId_;
-    bool found;
-    auto state = Caches::Workers->Get(workerId, found);
-    if (found) {
-      Caches::Workers->Remove(workerId);
+    this->isDisposed_ = true;
+    Runtime* runtime = Runtime::GetCurrentRuntime();
+    if (runtime != nullptr) {
+      delete runtime;
+    } else {
+      // Runtime was never created (worker terminated before initialization).
+      // The runtime destructor normally handles this cleanup, so do it here.
+      int workerId = this->workerId_;
+      bool found;
+      auto state = Caches::Workers->Get(workerId, found);
+      if (found) {
+        Caches::Workers->Remove(workerId);
+      }
     }
   }
 }

--- a/TestFixtures/Marshalling/TNSAllocLog.h
+++ b/TestFixtures/Marshalling/TNSAllocLog.h
@@ -10,6 +10,10 @@
 - (instancetype)init;
 - (void)dealloc;
 
+// Creates an instance whose only reference is in the current autorelease pool,
+// so its dealloc log marks when that pool drains.
++ (void)autoreleaseInstance;
+
 @end
 
 #endif /* TNSAllocLog_h */

--- a/TestFixtures/Marshalling/TNSAllocLog.m
+++ b/TestFixtures/Marshalling/TNSAllocLog.m
@@ -20,4 +20,10 @@
     TNSLog(@"TNSAllocLog dealloc");
 }
 
++ (void)autoreleaseInstance {
+  // CFBridgingRetain moves the instance's ownership out of ARC so the
+  // CFAutorelease'd reference in the current pool is the only one left.
+  CFAutorelease(CFBridgingRetain([[TNSAllocLog alloc] init]));
+}
+
 @end

--- a/TestRunner/app/tests/WorkerAutoreleasePoolTests.js
+++ b/TestRunner/app/tests/WorkerAutoreleasePoolTests.js
@@ -1,0 +1,11 @@
+describe("worker autorelease pools", function () {
+    it("drains autoreleased objects per event-loop callout, not at worker death", function (done) {
+        var worker = new Worker("~/tests/autoreleasePoolDrainWorker.js");
+        worker.onmessage = function (e) {
+            worker.terminate();
+            expect(e.data).toContain("TNSAllocLog init");
+            expect(e.data).toContain("TNSAllocLog dealloc");
+            done();
+        };
+    });
+});

--- a/TestRunner/app/tests/autoreleasePoolDrainWorker.js
+++ b/TestRunner/app/tests/autoreleasePoolDrainWorker.js
@@ -1,0 +1,11 @@
+// The autorelease happens inside one timer callout, and the report is sent
+// from the NEXT one: the dealloc log can only be present in between if the
+// worker drains a pool per callout. Without that the pool only drains at
+// worker death, after the report is sent.
+TNSClearOutput();
+setTimeout(function () {
+    TNSAllocLog.autoreleaseInstance();
+    setTimeout(function () {
+        postMessage(TNSGetOutput());
+    }, 0);
+}, 0);

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -192,6 +192,8 @@ require("./NapiCoverageTests");
 // Worker-isolate scoping of extended objc class names
 require("./ExtendedClassNamingTests");
 
+require("./WorkerAutoreleasePoolTests");
+
 // Tests common for all runtimes (git submodule of NativeScript/common-runtime-tests-app).
 require("../shared/index").runAllTests();
 


### PR DESCRIPTION
## Problem

Worker threads run a bare `CFRunLoopRun()` with no autorelease pool management. Autoreleased ObjC objects created while executing JS on a worker (marshalled method returns, framework-internal temporaries, call-scoped block copies) accumulate in the thread's implicit bottom pool and only drain when the worker dies — the backing `NSOperation`'s pool is the only drain point. That is a memory leak proportional to worker lifetime and native-call volume. The main thread does not have this problem because UIKit installs run-loop observers that drain a pool once per loop pass.

## Fix

Scope pools to the runtime's own callouts instead of to run-loop passes:

- `EventLoop`'s `RunGuarded` wraps each non-bare work unit in `@autoreleasepool` — this covers both scheduler lanes (timers/`setTimeout`, posted internal work, V8 platform tasks), which is where worker JS executes. Bare entries stay unwrapped: they may `@throw` on purpose, and an ObjC unwind must not cross a pool this code owns. On the main thread this only tightens drain latency (callout-end instead of UIKit's pass-end); the lifetime contract — an autoreleased object lives at least to the end of the current callout — is unchanged on both threads.
- The worker's message-drain source callout wraps `DrainPendingTasks()` in `@autoreleasepool`.
- An explicit `@autoreleasepool` around the worker boot phase (isolate creation + entry-script evaluation + first message drain), which runs before `CFRunLoopRun()`.
- An explicit `@autoreleasepool` around worker teardown (`DestroyInspector()` + `delete runtime`), so teardown garbage dies deterministically instead of whenever the operation's pool drains.

### Why not a UIKit-style run-loop observer?

Two observer designs (single pool with drain-per-pass; one pool per run-loop nesting level, UIKit's scheme) were tried first and both abort with `AutoreleasePoolPage::badPop` under the HTTP-ESM loader tests: worker module loading pumps nested `CFRunLoopRunInMode` from inside callouts whose async machinery interleaves its own pool lifetimes across callouts, so an observer-owned token can be cut out from under the observer by a pool it does not control. A pool that is pushed and popped strictly inside a single callout cannot be interleaved with by construction — and per-callout `@autoreleasepool` at entry points is already this codebase's established pattern (`ModuleInternalCallbacks`, `InteropTypes`, `AnimationFrame`, `HttpLoader`).

Known limitation: callouts the runtime does not own (e.g. a notification block delivered directly to the worker loop) still autorelease into the bottom pool. All JS execution and marshalling paths are covered.

## Test

`TestRunner/app/tests/WorkerAutoreleasePoolTests.js` + `autoreleasePoolDrainWorker.js`: the worker autoreleases a `TNSAllocLog` instance (new `+autoreleaseInstance` fixture method — `CFAutorelease(CFBridgingRetain(...))`, so the pool holds the only reference and no JS wrapper retain is involved) inside one timer callout and reports `TNSGetOutput()` from the next. The dealloc log can only be present in between if the pool drained between the callouts; without the fix it appears only at worker death, after the report is sent.

Full suite: green (Debug, simulator).
