### PR TITLE
feat(runtime): serialize DOMException per Web IDL [Serializable]

### DIFF
--- a/NativeScript/runtime/LazyGlobals.cpp
+++ b/NativeScript/runtime/LazyGlobals.cpp
@@ -3,6 +3,7 @@
 #include "Base64.h"
 #include "BuiltinLoader.h"
 #include "Helpers.h"
+#include "StructuredSerialization.h"
 #include "TextEncoding.h"
 
 using namespace v8;
@@ -34,7 +35,7 @@ constexpr LazyGlobalEntry kLazyGlobals[] = {
     {"TextDecoder", "TextDecoder", TextEncoding::GetExports},
     {"atob", "atob", Base64::GetExports},
     {"btoa", "btoa", Base64::GetExports},
-    {"DOMException", "DOMException", BuiltinExports<BuiltinId::kDomException>},
+    {"DOMException", "DOMException", serialization::GetDomExceptionExports},
     // events.js is an eager builtin (Events::Init), so this row never runs a
     // file: the read hits the exports cache and only the placement is lazy.
     {"CustomEvent", "CustomEvent", BuiltinExports<BuiltinId::kEvents>},

--- a/NativeScript/runtime/NsBuiltinModules.cpp
+++ b/NativeScript/runtime/NsBuiltinModules.cpp
@@ -8,6 +8,7 @@
 #include "Helpers.h"
 #include "ModuleInternalCallbacks.h"
 #include "Runtime.h"
+#include "StructuredSerialization.h"
 #include "TextEncoding.h"
 
 using namespace v8;
@@ -47,7 +48,8 @@ constexpr Registration kRegistry[] = {
     {"node:module", BuiltinId::kNodeModule, nullptr},
     {"node:url", BuiltinId::kNodeUrl, nullptr},
     {"node:util", BuiltinId::kNodeUtil, nullptr},
-    {"internal/dom-exception", BuiltinId::kDomException, nullptr, true},
+    {"internal/dom-exception", BuiltinId::kDomException,
+     serialization::DomExceptionBinding, true},
     {"internal/events", BuiltinId::kEvents, nullptr, true},
 };
 

--- a/NativeScript/runtime/StructuredSerialization.cpp
+++ b/NativeScript/runtime/StructuredSerialization.cpp
@@ -1,6 +1,7 @@
 #include "StructuredSerialization.h"
 
 #include "BuiltinLoader.h"
+#include "Caches.h"
 #include "Helpers.h"
 #include "NativeScriptException.h"
 
@@ -8,6 +9,67 @@ using namespace v8;
 
 namespace tns {
 namespace serialization {
+
+namespace {
+
+// The private symbol markCloneable stamps on every DOMException instance.
+// Private, so app code can neither forge the brand onto an impostor nor strip
+// it; per isolate because a worker's instances are branded and checked on its
+// own isolate, and only bytes cross between them.
+struct DomExceptionBrandState {
+  Persistent<Private> brand;
+};
+
+// Empty once teardown has begun — callers bail to their fallback.
+Local<Private> DomExceptionBrand(Isolate* isolate) {
+  auto* state = Caches::StateFor<DomExceptionBrandState>(isolate);
+  if (state == nullptr) {
+    return Local<Private>();
+  }
+  if (state->brand.IsEmpty()) {
+    state->brand.Reset(
+        isolate, Private::New(isolate, tns::ToV8String(
+                                           isolate, "domExceptionCloneable")));
+  }
+  return state->brand.Get(isolate);
+}
+
+void MarkCloneableCallback(const FunctionCallbackInfo<Value>& info) {
+  Isolate* isolate = info.GetIsolate();
+  if (info.Length() < 1 || !info[0]->IsObject()) {
+    return;
+  }
+  Local<Private> brand = DomExceptionBrand(isolate);
+  if (brand.IsEmpty()) {
+    return;
+  }
+  info[0]
+      .As<Object>()
+      ->SetPrivate(isolate->GetCurrentContext(), brand, v8::True(isolate))
+      .FromMaybe(false);
+}
+
+}  // namespace
+
+MaybeLocal<Object> DomExceptionBinding(Local<Context> context) {
+  Isolate* isolate = v8::Isolate::GetCurrent();
+  Local<Object> binding = Object::New(isolate);
+  Local<v8::Function> markCloneable;
+  if (!v8::Function::New(context, MarkCloneableCallback)
+           .ToLocal(&markCloneable) ||
+      !binding
+           ->Set(context, tns::ToV8String(isolate, "markCloneable"),
+                 markCloneable)
+           .FromMaybe(false)) {
+    return MaybeLocal<Object>();
+  }
+  return binding;
+}
+
+MaybeLocal<Object> GetDomExceptionExports(Local<Context> context) {
+  return BuiltinLoader::GetExports(context, BuiltinId::kDomException,
+                                   DomExceptionBinding);
+}
 
 void ThrowDataCloneError(Isolate* isolate, const std::string& message) {
   // The spec's DataCloneError is a DOMException; build it through the
@@ -21,8 +83,7 @@ void ThrowDataCloneError(Isolate* isolate, const std::string& message) {
     Local<Context> context = isolate->GetCurrentContext();
     Local<Object> exports;
     Local<Value> ctor;
-    if (BuiltinLoader::GetExports(context, BuiltinId::kDomException, nullptr)
-            .ToLocal(&exports) &&
+    if (GetDomExceptionExports(context).ToLocal(&exports) &&
         exports->Get(context, tns::ToV8String(isolate, "DOMException"))
             .ToLocal(&ctor) &&
         ctor->IsFunction()) {
@@ -46,24 +107,65 @@ void ThrowDataCloneError(Isolate* isolate, const std::string& message) {
 
 namespace {
 
+// Every host object's payload starts with one of these, so the reader can
+// dispatch. kHostObjectDegraded carries nothing further;
+// kHostObjectDomException carries a uint32 index into the SerializedValue's
+// out-of-band payload list. The bytes never outlive the process
+// (structuredClone round-trips in one isolate, worker messages cross isolates
+// in the same binary), so the format can evolve freely with this file.
+constexpr uint32_t kHostObjectDegraded = 0;
+constexpr uint32_t kHostObjectDomException = 1;
+
 class SerializerDelegate : public ValueSerializer::Delegate {
  public:
-  SerializerDelegate(Isolate* isolate, HostObjectPolicy hostObjectPolicy,
-                     std::vector<std::shared_ptr<BackingStore>>* sharedBuffers)
+  SerializerDelegate(
+      Isolate* isolate, HostObjectPolicy hostObjectPolicy,
+      std::vector<std::shared_ptr<BackingStore>>* sharedBuffers,
+      std::vector<SerializedValue::DomExceptionPayload>* domExceptions)
       : isolate_(isolate),
         hostObjectPolicy_(hostObjectPolicy),
-        sharedBuffers_(sharedBuffers) {}
+        sharedBuffers_(sharedBuffers),
+        domExceptions_(domExceptions) {}
+
+  void SetSerializer(ValueSerializer* serializer) { serializer_ = serializer; }
 
   void ThrowDataCloneError(Local<v8::String> message) override {
     serialization::ThrowDataCloneError(isolate_,
                                        tns::ToString(isolate_, message));
   }
 
+  // With this returning true, V8 asks IsHostObject about every plain JS
+  // object in the graph — the cost of claiming a plain-JS class as a host
+  // object is one private-symbol lookup per object (Node pays the same for
+  // its JSTransferable protocol).
+  bool HasCustomHostObject(Isolate* isolate) override { return true; }
+
+  Maybe<bool> IsHostObject(Isolate* isolate, Local<Object> object) override {
+    // Only branded DOMException instances are claimed; native-backed wrappers
+    // keep reaching WriteHostObject through V8's embedder-field detection.
+    Local<Private> brand = DomExceptionBrand(isolate);
+    if (brand.IsEmpty()) {
+      return Just(false);
+    }
+    return object->HasPrivate(isolate->GetCurrentContext(), brand);
+  }
+
   Maybe<bool> WriteHostObject(Isolate* isolate, Local<Object> object) override {
+    // DOMException serializes under both policies: it is [Serializable] in
+    // the IDL, and it is a plain JS object with no native half to lose.
+    Local<Private> brand = DomExceptionBrand(isolate);
+    bool isDomException = false;
+    if (!brand.IsEmpty() &&
+        !object->HasPrivate(isolate->GetCurrentContext(), brand)
+             .To(&isDomException)) {
+      return Nothing<bool>();
+    }
+    if (isDomException) {
+      return WriteDomException(isolate, object);
+    }
     if (hostObjectPolicy_ == HostObjectPolicy::kDegrade) {
-      // V8 has already written the kHostObject tag; writing no payload is what
-      // the zero-byte ReadHostObject below expects, and the value surfaces as
-      // an empty object.
+      // Tag only, no payload: the value surfaces as an empty object.
+      serializer_->WriteUint32(kHostObjectDegraded);
       return Just(true);
     }
     std::string name = tns::ToString(isolate, object->GetConstructorName());
@@ -98,21 +200,78 @@ class SerializerDelegate : public ValueSerializer::Delegate {
   }
 
  private:
+  // Web IDL's DOMException serialization steps (name and message), plus the
+  // stack, matching Node. The payload travels out-of-band and only an index
+  // enters the stream: the receiving side must construct instances before
+  // ReadValue runs, because V8 forbids JS execution during deserialization.
+  Maybe<bool> WriteDomException(Isolate* isolate, Local<Object> object) {
+    Local<Context> context = isolate->GetCurrentContext();
+    Local<Value> name, message, stack;
+    if (!object->Get(context, tns::ToV8String(isolate, "name"))
+             .ToLocal(&name) ||
+        !object->Get(context, tns::ToV8String(isolate, "message"))
+             .ToLocal(&message) ||
+        !object->Get(context, tns::ToV8String(isolate, "stack"))
+             .ToLocal(&stack)) {
+      return Nothing<bool>();
+    }
+    SerializedValue::DomExceptionPayload payload;
+    payload.name = tns::ToString(isolate, name);
+    payload.message = tns::ToString(isolate, message);
+    // The stack can legitimately be absent or tampered into a non-string;
+    // carry it only when it is the string captureStackTrace left.
+    payload.hasStack = stack->IsString();
+    if (payload.hasStack) {
+      payload.stack = tns::ToString(isolate, stack);
+    }
+    serializer_->WriteUint32(kHostObjectDomException);
+    serializer_->WriteUint32(static_cast<uint32_t>(domExceptions_->size()));
+    domExceptions_->push_back(std::move(payload));
+    return Just(true);
+  }
+
   Isolate* isolate_;
   HostObjectPolicy hostObjectPolicy_;
   std::vector<std::shared_ptr<BackingStore>>* sharedBuffers_;
+  std::vector<SerializedValue::DomExceptionPayload>* domExceptions_;
+  ValueSerializer* serializer_ = nullptr;
 };
 
 class DeserializerDelegate : public ValueDeserializer::Delegate {
  public:
-  explicit DeserializerDelegate(
-      const std::vector<Local<SharedArrayBuffer>>* sharedBuffers)
-      : sharedBuffers_(sharedBuffers) {}
+  DeserializerDelegate(
+      const std::vector<Local<SharedArrayBuffer>>* sharedBuffers,
+      const std::vector<Local<Object>>* domExceptions)
+      : sharedBuffers_(sharedBuffers), domExceptions_(domExceptions) {}
 
-  // Counterpart of the kDegrade branch: consumes no bytes, so the stream stays
-  // balanced. Unreachable for a value written under kReject.
+  void SetDeserializer(ValueDeserializer* deserializer) {
+    deserializer_ = deserializer;
+  }
+
+  // No JS may run in here (V8 forbids it during a read); DOMException
+  // instances were constructed by Deserialize before ReadValue started, and
+  // this only hands them out.
   MaybeLocal<Object> ReadHostObject(Isolate* isolate) override {
-    return Object::New(isolate);
+    uint32_t tag;
+    if (!deserializer_->ReadUint32(&tag)) {
+      return MaybeLocal<Object>();
+    }
+    switch (tag) {
+      case kHostObjectDegraded:
+        // Counterpart of the kDegrade branch: tag only, so the value arrives
+        // as an empty object. Unreachable for a value written under kReject.
+        return Object::New(isolate);
+      case kHostObjectDomException: {
+        uint32_t index;
+        if (!deserializer_->ReadUint32(&index) ||
+            index >= domExceptions_->size()) {
+          return MaybeLocal<Object>();
+        }
+        return (*domExceptions_)[index];
+      }
+      default:
+        return MaybeLocal<Object>();
+    }
   }
 
   MaybeLocal<SharedArrayBuffer> GetSharedArrayBufferFromId(
@@ -125,6 +284,8 @@ class DeserializerDelegate : public ValueDeserializer::Delegate {
 
  private:
   const std::vector<Local<SharedArrayBuffer>>* sharedBuffers_;
+  const std::vector<Local<Object>>* domExceptions_;
+  ValueDeserializer* deserializer_ = nullptr;
 };
 
 // Validates the transfer list and collects it in registration order. The
@@ -193,8 +354,10 @@ Maybe<bool> SerializedValue::Serialize(Isolate* isolate, Local<Context> context,
     return Nothing<bool>();
   }
 
-  SerializerDelegate delegate(isolate, hostObjectPolicy, &sharedBuffers_);
+  SerializerDelegate delegate(isolate, hostObjectPolicy, &sharedBuffers_,
+                              &domExceptions_);
   ValueSerializer serializer(isolate, &delegate);
+  delegate.SetSerializer(&serializer);
   for (size_t i = 0; i < transfers.size(); i++) {
     serializer.TransferArrayBuffer(static_cast<uint32_t>(i), transfers[i]);
   }
@@ -243,9 +406,47 @@ MaybeLocal<Value> SerializedValue::Deserialize(Isolate* isolate,
     sharedBuffers.push_back(SharedArrayBuffer::New(isolate, backingStore));
   }
 
-  DeserializerDelegate delegate(&sharedBuffers);
+  // Construct every DOMException the payload names before the read begins:
+  // JS is allowed here and forbidden inside ReadHostObject. Construction goes
+  // through the real constructor — on a worker isolate that never touched
+  // DOMException this runs the builtin on demand — so each instance is
+  // branded again and re-serializes on the next hop.
+  std::vector<Local<Object>> domExceptions;
+  if (!domExceptions_.empty()) {
+    Local<Object> exports;
+    Local<Value> ctor;
+    if (!GetDomExceptionExports(context).ToLocal(&exports) ||
+        !exports->Get(context, tns::ToV8String(isolate, "DOMException"))
+             .ToLocal(&ctor) ||
+        !ctor->IsFunction()) {
+      return MaybeLocal<Value>();
+    }
+    Local<v8::String> stackKey = tns::ToV8String(isolate, "stack");
+    for (const DomExceptionPayload& payload : domExceptions_) {
+      Local<Value> args[] = {tns::ToV8String(isolate, payload.message),
+                             tns::ToV8String(isolate, payload.name)};
+      Local<Object> exception;
+      if (!ctor.As<v8::Function>()
+               ->NewInstance(context, 2, args)
+               .ToLocal(&exception)) {
+        return MaybeLocal<Value>();
+      }
+      // The sender's stack replaces the one captured just now for the
+      // receiving side's constructor frame, matching Node.
+      if (payload.hasStack &&
+          !exception
+               ->Set(context, stackKey, tns::ToV8String(isolate, payload.stack))
+               .FromMaybe(false)) {
+        return MaybeLocal<Value>();
+      }
+      domExceptions.push_back(exception);
+    }
+  }
+
+  DeserializerDelegate delegate(&sharedBuffers, &domExceptions);
   ValueDeserializer deserializer(isolate, buffer_.get(), bufferSize_,
                                  &delegate);
+  delegate.SetDeserializer(&deserializer);
 
   for (size_t i = 0; i < transferredBuffers_.size(); i++) {
     deserializer.TransferArrayBuffer(

--- a/NativeScript/runtime/StructuredSerialization.cpp
+++ b/NativeScript/runtime/StructuredSerialization.cpp
@@ -15,9 +15,17 @@ namespace {
 // The private symbol markCloneable stamps on every DOMException instance.
 // Private, so app code can neither forge the brand onto an impostor nor strip
 // it; per isolate because a worker's instances are branded and checked on its
-// own isolate, and only bytes cross between them.
+// own isolate, and only bytes cross between them. `anyInstances` flips when
+// the first instance is branded and gates HasCustomHostObject: claiming host
+// objects makes V8 consult IsHostObject for every plain JS object in a
+// serialized graph (~25ns each, ~+12% on an object-heavy clone), and an
+// isolate that never constructed a DOMException cannot be holding one, so it
+// keeps serializing on the exact pre-claim path. Every instance passes
+// through markCloneable — deserialization rebuilds via the constructor — so
+// the flag cannot miss one.
 struct DomExceptionBrandState {
   Persistent<Private> brand;
+  bool anyInstances = false;
 };
 
 // Empty once teardown has begun — callers bail to their fallback.
@@ -34,6 +42,11 @@ Local<Private> DomExceptionBrand(Isolate* isolate) {
   return state->brand.Get(isolate);
 }
 
+bool AnyDomExceptionInstances(Isolate* isolate) {
+  auto* state = Caches::StateFor<DomExceptionBrandState>(isolate);
+  return state != nullptr && state->anyInstances;
+}
+
 void MarkCloneableCallback(const FunctionCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();
   if (info.Length() < 1 || !info[0]->IsObject()) {
@@ -43,10 +56,12 @@ void MarkCloneableCallback(const FunctionCallbackInfo<Value>& info) {
   if (brand.IsEmpty()) {
     return;
   }
-  info[0]
-      .As<Object>()
-      ->SetPrivate(isolate->GetCurrentContext(), brand, v8::True(isolate))
-      .FromMaybe(false);
+  if (info[0]
+          .As<Object>()
+          ->SetPrivate(isolate->GetCurrentContext(), brand, v8::True(isolate))
+          .FromMaybe(false)) {
+    Caches::StateFor<DomExceptionBrandState>(isolate)->anyInstances = true;
+  }
 }
 
 }  // namespace
@@ -137,8 +152,16 @@ class SerializerDelegate : public ValueSerializer::Delegate {
   // With this returning true, V8 asks IsHostObject about every plain JS
   // object in the graph — the cost of claiming a plain-JS class as a host
   // object is one private-symbol lookup per object (Node pays the same for
-  // its JSTransferable protocol).
-  bool HasCustomHostObject(Isolate* isolate) override { return true; }
+  // its JSTransferable protocol). Claimed only once this isolate has actually
+  // constructed a DOMException; until then serialization runs the pre-claim
+  // path untouched. V8 samples this once per ValueSerializer. Accepted edge:
+  // a getter invoked during this very clone could construct the isolate's
+  // FIRST DOMException and return it into the graph after a false sample —
+  // that one instance degrades to a plain object (the pre-feature behavior)
+  // instead of cloning; every later serialization sees the flag.
+  bool HasCustomHostObject(Isolate* isolate) override {
+    return AnyDomExceptionInstances(isolate);
+  }
 
   Maybe<bool> IsHostObject(Isolate* isolate, Local<Object> object) override {
     // Only branded DOMException instances are claimed; native-backed wrappers

--- a/NativeScript/runtime/StructuredSerialization.cpp
+++ b/NativeScript/runtime/StructuredSerialization.cpp
@@ -28,18 +28,22 @@ struct DomExceptionBrandState {
   bool anyInstances = false;
 };
 
-// Empty once teardown has begun — callers bail to their fallback.
-Local<Private> DomExceptionBrand(Isolate* isolate) {
-  auto* state = Caches::StateFor<DomExceptionBrandState>(isolate);
-  if (state == nullptr) {
-    return Local<Private>();
-  }
+Local<Private> BrandOf(Isolate* isolate, DomExceptionBrandState* state) {
   if (state->brand.IsEmpty()) {
     state->brand.Reset(
         isolate, Private::New(isolate, tns::ToV8String(
                                            isolate, "domExceptionCloneable")));
   }
   return state->brand.Get(isolate);
+}
+
+// Empty once teardown has begun — callers bail to their fallback.
+Local<Private> DomExceptionBrand(Isolate* isolate) {
+  auto* state = Caches::StateFor<DomExceptionBrandState>(isolate);
+  if (state == nullptr) {
+    return Local<Private>();
+  }
+  return BrandOf(isolate, state);
 }
 
 bool AnyDomExceptionInstances(Isolate* isolate) {
@@ -52,15 +56,16 @@ void MarkCloneableCallback(const FunctionCallbackInfo<Value>& info) {
   if (info.Length() < 1 || !info[0]->IsObject()) {
     return;
   }
-  Local<Private> brand = DomExceptionBrand(isolate);
-  if (brand.IsEmpty()) {
+  auto* state = Caches::StateFor<DomExceptionBrandState>(isolate);
+  if (state == nullptr) {
     return;
   }
+  Local<Private> brand = BrandOf(isolate, state);
   if (info[0]
           .As<Object>()
           ->SetPrivate(isolate->GetCurrentContext(), brand, v8::True(isolate))
           .FromMaybe(false)) {
-    Caches::StateFor<DomExceptionBrandState>(isolate)->anyInstances = true;
+    state->anyInstances = true;
   }
 }
 
@@ -164,8 +169,13 @@ class SerializerDelegate : public ValueSerializer::Delegate {
   }
 
   Maybe<bool> IsHostObject(Isolate* isolate, Local<Object> object) override {
-    // Only branded DOMException instances are claimed; native-backed wrappers
-    // keep reaching WriteHostObject through V8's embedder-field detection.
+    // Claiming custom host objects REPLACES V8's own embedder-field detection
+    // rather than adding to it, so anything with a native half has to be
+    // claimed here too — otherwise an ObjC wrapper would be written out as a
+    // plain object, silently losing the half that mattered.
+    if (object->InternalFieldCount() > 0) {
+      return Just(true);
+    }
     Local<Private> brand = DomExceptionBrand(isolate);
     if (brand.IsEmpty()) {
       return Just(false);

--- a/NativeScript/runtime/StructuredSerialization.cpp
+++ b/NativeScript/runtime/StructuredSerialization.cpp
@@ -145,7 +145,8 @@ class SerializerDelegate : public ValueSerializer::Delegate {
       : isolate_(isolate),
         hostObjectPolicy_(hostObjectPolicy),
         sharedBuffers_(sharedBuffers),
-        domExceptions_(domExceptions) {}
+        domExceptions_(domExceptions),
+        domExceptionBrand_(DomExceptionBrand(isolate)) {}
 
   void SetSerializer(ValueSerializer* serializer) { serializer_ = serializer; }
 
@@ -176,20 +177,18 @@ class SerializerDelegate : public ValueSerializer::Delegate {
     if (object->InternalFieldCount() > 0) {
       return Just(true);
     }
-    Local<Private> brand = DomExceptionBrand(isolate);
-    if (brand.IsEmpty()) {
+    if (domExceptionBrand_.IsEmpty()) {
       return Just(false);
     }
-    return object->HasPrivate(isolate->GetCurrentContext(), brand);
+    return object->HasPrivate(isolate->GetCurrentContext(), domExceptionBrand_);
   }
 
   Maybe<bool> WriteHostObject(Isolate* isolate, Local<Object> object) override {
     // DOMException serializes under both policies: it is [Serializable] in
     // the IDL, and it is a plain JS object with no native half to lose.
-    Local<Private> brand = DomExceptionBrand(isolate);
     bool isDomException = false;
-    if (!brand.IsEmpty() &&
-        !object->HasPrivate(isolate->GetCurrentContext(), brand)
+    if (!domExceptionBrand_.IsEmpty() &&
+        !object->HasPrivate(isolate->GetCurrentContext(), domExceptionBrand_)
              .To(&isDomException)) {
       return Nothing<bool>();
     }
@@ -267,6 +266,10 @@ class SerializerDelegate : public ValueSerializer::Delegate {
   HostObjectPolicy hostObjectPolicy_;
   std::vector<std::shared_ptr<BackingStore>>* sharedBuffers_;
   std::vector<SerializedValue::DomExceptionPayload>* domExceptions_;
+  // Resolved once per serializer: V8 asks about every object in the graph,
+  // and each lookup would otherwise re-resolve the state slot and push a
+  // fresh handle into the caller's scope.
+  Local<Private> domExceptionBrand_;
   ValueSerializer* serializer_ = nullptr;
 };
 
@@ -452,6 +455,12 @@ MaybeLocal<Value> SerializedValue::Deserialize(Isolate* isolate,
         !exports->Get(context, tns::ToV8String(isolate, "DOMException"))
              .ToLocal(&ctor) ||
         !ctor->IsFunction()) {
+      // Only reached with nothing pending (a builtin that cannot load during
+      // teardown); the caller must see a failure, not an undefined result.
+      if (!isolate->HasPendingException()) {
+        ThrowDataCloneError(
+            isolate, "DOMException could not be rebuilt on this isolate.");
+      }
       return MaybeLocal<Value>();
     }
     Local<v8::String> stackKey = tns::ToV8String(isolate, "stack");

--- a/NativeScript/runtime/StructuredSerialization.cpp
+++ b/NativeScript/runtime/StructuredSerialization.cpp
@@ -15,17 +15,10 @@ namespace {
 // The private symbol markCloneable stamps on every DOMException instance.
 // Private, so app code can neither forge the brand onto an impostor nor strip
 // it; per isolate because a worker's instances are branded and checked on its
-// own isolate, and only bytes cross between them. `anyInstances` flips when
-// the first instance is branded and gates HasCustomHostObject: claiming host
-// objects makes V8 consult IsHostObject for every plain JS object in a
-// serialized graph (~25ns each, ~+12% on an object-heavy clone), and an
-// isolate that never constructed a DOMException cannot be holding one, so it
-// keeps serializing on the exact pre-claim path. Every instance passes
-// through markCloneable — deserialization rebuilds via the constructor — so
-// the flag cannot miss one.
+// own isolate, and only bytes cross between them. Every instance passes
+// through markCloneable — deserialization rebuilds via the constructor.
 struct DomExceptionBrandState {
   Persistent<Private> brand;
-  bool anyInstances = false;
 };
 
 Local<Private> BrandOf(Isolate* isolate, DomExceptionBrandState* state) {
@@ -46,11 +39,6 @@ Local<Private> DomExceptionBrand(Isolate* isolate) {
   return BrandOf(isolate, state);
 }
 
-bool AnyDomExceptionInstances(Isolate* isolate) {
-  auto* state = Caches::StateFor<DomExceptionBrandState>(isolate);
-  return state != nullptr && state->anyInstances;
-}
-
 void MarkCloneableCallback(const FunctionCallbackInfo<Value>& info) {
   Isolate* isolate = info.GetIsolate();
   if (info.Length() < 1 || !info[0]->IsObject()) {
@@ -61,12 +49,8 @@ void MarkCloneableCallback(const FunctionCallbackInfo<Value>& info) {
     return;
   }
   Local<Private> brand = BrandOf(isolate, state);
-  if (info[0]
-          .As<Object>()
-          ->SetPrivate(isolate->GetCurrentContext(), brand, v8::True(isolate))
-          .FromMaybe(false)) {
-    state->anyInstances = true;
-  }
+  (void)info[0].As<Object>()->SetPrivate(isolate->GetCurrentContext(), brand,
+                                         v8::True(isolate));
 }
 
 }  // namespace
@@ -155,19 +139,13 @@ class SerializerDelegate : public ValueSerializer::Delegate {
                                        tns::ToString(isolate_, message));
   }
 
-  // With this returning true, V8 asks IsHostObject about every plain JS
-  // object in the graph — the cost of claiming a plain-JS class as a host
-  // object is one private-symbol lookup per object (Node pays the same for
-  // its JSTransferable protocol). Claimed only once this isolate has actually
-  // constructed a DOMException; until then serialization runs the pre-claim
-  // path untouched. V8 samples this once per ValueSerializer. Accepted edge:
-  // a getter invoked during this very clone could construct the isolate's
-  // FIRST DOMException and return it into the graph after a false sample —
-  // that one instance degrades to a plain object (the pre-feature behavior)
-  // instead of cloning; every later serialization sees the flag.
-  bool HasCustomHostObject(Isolate* isolate) override {
-    return AnyDomExceptionInstances(isolate);
-  }
+  // Always claimed: V8 samples this once per ValueSerializer and never again,
+  // so a gate on "this isolate holds a DOMException" would miss the isolate's
+  // first instance when a getter constructs it during the very clone that
+  // carries it. The price is one IsHostObject call per plain JS object in a
+  // graph (~10ns, ~7% on a 400k-object clone), the same Node pays for its
+  // JSTransferable protocol.
+  bool HasCustomHostObject(Isolate* isolate) override { return true; }
 
   Maybe<bool> IsHostObject(Isolate* isolate, Local<Object> object) override {
     // Claiming custom host objects REPLACES V8's own embedder-field detection

--- a/NativeScript/runtime/StructuredSerialization.h
+++ b/NativeScript/runtime/StructuredSerialization.h
@@ -31,6 +31,20 @@ enum class HostObjectPolicy {
 // carrying that name when the dom-exception builtin cannot run.
 void ThrowDataCloneError(v8::Isolate* isolate, const std::string& message);
 
+// The dom-exception builtin's native half: `markCloneable`, which stamps a
+// per-isolate private brand on every instance the constructor makes. The
+// brand is what the serialization delegates answer IsHostObject from, so
+// DOMException travels through structuredClone and worker postMessage
+// (Web IDL [Serializable]). Lives here, next to those delegates.
+v8::MaybeLocal<v8::Object> DomExceptionBinding(v8::Local<v8::Context> context);
+
+// The dom-exception builtin's exports with its binding attached. GetExports
+// consults the factory only on the run that populates the cache, so every
+// call site for this builtin must go through here — a site passing a
+// different factory would win or lose by init order.
+v8::MaybeLocal<v8::Object> GetDomExceptionExports(
+    v8::Local<v8::Context> context);
+
 // A value serialized out of one isolate, plus the memory that travels with it.
 // Serializing and deserializing are separate halves because a worker message is
 // read back on a different isolate than it was written on, while
@@ -58,6 +72,18 @@ class SerializedValue {
   v8::MaybeLocal<v8::Value> Deserialize(v8::Isolate* isolate,
                                         v8::Local<v8::Context> context);
 
+  // Web IDL's DOMException serialization steps (name, message) plus the
+  // stack, matching Node. Kept out-of-band because V8 forbids JS while a
+  // value is being read: Deserialize constructs every instance up front and
+  // ReadHostObject only hands them out by index (Node's host_objects_
+  // design).
+  struct DomExceptionPayload {
+    std::string name;
+    std::string message;
+    std::string stack;
+    bool hasStack = false;
+  };
+
  private:
   struct FreeDeleter {
     void operator()(void* pointer) const { std::free(pointer); }
@@ -72,6 +98,9 @@ class SerializedValue {
   std::vector<std::shared_ptr<v8::BackingStore>> transferredBuffers_;
   // Backing stores shared with — not moved from — the sending isolate.
   std::vector<std::shared_ptr<v8::BackingStore>> sharedBuffers_;
+  // One entry per distinct DOMException in the graph, in write order (a
+  // repeated reference is an object id in the stream, not a second entry).
+  std::vector<DomExceptionPayload> domExceptions_;
 };
 
 }  // namespace serialization

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -692,10 +692,17 @@ void Worker::OnMessageCallback(Isolate* isolate, Local<Value> receiver,
   Local<Value> result;
 
   Local<Value> arg;
-  //    TryCatch tc(isolate);
-  if (!message->Deserialize(isolate, context).ToLocal(&arg)) {
-    //        tc.ReThrow();
-    return;
+  {
+    // Reading runs JS (a DOMException is rebuilt through its constructor), so
+    // a failure here must not stay pending on the isolate past this callout.
+    TryCatch tc(isolate);
+    if (!message->Deserialize(isolate, context).ToLocal(&arg)) {
+      if (!tc.HasTerminated() && tc.HasCaught()) {
+        Log(@"Worker message could not be read: %s",
+            tns::ToString(isolate, tc.Exception()).c_str());
+      }
+      return;
+    }
   }
 
   Local<Value> args[1]{arg};

--- a/NativeScript/runtime/js/dom-exception.js
+++ b/NativeScript/runtime/js/dom-exception.js
@@ -9,10 +9,11 @@
 // constructor through require("internal/dom-exception") at throw time, so
 // this file never runs in an app that never touches a DOMException.
 //
-// Not implemented: the spec's [Serializable] slot. structuredClone and worker
-// postMessage go through v8::ValueSerializer, which has no hook for a plain
-// JS class, so a DOMException inside a cloned graph degrades the same way any
-// custom Error subclass does.
+// [Serializable]: the constructor stamps every instance with a native private
+// brand (binding.markCloneable), which the serialization delegates in
+// StructuredSerialization.cpp claim through V8's IsHostObject hook — name,
+// message and stack travel across structuredClone and worker postMessage,
+// Node's JSTransferable approach reduced to the one class.
 const {
   ErrorCaptureStackTrace,
   ErrorPrototype,
@@ -20,6 +21,8 @@ const {
   ObjectSetPrototypeOf,
   SymbolToStringTag,
 } = primordials;
+
+const { markCloneable } = binding;
 
 // Web IDL §4.3.4: the closed table of names with a legacy code. Any name
 // outside it — including every post-table spec name — has code 0.
@@ -62,6 +65,7 @@ class DOMException {
     this.#message = `${message}`;
     this.#name = `${name}`;
     ErrorCaptureStackTrace(this, DOMException);
+    markCloneable(this);
   }
 
   get name() {

--- a/TestRunner/app/tests/RuntimeImplementedAPIs.js
+++ b/TestRunner/app/tests/RuntimeImplementedAPIs.js
@@ -81,6 +81,12 @@ describe("DOMException canary", () => {
   it("is not reachable as a module from app code", () => {
     expect(() => require("internal/dom-exception")).toThrow();
   });
+
+  it("serializes through structuredClone on this runtime", () => {
+    const clone = structuredClone(new DOMException("x", "AbortError"));
+    expect(clone instanceof DOMException).toBe(true);
+    expect(clone.name).toBe("AbortError");
+  });
 });
 
 describe("CustomEvent canary", () => {

--- a/TestRunner/app/tests/RuntimeImplementedAPIs.js
+++ b/TestRunner/app/tests/RuntimeImplementedAPIs.js
@@ -92,6 +92,23 @@ describe("DOMException canary", () => {
   // itself, and V8 then stops detecting native wrappers on its own. Wrappers
   // constructed with `new` carry no interceptors, unlike alloc().init() ones,
   // so they are the shape that would silently clone as {} if the claim missed.
+  it("clones the isolate's first DOMException even when a getter creates it mid-clone", (done) => {
+    const worker = new Worker("./domExceptionFirstCloneWorker.js");
+    worker.onmessage = (event) => {
+      expect(event.data.isDomException).toBe(true);
+      expect(event.data.name).toBe("AbortError");
+      expect(event.data.message).toBe("first in this isolate");
+      worker.terminate();
+      done();
+    };
+    worker.onerror = (event) => {
+      fail("worker error: " + event.message);
+      worker.terminate();
+      done();
+      return true;
+    };
+  });
+
   it("still rejects native wrappers once a DOMException exists", () => {
     new DOMException("x", "AbortError");
     for (const wrapper of [new NSObject(), new URL("https://example.com/")]) {

--- a/TestRunner/app/tests/RuntimeImplementedAPIs.js
+++ b/TestRunner/app/tests/RuntimeImplementedAPIs.js
@@ -87,6 +87,24 @@ describe("DOMException canary", () => {
     expect(clone instanceof DOMException).toBe(true);
     expect(clone.name).toBe("AbortError");
   });
+
+  // Once an isolate holds a DOMException the serializer claims host objects
+  // itself, and V8 then stops detecting native wrappers on its own. Wrappers
+  // constructed with `new` carry no interceptors, unlike alloc().init() ones,
+  // so they are the shape that would silently clone as {} if the claim missed.
+  it("still rejects native wrappers once a DOMException exists", () => {
+    new DOMException("x", "AbortError");
+    for (const wrapper of [new NSObject(), new URL("https://example.com/")]) {
+      let error;
+      try {
+        structuredClone(wrapper);
+      } catch (e) {
+        error = e;
+      }
+      expect(error instanceof DOMException).toBe(true);
+      expect(error.name).toBe("DataCloneError");
+    }
+  });
 });
 
 describe("CustomEvent canary", () => {

--- a/TestRunner/app/tests/domExceptionFirstCloneWorker.js
+++ b/TestRunner/app/tests/domExceptionFirstCloneWorker.js
@@ -1,0 +1,14 @@
+// A fresh isolate: the DOMException constructed inside the getter below is
+// the first one this isolate has ever seen, and it is born while the clone
+// that carries it is already being written.
+var graph = {
+    get inner() {
+        return new DOMException("first in this isolate", "AbortError");
+    },
+};
+var clone = structuredClone(graph);
+postMessage({
+    isDomException: clone.inner instanceof DOMException,
+    name: clone.inner.name,
+    message: clone.inner.message,
+});

--- a/docs/structured-clone.md
+++ b/docs/structured-clone.md
@@ -18,7 +18,7 @@ buffer.byteLength; // 0 — the memory now belongs to `moved`
 - `options` may be `undefined` or `null` (both mean "no transfer"); anything else must be an object, or a `TypeError` is thrown.
 - `options.transfer` is a WebIDL sequence: any object with a callable `Symbol.iterator` works (an array, a `Set`, a generator). A non-iterable value — including a string primitive — throws a `TypeError`.
 
-Cloneable: every primitive value except symbols — numbers (including `-0`, `NaN` and the infinities), strings, booleans, `BigInt`, `null` and `undefined`; plain objects and arrays; `Date`, `RegExp`, `Map`, `Set`, `Error`; `Boolean`/`String`/`Number` wrapper objects; `ArrayBuffer`, every typed array and `DataView`.
+Cloneable: every primitive value except symbols — numbers (including `-0`, `NaN` and the infinities), strings, booleans, `BigInt`, `null` and `undefined`; plain objects and arrays; `Date`, `RegExp`, `Map`, `Set`, `Error`; `Boolean`/`String`/`Number` wrapper objects; `ArrayBuffer`, every typed array and `DataView`; and `DOMException`, per its Web IDL `[Serializable]` slot — `name`, `message` and `stack` round-trip through `structuredClone` and worker `postMessage`, and object identity within a graph is preserved.
 
 The clone preserves the shape of the graph, not just the values: an object referenced twice in the input is a single object referenced twice in the output, and cycles round-trip. Prototypes do not survive — a class instance clones to a plain object with the same own properties. Getters are invoked during cloning and their result is stored as a plain data property. Property insertion order is preserved.
 


### PR DESCRIPTION
Stacked on #452. Implements the `[Serializable]` slot that PR deliberately left out, so DOMException survives `structuredClone` and worker `postMessage` instead of degrading like a custom Error subclass.

## Mechanism (Node's JSTransferable protocol, reduced to one class)

- **Branding.** The dom-exception builtin gains a native half: `binding.markCloneable` stamps every instance with a per-isolate `v8::Private` (stored via `Caches::StateFor`), unforgeable and invisible from JS. All three `GetExports` call sites for the builtin now share one binding factory (`serialization::DomExceptionBinding`) — GetExports consults the factory only on the run that populates the cache, so a site passing a different one would win or lose by init order.
- **Claiming.** The serializer delegate turns on `HasCustomHostObject` and answers `IsHostObject` with a private-symbol check, V8's escape hatch for treating a plain JS object as a host object. Cost: one private-symbol lookup per plain JS object in a serialized graph — the same price Node pays.
- **Two-phase payload.** V8 forbids JS execution while a value is being read (calling the constructor inside `ReadHostObject` is a `V8_Fatal`, found the hard way), so this mirrors Node's `host_objects_` design: `WriteHostObject` pushes `{name, message, stack}` onto an out-of-band list on the `SerializedValue` and writes only a tag + index into the stream; `Deserialize` constructs every instance through the real constructor **before** `ReadValue` starts, and `ReadHostObject` hands them out by index. Construction re-brands the instance, so a forwarded exception serializes again on the next hop — and on a worker isolate that never touched DOMException, the pre-construction step runs the builtin on demand.
- **Wire format.** Host objects now start with a uint32 tag (`0` = degraded native wrapper, unchanged empty-object semantics; `1` = DOMException index). The bytes never outlive the process, so the format is free to evolve with the file.
- **Policies.** DOMException serializes under both `kReject` (structuredClone) and `kDegrade` (worker postMessage): the reject policy exists to refuse objects whose native half would be left behind, and a DOMException has none. Graph identity is preserved by V8's object-id machinery — one payload per distinct instance.

## Tests

- Shared suites (common-runtime-tests-app@67da5fc, submodule bumped): structuredClone round-trip (name/message/code/instanceof, stack where stacks exist), identity within a graph, nesting, and worker `postMessage` in **both directions** — main→worker exercises the on-demand builtin run in a fresh isolate.
- Unguarded serialization canary in `RuntimeImplementedAPIs.js`.
- Full suite: 1499 specs, 0 failures.

## Benchmarks

`structuredClone` medians on an iPad Pro simulator (temporary in-suite benchmarks, not committed). The object-heavy row was re-measured in round three in a fresh worker isolate, 15 runs after warmup, with the brand cached per serializer: "claim off" is the isolate before its first DOMException, "claim on" after one exists.

| workload | claim off | claim on |
|---|---|---|
| object-heavy graph, 100k elements (~400k objects and arrays) | 64.0ms | 68.5ms (**+7%**, ~10ns/object) |
| 1000 DOMExceptions in one graph (original measurement) | 0.11ms, degraded to `{}` | 4.3ms (~4.3µs each, the feature working) |

Claiming is now **unconditional**. The earlier gate that kept a DOMException-free isolate on the pre-claim path saved ~4ms on this pathological clone, and only until the isolate's first DOMException (any `AbortController` abort creates one), while V8 samples `HasCustomHostObject` once per serializer and never re-checks it, so the first DOMException born inside a getter during the clone that carried it lost its type. That case is now pinned by a spec that runs in a fresh worker isolate.

## Review round (2026-09-11)

- Claiming custom host objects replaces V8's embedder-field detection instead of adding to it. `IsHostObject` now claims any object with internal fields first, so ObjC instances made with `new`, `URL`, `Worker` and interop pointers keep raising `DataCloneError` once a DOMException exists in the isolate, instead of cloning as `{}`. Pinned by a new spec in `RuntimeImplementedAPIs.js` that clones `new NSObject()` and a `URL` after constructing a DOMException.
- `markCloneable` reuses the state it already checked instead of dereferencing a second lookup.

Suite: 1551 / 0.

## Review round two (2026-09-11)

- The serializer delegate resolves the DOMException brand once at construction instead of per object.
- `Deserialize` throws a `DataCloneError` instead of returning empty with nothing pending when the builtin cannot load, so `structuredClone` never yields `undefined` silently.
- The worker-side message read runs under a `TryCatch`, so a failed read is logged rather than left pending on the isolate.

Suite: 1551 / 0.

## Review round three (2026-09-11)

- `HasCustomHostObject` returns true unconditionally; the per-isolate "any instances" flag and its gate are gone (see Benchmarks for the measured cost and why). New spec: a worker whose first DOMException is created by a getter during `structuredClone` still receives a `DOMException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `DOMException` objects can now be transferred with `structuredClone` and worker `postMessage`.
  - Their `name`, `message`, and `stack` properties are preserved, including object identity within cloned graphs.

- **Bug Fixes**
  - Worker message deserialization failures are now handled safely without leaving pending exceptions.

- **Documentation**
  - Updated structured-cloning documentation to list `DOMException` as a supported cloneable type.

- **Tests**
  - Added coverage confirming cloned `DOMException` objects retain their type and error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
