### PR TITLE
feat(runtime): add nullability annotations to NativeScript.h

### DIFF
--- a/NativeScript/NativeScript.h
+++ b/NativeScript/NativeScript.h
@@ -1,14 +1,16 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface Config : NSObject
 
 @property (nonatomic, retain) NSString* BaseDir;
-@property (nonatomic, retain) NSString* ApplicationPath;
-@property (nonatomic) void* MetadataPtr;
+@property (nonatomic, retain, nullable) NSString* ApplicationPath;
+@property (nonatomic, nullable) void* MetadataPtr;
 @property BOOL IsDebug;
 @property BOOL LogToSystemConsole;
 @property int ArgumentsCount;
-@property (nonatomic) char** Arguments;
+@property (nonatomic) char* _Nullable* _Nullable Arguments;
 
 @end
 
@@ -26,3 +28,5 @@
 - (bool)liveSync;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/NativeScript/NativeScript.mm
+++ b/NativeScript/NativeScript.mm
@@ -184,7 +184,9 @@ std::unique_ptr<Runtime> runtime_;
           new v8_inspector::JsV8InspectorClient(runtime_.get());
       inspectorClient->init();
       inspectorClient->registerModules();
-      inspectorClient->connect([config ArgumentsCount], [config Arguments]);
+      // A nil Arguments array carries no inspector flags, whatever ArgumentsCount says.
+      inspectorClient->connect(config.Arguments != nullptr ? config.ArgumentsCount : 0,
+                               config.Arguments);
       Console::AttachInspectorClient(inspectorClient);
     }
   }


### PR DESCRIPTION
The embedder header has no nullability annotations, so a Swift embedder sees every pointer in `Config` and `NativeScript` as implicitly unwrapped. The implementation already has a clear contract: `BaseDir`, the script string and the `Config` argument are required (their `UTF8String` goes straight into a `std::string`), `ApplicationPath` and `MetadataPtr` fall back to `BaseDir/app` and the `__TNSMetadata` section when nil, `Arguments` is only read when `IsDebug` is set, and `initWithConfig:` never returns nil.

This wraps the header in `NS_ASSUME_NONNULL` and marks the three optional properties `nullable`, so Swift imports them as `String?` / `UnsafeMutableRawPointer?` / an optional argv and the rest as non-optional. No change for Objective-C callers; the in-repo consumers (TestRunner, AppWithModules, the project templates) already set the required fields. A nil `Arguments` with a stale `ArgumentsCount` made debug startup index a null argv; the inspector gets a count of 0 in that case.

Checked with `clang -fsyntax-only -Wnullability-completeness -Werror` in both Objective-C and Objective-C++, with a Swift type-check of the imported API, and with the TestRunner suite on the iOS simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clarified nullability for application configuration properties.
  - Improved compatibility for configurations where application paths, metadata, or arguments may be absent.
  - Prevented invalid inspector connection setup when no application arguments are provided.
  - Preserved configured argument counts when application arguments are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
