### PR TITLE
fix(runtime): null-initialize Runtime::isolate_

### DIFF
--- a/NativeScript/runtime/Runtime.h
+++ b/NativeScript/runtime/Runtime.h
@@ -159,7 +159,7 @@ class Runtime {
 
   static void DrainRejectionsObserver(CFRunLoopObserverRef observer,
                                       CFRunLoopActivity activity, void* info);
-  v8::Isolate* isolate_;
+  v8::Isolate* isolate_ = nullptr;
   std::atomic<bool> terminationRequested_{false};
   napi_env napiEnv_ = nullptr;
   std::unique_ptr<ModuleInternal> moduleInternal_;


### PR DESCRIPTION
`Runtime::isolate_` is only assigned near the end of `Init`, after the context and its bindings are set up, so between construction and that point it holds an indeterminate value. `~Runtime` and `GetIsolate()` read it unconditionally, and `currentRuntime_` already points at the runtime from the constructor on, so anything that reaches the runtime before `Init` finishes gets garbage rather than null.

This initializes it to `nullptr`, the same way `napiEnv_` next to it already is. No change for a runtime that completed `Init`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime stability by ensuring internal state is safely initialized before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->