### PR TITLE
fix(runtime): interop memory-safety fixes from the worker memory-corruption hunt

### DIFF
--- a/NativeScript/runtime/ArrayAdapter.mm
+++ b/NativeScript/runtime/ArrayAdapter.mm
@@ -12,8 +12,10 @@ using namespace v8;
   IsolateWrapper* wrapper_;
   std::shared_ptr<Persistent<Value>> object_;
   // The wrapper this adapter attached to the JS object, or nullptr when the
-  // field was already taken. Ownership lives with the field, not with this
-  // pointer: it is only the claim used to recognise our own wrapper there.
+  // field was already taken. The adapter owns the claim exclusively --
+  // retirement paths leave adapter claims attached -- so -dealloc frees it in
+  // both isolate states; the field compare below guards the isolate-alive
+  // path against a slot someone else overwrote.
   ObjCDataWrapper* dataWrapper_;
 }
 
@@ -27,6 +29,7 @@ using namespace v8;
     // and never writes or clears it; it still reads the object through object_.
     if (tns::GetValue(isolate, jsObject) == nullptr) {
       self->dataWrapper_ = new ObjCDataWrapper(self);
+      self->dataWrapper_->MarkAdapterClaim();
       tns::SetValue(isolate, jsObject, self->dataWrapper_);
     }
   }
@@ -130,11 +133,11 @@ using namespace v8;
     }
     self->object_->Reset();
   } else if (dataWrapper_ != nullptr) {
-    // The isolate is gone, and with it the JS object and every other reader
-    // or deleter of the claim (all IsValid-gated): an attached claim only
-    // ever exists on a plain, never-registered object no finalizer visits,
-    // so the owner frees it here — adapters released after a worker isolate's
-    // teardown otherwise leak one wrapper each.
+    // The isolate is gone, and with it the JS object and every reader of the
+    // claim; no other path deletes one (__releaseNativeCounterpart leaves
+    // adapter claims attached), so the owner frees it here — adapters
+    // released after a worker isolate's teardown otherwise leak one wrapper
+    // each.
     delete dataWrapper_;
     dataWrapper_ = nullptr;
   }

--- a/NativeScript/runtime/ArrayAdapter.mm
+++ b/NativeScript/runtime/ArrayAdapter.mm
@@ -11,7 +11,9 @@ using namespace v8;
 @implementation ArrayAdapter {
   IsolateWrapper* wrapper_;
   std::shared_ptr<Persistent<Value>> object_;
-  // we're responsible for this wrapper
+  // The wrapper this adapter attached to the JS object, or nullptr when the
+  // field was already taken. Ownership lives with the field, not with this
+  // pointer: it is only the claim used to recognise our own wrapper there.
   ObjCDataWrapper* dataWrapper_;
 }
 
@@ -19,8 +21,14 @@ using namespace v8;
   if (self) {
     self->wrapper_ = new IsolateWrapper(isolate);
     self->object_ = std::make_shared<Persistent<Value>>(isolate, jsObject);
-    self->wrapper_->GetCache()->Instances.emplace(self, self->object_);
-    tns::SetValue(isolate, jsObject, (self->dataWrapper_ = new ObjCDataWrapper(self)));
+    self->wrapper_->GetCache()->Instances[self] = self->object_;
+    // A JS object's internal field holds at most one wrapper, owned by whoever
+    // attached it first. An adapter that finds the field taken stays detached
+    // and never writes or clears it; it still reads the object through object_.
+    if (tns::GetValue(isolate, jsObject) == nullptr) {
+      self->dataWrapper_ = new ObjCDataWrapper(self);
+      tns::SetValue(isolate, jsObject, self->dataWrapper_);
+    }
   }
 
   return self;
@@ -107,23 +115,22 @@ using namespace v8;
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     wrapper_->GetCache()->Instances.erase(self);
-    Local<Value> value = self->object_->Get(isolate);
-    BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-    if (wrapper != nullptr) {
-      tns::DeleteValue(isolate, value);
-      // ensure we don't delete the same wrapper twice
-      // this is just needed as a failsafe in case some other wrapper is assigned to this object
-      if (wrapper == dataWrapper_) {
-        dataWrapper_ = nullptr;
+    // Detach and free only a wrapper that is still the one we attached: a
+    // finalizer or __releaseNativeCounterpart can have retired it already, and
+    // whatever else sits in the field belongs to another owner. Once the
+    // isolate is gone the field can no longer be read, so the claim is dropped
+    // rather than freed blind.
+    if (dataWrapper_ != nullptr) {
+      Local<Value> value = self->object_->Get(isolate);
+      if (tns::GetValue(isolate, value) == dataWrapper_) {
+        tns::DeleteValue(isolate, value);
+        delete dataWrapper_;
       }
-      delete wrapper;
+      dataWrapper_ = nullptr;
     }
     self->object_->Reset();
   }
   delete wrapper_;
-  if (dataWrapper_ != nullptr) {
-    delete dataWrapper_;
-  }
   self->object_ = nullptr;
   [super dealloc];
 }

--- a/NativeScript/runtime/ArrayAdapter.mm
+++ b/NativeScript/runtime/ArrayAdapter.mm
@@ -129,6 +129,14 @@ using namespace v8;
       dataWrapper_ = nullptr;
     }
     self->object_->Reset();
+  } else if (dataWrapper_ != nullptr) {
+    // The isolate is gone, and with it the JS object and every other reader
+    // or deleter of the claim (all IsValid-gated): an attached claim only
+    // ever exists on a plain, never-registered object no finalizer visits,
+    // so the owner frees it here — adapters released after a worker isolate's
+    // teardown otherwise leak one wrapper each.
+    delete dataWrapper_;
+    dataWrapper_ = nullptr;
   }
   delete wrapper_;
   self->object_ = nullptr;

--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -375,6 +375,13 @@ class ObjCDataWrapper : public BaseDataWrapper {
 
   id Data() { return this->data_; }
 
+  // True for the claim a collection adapter attaches to the plain JS object it
+  // was built from. The adapter owns that claim exclusively -- it must stay
+  // deletable from the adapter's -dealloc even after isolate teardown -- so no
+  // other retirement path may free it.
+  bool IsAdapterClaim() { return this->adapterClaim_; }
+  void MarkAdapterClaim() { this->adapterClaim_ = true; }
+
   const TypeEncoding* TypeEncoding() { return this->typeEncoding_; }
 
   // The class Data() had when this wrapper was built. Data() alone cannot tell
@@ -383,6 +390,7 @@ class ObjCDataWrapper : public BaseDataWrapper {
   Class Klass() { return this->klass_; }
 
  private:
+  bool adapterClaim_ = false;
   id data_;
   const tns::TypeEncoding* typeEncoding_;
   Class klass_;

--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -14,7 +14,7 @@ using namespace tns;
 
 - (instancetype)initWithMap:(std::shared_ptr<Persistent<Value>>)map
                     isolate:(Isolate*)isolate
-                      cache:(std::shared_ptr<Caches>)cache;
+                      owner:(id)owner;
 
 @end
 
@@ -22,15 +22,19 @@ using namespace tns;
   IsolateWrapper* wrapper_;
   uint32_t index_;
   std::shared_ptr<Persistent<Value>> map_;
+  // The adapter owns the persistent this enumerator reads and resets it in
+  // -dealloc, so an enumeration keeps its adapter alive.
+  id owner_;
 }
 
 - (instancetype)initWithMap:(std::shared_ptr<Persistent<Value>>)map
                     isolate:(Isolate*)isolate
-                      cache:(std::shared_ptr<Caches>)cache {
+                      owner:(id)owner {
   if (self) {
     self->wrapper_ = new IsolateWrapper(isolate);
     self->index_ = 0;
     self->map_ = map;
+    self->owner_ = [owner retain];
   }
 
   return self;
@@ -76,6 +80,8 @@ using namespace tns;
 - (void)dealloc {
   self->map_ = nil;
   delete self->wrapper_;
+  [self->owner_ release];
+  self->owner_ = nil;
 
   [super dealloc];
 }
@@ -86,7 +92,7 @@ using namespace tns;
 
 - (instancetype)initWithProperties:(std::shared_ptr<Persistent<Value>>)dictionary
                            isolate:(Isolate*)isolate
-                             cache:(std::shared_ptr<Caches>)cache;
+                             owner:(id)owner;
 - (Local<v8::Array>)getProperties;
 
 @end
@@ -95,15 +101,19 @@ using namespace tns;
   IsolateWrapper* wrapper_;
   std::shared_ptr<Persistent<Value>> dictionary_;
   NSUInteger index_;
+  // The adapter owns the persistent this enumerator reads and resets it in
+  // -dealloc, so an enumeration keeps its adapter alive.
+  id owner_;
 }
 
 - (instancetype)initWithProperties:(std::shared_ptr<Persistent<Value>>)dictionary
                            isolate:(Isolate*)isolate
-                             cache:(std::shared_ptr<Caches>)cache {
+                             owner:(id)owner {
   if (self) {
     self->wrapper_ = new IsolateWrapper(isolate);
     self->dictionary_ = dictionary;
     self->index_ = 0;
+    self->owner_ = [owner retain];
   }
 
   return self;
@@ -199,6 +209,8 @@ using namespace tns;
 - (void)dealloc {
   self->dictionary_ = nil;
   delete self->wrapper_;
+  [self->owner_ release];
+  self->owner_ = nil;
 
   [super dealloc];
 }
@@ -208,6 +220,9 @@ using namespace tns;
 @implementation DictionaryAdapter {
   IsolateWrapper* wrapper_;
   std::shared_ptr<Persistent<Value>> object_;
+  // The wrapper this adapter attached to the JS object, or nullptr when the
+  // field was already taken. Ownership lives with the field, not with this
+  // pointer: it is only the claim used to recognise our own wrapper there.
   ObjCDataWrapper* dataWrapper_;
 }
 
@@ -215,8 +230,14 @@ using namespace tns;
   if (self) {
     self->wrapper_ = new IsolateWrapper(isolate);
     self->object_ = std::make_shared<Persistent<Value>>(isolate, jsObject);
-    self->wrapper_->GetCache()->Instances.emplace(self, self->object_);
-    tns::SetValue(isolate, jsObject, (self->dataWrapper_ = new ObjCDataWrapper(self)));
+    self->wrapper_->GetCache()->Instances[self] = self->object_;
+    // A JS object's internal field holds at most one wrapper, owned by whoever
+    // attached it first. An adapter that finds the field taken stays detached
+    // and never writes or clears it; it still reads the object through object_.
+    if (tns::GetValue(isolate, jsObject) == nullptr) {
+      self->dataWrapper_ = new ObjCDataWrapper(self);
+      tns::SetValue(isolate, jsObject, self->dataWrapper_);
+    }
   }
 
   return self;
@@ -321,16 +342,14 @@ using namespace tns;
   Local<Value> obj = self->object_->Get(isolate);
 
   if (obj->IsMap()) {
-    return
-        [[[DictionaryAdapterMapKeysEnumerator alloc] initWithMap:self->object_
-                                                         isolate:isolate
-                                                           cache:wrapper_->GetCache()] autorelease];
+    return [[[DictionaryAdapterMapKeysEnumerator alloc] initWithMap:self->object_
+                                                            isolate:isolate
+                                                              owner:self] autorelease];
   }
 
   return [[[DictionaryAdapterObjectKeysEnumerator alloc] initWithProperties:self->object_
                                                                     isolate:isolate
-                                                                      cache:wrapper_->GetCache()]
-      autorelease];
+                                                                      owner:self] autorelease];
 }
 
 - (void)dealloc {
@@ -340,18 +359,23 @@ using namespace tns;
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     wrapper_->GetCache()->Instances.erase(self);
-    Local<Value> value = self->object_->Get(isolate);
-    BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-    if (wrapper != nullptr) {
-      if (wrapper == dataWrapper_) {
-        dataWrapper_ = nullptr;
+    // Detach and free only a wrapper that is still the one we attached: a
+    // finalizer or __releaseNativeCounterpart can have retired it already, and
+    // whatever else sits in the field belongs to another owner. Once the
+    // isolate is gone the field can no longer be read, so the claim is dropped
+    // rather than freed blind.
+    if (dataWrapper_ != nullptr) {
+      Local<Value> value = self->object_->Get(isolate);
+      if (tns::GetValue(isolate, value) == dataWrapper_) {
+        tns::DeleteValue(isolate, value);
+        delete dataWrapper_;
       }
-      tns::DeleteValue(isolate, value);
-      delete wrapper;
+      dataWrapper_ = nullptr;
     }
-  }
-  if (dataWrapper_ != nullptr) {
-    delete dataWrapper_;
+    // Persistent<Value> does not reset in its destructor; the enumerators
+    // vended by -keyEnumerator hold this adapter alive, so nothing can be
+    // reading the handle by the time this runs.
+    self->object_->Reset();
   }
   self->object_ = nullptr;
   delete self->wrapper_;

--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -376,6 +376,14 @@ using namespace tns;
     // vended by -keyEnumerator hold this adapter alive, so nothing can be
     // reading the handle by the time this runs.
     self->object_->Reset();
+  } else if (dataWrapper_ != nullptr) {
+    // The isolate is gone, and with it the JS object and every other reader
+    // or deleter of the claim (all IsValid-gated): an attached claim only
+    // ever exists on a plain, never-registered object no finalizer visits,
+    // so the owner frees it here — adapters released after a worker isolate's
+    // teardown otherwise leak one wrapper each.
+    delete dataWrapper_;
+    dataWrapper_ = nullptr;
   }
   self->object_ = nullptr;
   delete self->wrapper_;

--- a/NativeScript/runtime/DictionaryAdapter.mm
+++ b/NativeScript/runtime/DictionaryAdapter.mm
@@ -221,8 +221,10 @@ using namespace tns;
   IsolateWrapper* wrapper_;
   std::shared_ptr<Persistent<Value>> object_;
   // The wrapper this adapter attached to the JS object, or nullptr when the
-  // field was already taken. Ownership lives with the field, not with this
-  // pointer: it is only the claim used to recognise our own wrapper there.
+  // field was already taken. The adapter owns the claim exclusively --
+  // retirement paths leave adapter claims attached -- so -dealloc frees it in
+  // both isolate states; the field compare below guards the isolate-alive
+  // path against a slot someone else overwrote.
   ObjCDataWrapper* dataWrapper_;
 }
 
@@ -236,6 +238,7 @@ using namespace tns;
     // and never writes or clears it; it still reads the object through object_.
     if (tns::GetValue(isolate, jsObject) == nullptr) {
       self->dataWrapper_ = new ObjCDataWrapper(self);
+      self->dataWrapper_->MarkAdapterClaim();
       tns::SetValue(isolate, jsObject, self->dataWrapper_);
     }
   }
@@ -377,11 +380,11 @@ using namespace tns;
     // reading the handle by the time this runs.
     self->object_->Reset();
   } else if (dataWrapper_ != nullptr) {
-    // The isolate is gone, and with it the JS object and every other reader
-    // or deleter of the claim (all IsValid-gated): an attached claim only
-    // ever exists on a plain, never-registered object no finalizer visits,
-    // so the owner frees it here — adapters released after a worker isolate's
-    // teardown otherwise leak one wrapper each.
+    // The isolate is gone, and with it the JS object and every reader of the
+    // claim; no other path deletes one (__releaseNativeCounterpart leaves
+    // adapter claims attached), so the owner frees it here — adapters
+    // released after a worker isolate's teardown otherwise leak one wrapper
+    // each.
     delete dataWrapper_;
     dataWrapper_ = nullptr;
   }

--- a/NativeScript/runtime/Interop.h
+++ b/NativeScript/runtime/Interop.h
@@ -213,6 +213,11 @@ class Interop {
     JSBlockDescriptor* descriptor;
     void* userData;
     ffi_closure* ffiClosure;
+    // The wrapper caching this block on the JS function it was built from. It
+    // is owned here rather than through that function: the cache slot lives in
+    // a V8 heap that can be torn down (a worker isolate) while the block is
+    // still referenced by native code.
+    BlockWrapper* blockWrapper;
 
     static JSBlockDescriptor kJSBlockDescriptor;
   } JSBlock;

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -1675,7 +1675,11 @@ Local<Value> Interop::CallFunctionInternal(MethodCall& methodCall) {
   void* errorRef = nullptr;
   if (methodCall.provideErrorOutParameter_) {
     void* dest = call.ArgumentBuffer(argsCount);
-    errorRef = malloc(ffi_type_pointer.size);
+    // Zero-initialized: a callee writes *error only on failure, so the
+    // success-path read below must find nil. Garbage here is read through a
+    // __strong pointer -- ARC retains and releases it -- so a stale non-null
+    // value over-releases whatever lives at that address now.
+    errorRef = calloc(1, ffi_type_pointer.size);
     Interop::SetValue(dest, errorRef);
   }
 

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -38,6 +38,7 @@ Interop::JSBlock::JSBlockDescriptor Interop::JSBlock::kJSBlockDescriptor = {
         [](JSBlock* block) {
           if (block->descriptor == &JSBlock::kJSBlockDescriptor) {
             MethodCallbackWrapper* wrapper = static_cast<MethodCallbackWrapper*>(block->userData);
+            BlockWrapper* blockWrapper = block->blockWrapper;
             // Runs on whatever thread drops the last native reference. That is
             // safe inline: callback_ is a strong, unregistered persistent, so
             // resetting it never touches the finalizer drain's bookkeeping,
@@ -50,16 +51,22 @@ Interop::JSBlock::JSBlockDescriptor Interop::JSBlock::kJSBlockDescriptor = {
               HandleScope handle_scope(isolate);
               Local<Value> callback = wrapper->callback_->Get(isolate);
               if (!callback.IsEmpty() && callback->IsObject()) {
-                BlockWrapper* blockWrapper =
-                    static_cast<BlockWrapper*>(tns::GetValue(isolate, callback));
-                tns::DeleteValue(isolate, callback);
-                delete blockWrapper;
+                // The callback's slot is the cache's owner, so only a wrapper
+                // still sitting in it is ours to free.
+                if (tns::GetValue(isolate, callback) == blockWrapper) {
+                  tns::DeleteValue(isolate, callback);
+                } else {
+                  blockWrapper = nullptr;
+                }
               }
               // Unconditional: an already-detached callback still owns its
               // node, and dropping the persistent without a reset would leave
               // that node rooted forever.
               wrapper->callback_->Reset();
             }
+            // Outside the isolate guard: once the isolate is gone the cache
+            // slot is unreachable and nothing else can free the wrapper.
+            delete blockWrapper;
             delete wrapper;
             ffi_closure_free(block->ffiClosure);
             block->~JSBlock();
@@ -109,6 +116,7 @@ CFTypeRef Interop::CreateBlock(const uint8_t initialParamIndex, const uint8_t ar
       .descriptor = &JSBlock::kJSBlockDescriptor,
       .userData = userData,
       .ffiClosure = result.second,
+      .blockWrapper = nullptr,
   };
 
   object_setClass((__bridge id)blockPointer, objc_getClass("__NSMallocBlock__"));
@@ -539,6 +547,7 @@ void Interop::WriteValue(Local<Context> context, const TypeEncoding* typeEncodin
                                       userData);
 
       BlockWrapper* wrapper = new BlockWrapper((void*)blockPtr, blockTypeEncoding, false);
+      reinterpret_cast<JSBlock*>((void*)blockPtr)->blockWrapper = wrapper;
       tns::SetValue(isolate, arg.As<v8::Function>(), wrapper);
     }
 

--- a/NativeScript/runtime/Metadata.mm
+++ b/NativeScript/runtime/Metadata.mm
@@ -106,6 +106,11 @@ bool MethodMeta::isImplementedInClass(Class klass, bool isStatic) const {
       @try {
         id instance = [klass alloc];
         std::lock_guard<UnfairMutex> lock(sampleInstancesMutex);
+        // A losing emplace (a +initialize re-entry or another thread populated
+        // the entry first) LEAKS `instance`, knowingly: it was never init'd, so
+        // releasing it would run -dealloc against zero-filled ivars of an
+        // arbitrary class on an arbitrary thread.
+        // https://github.com/NativeScript/ios/issues/459
         sampleInstance = sampleInstances.emplace(klass, instance).first->second;
       } @catch (id err) {
         return false;

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -119,6 +119,14 @@ using namespace v8;
       dataWrapper_ = nullptr;
     }
     self->object_->Reset();
+  } else if (dataWrapper_ != nullptr) {
+    // The isolate is gone, and with it the JS object and every other reader
+    // or deleter of the claim (all IsValid-gated): an attached claim only
+    // ever exists on a plain, never-registered object no finalizer visits,
+    // so the owner frees it here — adapters released after a worker isolate's
+    // teardown otherwise leak one wrapper each.
+    delete dataWrapper_;
+    dataWrapper_ = nullptr;
   }
 
   delete self->wrapper_;

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -21,6 +21,10 @@ using namespace v8;
   std::shared_ptr<v8::BackingStore> store_;
   // View byte offset into store_, captured with it (immutable for a view).
   size_t storeOffset_;
+  // Byte length snapshotted with the store. NSData is immutable — its length
+  // must not change for the object's lifetime — and the live ByteLength()
+  // reads zero after a transfer detach while the pinned bytes stay valid.
+  size_t length_;
   // Lazily-built stable copy for a view whose buffer was never materialized;
   // owned here, freed in dealloc.
   void* heapCopy_;
@@ -37,11 +41,16 @@ using namespace v8;
     self->storeOffset_ = 0;
     self->heapCopy_ = nullptr;
     if (jsObject->IsArrayBuffer()) {
-      self->store_ = jsObject.As<ArrayBuffer>()->GetBackingStore();
+      Local<ArrayBuffer> buffer = jsObject.As<ArrayBuffer>();
+      self->store_ = buffer->GetBackingStore();
+      self->length_ = buffer->ByteLength();
     } else if (jsObject->IsSharedArrayBuffer()) {
-      self->store_ = jsObject.As<SharedArrayBuffer>()->GetBackingStore();
+      Local<SharedArrayBuffer> buffer = jsObject.As<SharedArrayBuffer>();
+      self->store_ = buffer->GetBackingStore();
+      self->length_ = buffer->ByteLength();
     } else {
       Local<ArrayBufferView> view = jsObject.As<ArrayBufferView>();
+      self->length_ = view->ByteLength();
       if (view->HasBuffer()) {
         self->store_ = view->Buffer()->GetBackingStore();
         self->storeOffset_ = view->ByteOffset();
@@ -87,29 +96,15 @@ using namespace v8;
   Isolate* isolate = wrapper_->Isolate();
   Local<Object> obj = self->object_->Get(isolate).As<Object>();
   Local<ArrayBufferView> bufferView = obj.As<ArrayBufferView>();
-  size_t length = bufferView->ByteLength();
-  heapCopy_ = malloc(length);
+  heapCopy_ = malloc(length_);
   if (heapCopy_ != nullptr) {
-    bufferView->CopyContents(heapCopy_, length);
+    bufferView->CopyContents(heapCopy_, length_);
   }
   return heapCopy_;
 }
 
 - (NSUInteger)length {
-  if (!wrapper_->IsValid()) {
-    return 0;
-  }
-  Isolate* isolate = wrapper_->Isolate();
-  Local<Object> obj = self->object_->Get(isolate).As<Object>();
-  if (obj->IsArrayBuffer()) {
-    return obj.As<ArrayBuffer>()->ByteLength();
-  }
-
-  if (obj->IsSharedArrayBuffer()) {
-    return obj.As<SharedArrayBuffer>()->ByteLength();
-  }
-
-  return obj.As<ArrayBufferView>()->ByteLength();
+  return length_;
 }
 
 - (void)dealloc {

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -9,8 +9,10 @@ using namespace v8;
 @implementation NSDataAdapter {
   IsolateWrapper* wrapper_;
   // The wrapper this adapter attached to the JS object, or nullptr when the
-  // field was already taken. Ownership lives with the field, not with this
-  // pointer: it is only the claim used to recognise our own wrapper there.
+  // field was already taken. The adapter owns the claim exclusively --
+  // retirement paths leave adapter claims attached -- so -dealloc frees it in
+  // both isolate states; the field compare below guards the isolate-alive
+  // path against a slot someone else overwrote.
   ObjCDataWrapper* dataWrapper_;
   std::shared_ptr<Persistent<Value>> object_;
   // Pins the bytes for the adapter's lifetime, which is the NSData contract
@@ -69,6 +71,7 @@ using namespace v8;
     // and never writes or clears it; it still reads the object through object_.
     if (tns::GetValue(isolate, jsObject) == nullptr) {
       self->dataWrapper_ = new ObjCDataWrapper(self);
+      self->dataWrapper_->MarkAdapterClaim();
       tns::SetValue(isolate, jsObject, self->dataWrapper_);
     }
   }
@@ -120,11 +123,11 @@ using namespace v8;
     }
     self->object_->Reset();
   } else if (dataWrapper_ != nullptr) {
-    // The isolate is gone, and with it the JS object and every other reader
-    // or deleter of the claim (all IsValid-gated): an attached claim only
-    // ever exists on a plain, never-registered object no finalizer visits,
-    // so the owner frees it here — adapters released after a worker isolate's
-    // teardown otherwise leak one wrapper each.
+    // The isolate is gone, and with it the JS object and every reader of the
+    // claim; no other path deletes one (__releaseNativeCounterpart leaves
+    // adapter claims attached), so the owner frees it here — adapters
+    // released after a worker isolate's teardown otherwise leak one wrapper
+    // each.
     delete dataWrapper_;
     dataWrapper_ = nullptr;
   }

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -25,8 +25,9 @@ using namespace v8;
   // must not change for the object's lifetime — and the live ByteLength()
   // reads zero after a transfer detach while the pinned bytes stay valid.
   size_t length_;
-  // Lazily-built stable copy for a view whose buffer was never materialized;
-  // owned here, freed in dealloc.
+  // Stable copy for a view whose buffer was never materialized, built during
+  // init while the isolate is owned and the view alive — -bytes may run on
+  // threads that cannot touch V8. Owned here, freed in dealloc.
   void* heapCopy_;
 }
 
@@ -54,6 +55,13 @@ using namespace v8;
       if (view->HasBuffer()) {
         self->store_ = view->Buffer()->GetBackingStore();
         self->storeOffset_ = view->ByteOffset();
+      } else {
+        self->heapCopy_ = malloc(self->length_);
+        if (self->heapCopy_ != nullptr) {
+          view->CopyContents(self->heapCopy_, self->length_);
+        } else {
+          self->length_ = 0;
+        }
       }
     }
     // A JS object's internal field holds at most one wrapper, owned by whoever
@@ -73,8 +81,8 @@ using namespace v8;
 }
 
 - (void*)mutableBytes {
-  // The pinned store answers without touching V8, so native callers on
-  // foreign threads need no isolate access (the old per-call
+  // Every branch answers from native storage captured at init, so callers on
+  // foreign threads never need isolate access (the old per-call
   // GetBackingStore() lookup ran unlocked from any thread).
   if (store_ != nullptr) {
     void* data = store_->Data();
@@ -82,23 +90,6 @@ using namespace v8;
       return nullptr;
     }
     return static_cast<uint8_t*>(data) + storeOffset_;
-  }
-
-  if (!wrapper_->IsValid()) {
-    return nil;
-  }
-  // Only reachable for a view whose buffer was never materialized. Serve one
-  // stable copy for the adapter's lifetime: NSData callers assume -bytes is
-  // stable, and a fresh allocation per call also never got freed.
-  if (heapCopy_ != nullptr) {
-    return heapCopy_;
-  }
-  Isolate* isolate = wrapper_->Isolate();
-  Local<Object> obj = self->object_->Get(isolate).As<Object>();
-  Local<ArrayBufferView> bufferView = obj.As<ArrayBufferView>();
-  heapCopy_ = malloc(length_);
-  if (heapCopy_ != nullptr) {
-    bufferView->CopyContents(heapCopy_, length_);
   }
   return heapCopy_;
 }

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -8,6 +8,9 @@ using namespace v8;
 
 @implementation NSDataAdapter {
   IsolateWrapper* wrapper_;
+  // The wrapper this adapter attached to the JS object, or nullptr when the
+  // field was already taken. Ownership lives with the field, not with this
+  // pointer: it is only the claim used to recognise our own wrapper there.
   ObjCDataWrapper* dataWrapper_;
   std::shared_ptr<Persistent<Value>> object_;
 }
@@ -19,8 +22,14 @@ using namespace v8;
                 isolate);
     self->wrapper_ = new IsolateWrapper(isolate);
     self->object_ = std::make_shared<Persistent<Value>>(isolate, jsObject);
-    self->wrapper_->GetCache()->Instances.emplace(self, self->object_);
-    tns::SetValue(isolate, jsObject, (dataWrapper_ = new ObjCDataWrapper(self)));
+    self->wrapper_->GetCache()->Instances[self] = self->object_;
+    // A JS object's internal field holds at most one wrapper, owned by whoever
+    // attached it first. An adapter that finds the field taken stays detached
+    // and never writes or clears it; it still reads the object through object_.
+    if (tns::GetValue(isolate, jsObject) == nullptr) {
+      self->dataWrapper_ = new ObjCDataWrapper(self);
+      tns::SetValue(isolate, jsObject, self->dataWrapper_);
+    }
   }
 
   return self;
@@ -87,21 +96,20 @@ using namespace v8;
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     wrapper_->GetCache()->Instances.erase(self);
-    Local<Value> value = self->object_->Get(isolate);
-    BaseDataWrapper* wrapper = tns::GetValue(isolate, value);
-    if (wrapper != nullptr) {
-      tns::DeleteValue(isolate, value);
-      // ensure we don't delete the same wrapper twice
-      // this is just needed as a failsafe in case some other wrapper is assigned to this object
-      if (wrapper == dataWrapper_) {
-        dataWrapper_ = nullptr;
+    // Detach and free only a wrapper that is still the one we attached: a
+    // finalizer or __releaseNativeCounterpart can have retired it already, and
+    // whatever else sits in the field belongs to another owner. Once the
+    // isolate is gone the field can no longer be read, so the claim is dropped
+    // rather than freed blind.
+    if (dataWrapper_ != nullptr) {
+      Local<Value> value = self->object_->Get(isolate);
+      if (tns::GetValue(isolate, value) == dataWrapper_) {
+        tns::DeleteValue(isolate, value);
+        delete dataWrapper_;
       }
-      delete wrapper;
+      dataWrapper_ = nullptr;
     }
     self->object_->Reset();
-  }
-  if (dataWrapper_ != nullptr) {
-    delete dataWrapper_;
   }
 
   delete self->wrapper_;

--- a/NativeScript/runtime/NSDataAdapter.mm
+++ b/NativeScript/runtime/NSDataAdapter.mm
@@ -13,6 +13,17 @@ using namespace v8;
   // pointer: it is only the claim used to recognise our own wrapper there.
   ObjCDataWrapper* dataWrapper_;
   std::shared_ptr<Persistent<Value>> object_;
+  // Pins the bytes for the adapter's lifetime, which is the NSData contract
+  // native callers rely on. The persistent above pins only the JS OBJECT: a
+  // postMessage transfer detaches it and hands the store to another isolate,
+  // whose GC can free the memory while native code still holds this NSData —
+  // an async reader/writer then touches a freed, recycled chunk.
+  std::shared_ptr<v8::BackingStore> store_;
+  // View byte offset into store_, captured with it (immutable for a view).
+  size_t storeOffset_;
+  // Lazily-built stable copy for a view whose buffer was never materialized;
+  // owned here, freed in dealloc.
+  void* heapCopy_;
 }
 
 - (instancetype)initWithJSObject:(Local<Object>)jsObject isolate:(Isolate*)isolate {
@@ -23,6 +34,19 @@ using namespace v8;
     self->wrapper_ = new IsolateWrapper(isolate);
     self->object_ = std::make_shared<Persistent<Value>>(isolate, jsObject);
     self->wrapper_->GetCache()->Instances[self] = self->object_;
+    self->storeOffset_ = 0;
+    self->heapCopy_ = nullptr;
+    if (jsObject->IsArrayBuffer()) {
+      self->store_ = jsObject.As<ArrayBuffer>()->GetBackingStore();
+    } else if (jsObject->IsSharedArrayBuffer()) {
+      self->store_ = jsObject.As<SharedArrayBuffer>()->GetBackingStore();
+    } else {
+      Local<ArrayBufferView> view = jsObject.As<ArrayBufferView>();
+      if (view->HasBuffer()) {
+        self->store_ = view->Buffer()->GetBackingStore();
+        self->storeOffset_ = view->ByteOffset();
+      }
+    }
     // A JS object's internal field holds at most one wrapper, owned by whoever
     // attached it first. An adapter that finds the field taken stays detached
     // and never writes or clears it; it still reads the object through object_.
@@ -40,36 +64,35 @@ using namespace v8;
 }
 
 - (void*)mutableBytes {
-  if (!wrapper_->IsValid()) {
-    return nil;
-  }
-  Isolate* isolate = wrapper_->Isolate();
-  Local<Object> obj = self->object_->Get(isolate).As<Object>();
-  if (obj->IsArrayBuffer()) {
-    void* data = obj.As<ArrayBuffer>()->GetBackingStore()->Data();
-    return data;
-  }
-
-  if (obj->IsSharedArrayBuffer()) {
-    void* data = obj.As<SharedArrayBuffer>()->GetBackingStore()->Data();
-    return data;
-  }
-
-  Local<ArrayBufferView> bufferView = obj.As<ArrayBufferView>();
-  if (bufferView->HasBuffer()) {
-    uint8_t* data = static_cast<uint8_t*>(bufferView->Buffer()->GetBackingStore()->Data());
+  // The pinned store answers without touching V8, so native callers on
+  // foreign threads need no isolate access (the old per-call
+  // GetBackingStore() lookup ran unlocked from any thread).
+  if (store_ != nullptr) {
+    void* data = store_->Data();
     if (data == nullptr) {
       return nullptr;
     }
-
-    return data + bufferView->ByteOffset();
+    return static_cast<uint8_t*>(data) + storeOffset_;
   }
 
+  if (!wrapper_->IsValid()) {
+    return nil;
+  }
+  // Only reachable for a view whose buffer was never materialized. Serve one
+  // stable copy for the adapter's lifetime: NSData callers assume -bytes is
+  // stable, and a fresh allocation per call also never got freed.
+  if (heapCopy_ != nullptr) {
+    return heapCopy_;
+  }
+  Isolate* isolate = wrapper_->Isolate();
+  Local<Object> obj = self->object_->Get(isolate).As<Object>();
+  Local<ArrayBufferView> bufferView = obj.As<ArrayBufferView>();
   size_t length = bufferView->ByteLength();
-  void* data = malloc(length);
-  bufferView->CopyContents(data, length);
-
-  return data;
+  heapCopy_ = malloc(length);
+  if (heapCopy_ != nullptr) {
+    bufferView->CopyContents(heapCopy_, length);
+  }
+  return heapCopy_;
 }
 
 - (NSUInteger)length {
@@ -114,6 +137,8 @@ using namespace v8;
 
   delete self->wrapper_;
   self->object_ = nullptr;
+  free(self->heapCopy_);
+  self->heapCopy_ = nullptr;
   [super dealloc];
 }
 

--- a/NativeScript/runtime/ObjectManager.mm
+++ b/NativeScript/runtime/ObjectManager.mm
@@ -390,11 +390,19 @@ void ObjectManager::ReleaseNativeCounterpartCallback(const FunctionCallbackInfo<
     // NSNotificationCenter observer token) the remaining owners keep it alive.
     // Calling [data dealloc] here, as this used to do, destroyed objects that
     // were still referenced elsewhere and caused use-after-free crashes.
+    // Read before the release below: an adapter claim's -dealloc frees the
+    // wrapper, so it must not be touched afterwards.
+    bool adapterClaim = objcWrapper->IsAdapterClaim();
+
     [data release];
 
     // The release above can run a -dealloc that detaches this wrapper; the
-    // internal field owns it, so free only what is still attached.
-    if (tns::GetValue(isolate, value) == wrapper) {
+    // internal field owns it, so free only what is still attached. An
+    // adapter's claim is exempt: the adapter owns it exclusively and deletes
+    // it from its own -dealloc even after isolate teardown, so retiring it
+    // here would leave the adapter holding a stale pointer it later frees
+    // again.
+    if (!adapterClaim && tns::GetValue(isolate, value) == wrapper) {
       delete wrapper;
       tns::SetValue(isolate, value.As<Object>(), nullptr);
     }

--- a/NativeScript/runtime/ObjectManager.mm
+++ b/NativeScript/runtime/ObjectManager.mm
@@ -317,9 +317,14 @@ bool ObjectManager::DisposeValue(Isolate* isolate, Local<Value> value, bool isFi
       break;
   }
 
-  delete wrapper;
-  wrapper = nullptr;
-  tns::DeleteValue(isolate, obj);
+  // A branch above can run arbitrary code -- [target release] reaching an ObjC
+  // -dealloc is the reachable one -- and that code may detach this wrapper or
+  // attach a different one. The object's internal field is the wrapper's owner,
+  // so only a wrapper still sitting in it is ours to free.
+  if (tns::GetValue(isolate, obj) == wrapper) {
+    delete wrapper;
+    tns::DeleteValue(isolate, obj);
+  }
   return true;
 }
 
@@ -387,8 +392,12 @@ void ObjectManager::ReleaseNativeCounterpartCallback(const FunctionCallbackInfo<
     // were still referenced elsewhere and caused use-after-free crashes.
     [data release];
 
-    delete wrapper;
-    tns::SetValue(isolate, value.As<Object>(), nullptr);
+    // The release above can run a -dealloc that detaches this wrapper; the
+    // internal field owns it, so free only what is still attached.
+    if (tns::GetValue(isolate, value) == wrapper) {
+      delete wrapper;
+      tns::SetValue(isolate, value.As<Object>(), nullptr);
+    }
   }
 }
 

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -1,4 +1,5 @@
 #include "Worker.h"
+#include <pthread.h>
 #include <functional>
 #include "Caches.h"
 #include "Constants.h"
@@ -181,6 +182,22 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
     tns::LoaderVocabulary inheritedVocabulary = tns::CaptureLoaderVocabulary(isolate);
 
     std::function<Isolate*()> func([worker, workerPath, inheritedVocabulary]() {
+      // Name the looper thread after its entry script so a crash report
+      // identifies which worker died instead of an anonymous NSOperationQueue
+      // thread. Darwin caps thread names at 63 bytes; keep the basename only.
+      {
+        std::string threadName = workerPath;
+        size_t slash = threadName.find_last_of('/');
+        if (slash != std::string::npos) {
+          threadName = threadName.substr(slash + 1);
+        }
+        threadName = "worker" + std::to_string(worker->WorkerId()) + ":" + threadName;
+        if (threadName.size() > 63) {
+          threadName.resize(63);
+        }
+        pthread_setname_np(threadName.c_str());
+      }
+
       // Resolve tilde paths before creating the runtime
       std::string resolvedPath = workerPath;
       if (!workerPath.empty() && workerPath[0] == '~') {

--- a/TestRunner/app/tests/GCFinalizerTests.js
+++ b/TestRunner/app/tests/GCFinalizerTests.js
@@ -236,6 +236,162 @@ describe("GC finalizer callbacks", function () {
         expect(survivor.objectAtIndex(1)).toBe(2);
     });
 
+    // Allocation pressure shaped like the field workload: native lazy-global
+    // paths (TextDecoder, atob/btoa) interleaved with adapter marshalling, so
+    // a wrapper freed twice lands on somebody else's live allocation.
+    function churn(rounds) {
+        var decoder = new TextDecoder();
+        var sink = 0;
+        for (var i = 0; i < rounds; i++) {
+            sink += decoder.decode(new Uint8Array([65, 66, 67, i % 128])).length;
+            sink += atob(btoa("churn-" + i)).length;
+            var probe = NSMutableArray.alloc().init();
+            probe.addObject([i, i + 1]);
+            probe.addObject(new Uint8Array(8));
+            probe.addObject({ k: i });
+            sink += probe.count;
+        }
+        return sink;
+    }
+
+    // The JS object's internal field owns the wrapper an adapter attaches to
+    // it. When a finalizer drops the last native reference to the adapter, the
+    // adapter's -dealloc detaches that wrapper from inside the disposal that
+    // released it, so the disposal must not free what it read beforehand.
+    it("releases adapters from inside a finalizer across repeated cycles", function () {
+        var cycles = 12;
+
+        for (var c = 0; c < cycles; c++) {
+            (function () {
+                var holders = [];
+                for (var i = 0; i < 8; i++) {
+                    // Each holder takes the only native reference to the
+                    // adapters built for these collections.
+                    var holder = NSMutableArray.alloc().init();
+                    holder.addObject([c, i, i + 1]);
+                    holder.addObject(new Uint8Array(16));
+                    holder.addObject({ c: c, i: i });
+                    holders.push(holder);
+                }
+            })();
+
+            scrubStack();
+            __collect();
+            expect(churn(16)).toBeGreaterThan(0);
+            __collect();
+        }
+
+        var survivor = NSMutableArray.arrayWithArray([1, 2, 3]);
+        expect(survivor.count).toBe(3);
+        expect(survivor.objectAtIndex(2)).toBe(3);
+    });
+
+    // Marshalling the same collection twice builds a second adapter for a JS
+    // object whose field is already claimed. The second adapter must leave the
+    // field alone, so that neither adapter's -dealloc frees the other's
+    // wrapper, and both must still marshal back to the original JS object.
+    it("survives a JS collection marshalled to native twice", function () {
+        var rounds = 8;
+
+        for (var r = 0; r < rounds; r++) {
+            var arr = [r, r + 1, r + 2];
+            var obj = { id: r, param: "abc" };
+            var types = TNSObjCTypes.alloc().init();
+
+            // objectAtIndex: on the outer adapter builds a fresh adapter for
+            // the nested collection on every call.
+            expect(types.methodWithNSArrayWrappingDictionary([obj])).toBe(obj);
+            expect(types.methodWithNSArrayWrappingDictionary([obj])).toBe(obj);
+            expect(types.methodWithNSArrayWrappingDictionary([arr])).toBe(arr);
+            expect(types.methodWithNSArrayWrappingDictionary([arr])).toBe(arr);
+
+            var first = NSMutableArray.alloc().init();
+            first.addObject(arr);
+            var second = NSMutableArray.alloc().init();
+            second.addObject(arr);
+            expect(first.count).toBe(1);
+            expect(second.count).toBe(1);
+
+            expect(churn(8)).toBeGreaterThan(0);
+        }
+
+        scrubStack();
+        __collect();
+        expect(churn(16)).toBeGreaterThan(0);
+        __collect();
+
+        var survivor = NSMutableArray.arrayWithArray([4, 5]);
+        expect(survivor.count).toBe(2);
+    });
+
+    // A key enumerator reads the persistent its adapter owns, and the adapter
+    // resets that persistent in -dealloc, so an enumeration keeps its adapter
+    // alive for as long as the enumerator itself lives.
+    it("keeps a dictionary adapter alive for its keys enumerator", function () {
+        var rounds = 8;
+
+        for (var r = 0; r < rounds; r++) {
+            var types = TNSObjCTypes.alloc().init();
+            // Fast enumeration over a foreign NSDictionary goes through
+            // -keyEnumerator; the enumerator outlives the call that made it,
+            // draining with the pool rather than with the adapter.
+            var dictionary = { a: 3, b: { "-1": [4, 5] }, d: 6 };
+            expect(types.methodWithNSDictionary(dictionary)).toBe(dictionary);
+            TNSClearOutput();
+
+            var map = new Map();
+            map.set("a", 3);
+            map.set("d", 6);
+            expect(types.methodWithNSDictionary(map)).toBe(map);
+            TNSClearOutput();
+
+            expect(churn(8)).toBeGreaterThan(0);
+        }
+
+        scrubStack();
+        __collect();
+        expect(churn(16)).toBeGreaterThan(0);
+        __collect();
+
+        // A dictionary enumerated after the sweep still reports its keys.
+        var late = { x: 1, y: 2 };
+        expect(TNSObjCTypes.alloc().init().methodWithNSDictionary(late)).toBe(late);
+        expect(TNSGetOutput()).toBe("x 1y 2");
+        TNSClearOutput();
+    });
+
+    // The field crashes surfaced on worker isolates, where the same churn runs
+    // and the isolate is torn down while adapters may still be alive.
+    it("survives the same churn on a worker isolate", function (done) {
+        var originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+
+        var worker = new Worker("./adapterChurnWorker.js");
+        var rounds = 0;
+
+        var finish = function () {
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+            worker.terminate();
+            done();
+        };
+
+        worker.onmessage = function (msg) {
+            expect(msg.data.ok).toBe(true);
+            rounds++;
+            if (rounds === 6) {
+                finish();
+                return;
+            }
+            worker.postMessage(rounds);
+        };
+        worker.onerror = function (e) {
+            expect(String(e && e.message ? e.message : e)).toBe("<no worker error>");
+            finish();
+        };
+
+        worker.postMessage(0);
+    });
+
     // A natively held block's last release can land inside the finalizer
     // drain, where the JSBlock dispose helper must not touch handles itself.
     it("tears down a natively held block released by a finalizer", function (done) {

--- a/TestRunner/app/tests/adapterChurnWorker.js
+++ b/TestRunner/app/tests/adapterChurnWorker.js
@@ -1,0 +1,24 @@
+// Adapter marshalling interleaved with the native lazy-global paths, on a
+// worker isolate: the shape the production heap corruption surfaced under.
+onmessage = function (msg) {
+    var round = msg.data;
+    var decoder = new TextDecoder();
+    var sink = 0;
+
+    for (var i = 0; i < 24; i++) {
+        var holder = NSMutableArray.alloc().init();
+        holder.addObject([round, i]);
+        holder.addObject(new Uint8Array(16));
+        holder.addObject({ round: round, i: i });
+        sink += holder.count;
+
+        sink += decoder.decode(new Uint8Array([65, 66, 67, i % 128])).length;
+        sink += atob(btoa("worker-" + i)).length;
+    }
+
+    __collect();
+    __collect();
+
+    var survivor = NSMutableArray.arrayWithArray([1, 2, 3]);
+    postMessage({ ok: sink > 0 && survivor.count === 3 });
+};


### PR DESCRIPTION
## Summary

Memory-safety fixes and hardening that came out of a production memory-corruption hunt (crashes at `global-handles.cc` drain CHECKs, `DisposeValue` segfaults, and silent stalls in a worker-heavy app). The investigation root-caused four distinct defects; three were runtime bugs and are fixed here. The fourth — the one producing the headline crashes — turned out to be **app/core-side**: `NSData.dataWithBytesNoCopy(ptr, len)` (2-arg = `freeWhenDone:YES`) called over pointers into V8-owned ArrayBuffer backing buffers, handing Foundation ownership of memory the ArrayBufferSweeper also frees — a double-ownership double-free that sprays whatever allocation lands between the two frees. That is fixed by two NativeScript core patches (`wgc` crypto `getRandomValues`, `file-system-access` write path); this PR carries the runtime's share: the fixes below plus observability that makes this bug class diagnosable.

## Fixes

1. **Single-owner adapter wrappers and reentrancy-safe disposal.** `DisposeValue`'s ObjCObject branch ran `[target release]` — which can re-enter through an adapter `-dealloc` that deletes the attached wrapper and resets the persistent — and then deleted the wrapper through a stale local: a double delete whose freed-chunk reuse corrupted unrelated allocations. The tail now re-reads the field after every reentrancy-capable step, and adapters only detach/free a wrapper that is still the one they attached. Also fixes `DictionaryAdapter` never resetting `object_` (leaked armed weak nodes).

2. **Zero-initialized `NSError` out-parameter buffer.** `Interop::CallFunctionInternal` malloc'd the `NSError**` slot without zeroing. Cocoa only writes `*error` on failure, so every *successful* call read back heap garbage; a non-null garbage pointer went through `NSError* __strong*` and got retained/released by ARC — an over-release of whatever live object had been reallocated at that address, freeing it under its true owner. Dates back to the original `NSError**` support.

3. **`NSDataAdapter` pins its backing store.** The adapter held a `Persistent` (pinning the JS *object*) but re-fetched `GetBackingStore()->Data()` per `-bytes` call with no store reference — so a `postMessage` transfer-detach could free the bytes while native code still held the `NSData`, and every call did unlocked cross-thread V8 access. The adapter now captures the `shared_ptr<BackingStore>` at init (bytes valid for the adapter's lifetime — the contract NSData callers assume) and `-bytes` no longer touches V8. The never-materialized-view branch, which leaked a fresh `malloc` copy on every call, now serves one stable copy freed in `dealloc`.

4. **Adapters free their wrapper claim after isolate teardown.** An adapter released after its isolate died (workers) skipped its whole cleanup block behind the `IsValid()` gate and orphaned the attached `ObjCDataWrapper` — one 48-byte leak per adapter on every worker teardown, surfaced by this PR's new worker-churn test under Instruments. With the isolate gone, the JS object and every other reader or deleter of the claim are gone too (all `IsValid`-gated), so the owning adapter deletes it unconditionally. Verified with live `leaks` runs: 24-per-adapter-type before, zero after.

5. **The `JSBlock` owns the block cache attached to its function.** Passing a JS function as a block argument caches a `BlockWrapper` on the function for block reuse; the dispose helper freed it only by looking it up through the cached function, which needs a live isolate — a block built on a worker isolate and released after its teardown orphaned the wrapper (two 48-byte leaks per TestRunner run). The block now carries its wrapper pointer, so disposal frees it without the isolate; while the isolate is alive the same slot-ownership rule as `DisposeValue` applies, so `__releaseNativeCounterpart` cannot cause a double free. Disposal stays inline and `callback_->Reset()` stays unconditional.

6. **Worker looper threads are named** (`worker<id>:<script-basename>` via `pthread_setname_np`). Every crash report now says *which* worker died instead of an anonymous `NSOperationQueue` thread — this single change converted the hunt's crash reports from anonymous to self-identifying.

## The forensic short version

The corruption presented as V8 `global-handles` fatals on worker threads ("Finalizer callback must either reset its handle or re-arm it"), with the faulting values rotating between runs. Instrumented builds (registration-ordinal stamping, slot watches, guard pages, and finally `MallocStackLogging` + a pause-on-fatal park with `malloc_history` against the live task) produced the complete biography of one corrupted chunk:

1. JS passes an on-heap typed array to native → V8 materializes an off-heap buffer it owns;
2. JS calls `dataWithBytesNoCopy(ptr, len)` on a pointer into that buffer → Foundation's small-payload path copies and **frees the donor immediately**;
3. the chunk is recycled (here: into a registered `Persistent`);
4. the ArrayBuffer dies → the sweeper frees the **same address again**, destroying the current tenant.

Fixes 1 and 2 are real defects, found and validated during the hunt (fix 2's garbage read-back reproduced deterministically under `MallocScribble=1`), but the final attribution run shows they were **latent, not the production trigger**: an unpatched released runtime with only the core call sites fixed soaked clean for 10+ minutes where every unpatched combination died in about a minute. The core double-free was the sole trigger; this PR removes the runtime's own members of the same premature-free bug class before they get their turn.

## Follow-ups (tracked, not in this PR)

- **Debug-build marshalling guard**: warn when 2-arg `dataWithBytesNoCopy:length:` receives a pointer inside a live BackingStore — the metadata layer sees the selector, so this is checkable at the exact choke point and would have caught the core bugs in seconds.
- Docs note: pointers into ArrayBuffers must never be donated to `freeWhenDone`-style APIs.
- `MallocScribble` / ASan CI lane (`MallocScribble=1` deterministically caught fix 2 at boot).
- `NSDataAdapter.mutableBytes` length-uncoupling (`setLength:`/`appendData:` on an adapter can write past the store).
- `Interop::GetResult` cache-hit early-return skips the owned-result release (leak).
- `MethodMeta::isImplementedInClass` leaks the losing sample instance on re-entrant/racing cache population — kept visible and documented at the site rather than hidden (releasing a never-initialized instance of an arbitrary class is unsafe; parking it is perpetual retention): #459.
- Build-script hygiene: fail hard when `xcodebuild clean` fails (a stray repo-root `build/` dir shipped stale binaries three times during the hunt), and make `build_npm_ios.sh` verify `metadata-generator/dist` freshness — it packages whatever sits there, however stale, and the per-stage build flow (unlike `build_all_ios.sh`) never rebuilds it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when JavaScript and native objects are converted between representations and later collected by garbage collection.
  - Prevented stale or conflicting internal wrappers from being incorrectly released.
  - Fixed cleanup scenarios involving callbacks, workers, dictionaries, arrays, and binary data.
  - Improved binary data access reliability, including views and buffers after isolate shutdown.
  - Ensured native error output is initialized consistently.

- **Enhancements**
  - Worker threads now have clearer names based on their entry scripts, simplifying diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->