### PR TITLE
fix(runtime): read script caches into per-call buffers, publish them atomically

### DIFF
--- a/NativeScript/runtime/Helpers.h
+++ b/NativeScript/runtime/Helpers.h
@@ -243,10 +243,15 @@ inline bool ToBool(const v8::Local<v8::Value>& value) {
 }
 bool Exists(const char* fullPath);
 v8::Local<v8::String> ReadModule(v8::Isolate* isolate, const std::string& filePath);
-const char* ReadText(const std::string& filePath, long& length, bool& isNew);
 std::string ReadText(const std::string& file);
-uint8_t* ReadBinary(const std::string path, long& length, bool& isNew);
-bool WriteBinary(const std::string& path, const void* data, long length);
+// The whole file in a heap buffer the caller owns (delete[]); nullptr and a
+// zero length when it cannot be read.
+uint8_t* ReadBinary(const std::string& path, long& length);
+// Replaces the file at `path` atomically: readers see the old contents or the
+// new ones, never a partial write. A non-negative `modificationTime` stamps the
+// file's mtime before it is published.
+bool WriteBinary(const std::string& path, const void* data, long length,
+                 time_t modificationTime = -1);
 
 void SetPrivateValue(const v8::Local<v8::Object>& obj, const v8::Local<v8::String>& propName,
                      const v8::Local<v8::Value>& value);

--- a/NativeScript/runtime/Helpers.mm
+++ b/NativeScript/runtime/Helpers.mm
@@ -8,10 +8,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <atomic>
-#include <fstream>
+#include <cerrno>
 #include <mutex>
 #include <sstream>
+#include <vector>
 #include "Caches.h"
 #include "ErrorEvents.h"
 #include "NativeScriptException.h"
@@ -19,12 +21,6 @@
 #include "RuntimeConfig.h"
 
 using namespace v8;
-
-namespace {
-const int BUFFER_SIZE = 1024 * 1024;
-char* Buffer = new char[BUFFER_SIZE];
-uint8_t* BinBuffer = new uint8_t[BUFFER_SIZE];
-}  // namespace
 
 std::u16string tns::ToUtf16String(Isolate* isolate, const Local<Value>& value) {
   // Read the V8 string's native UTF-16 buffer directly instead of round-tripping
@@ -99,88 +95,107 @@ Local<v8::String> tns::ReadModule(Isolate* isolate, const std::string& filePath)
   return str;
 }
 
-const char* tns::ReadText(const std::string& filePath, long& length, bool& isNew) {
+// The file readers below run on the main thread and on every worker's thread
+// at once (workers load shared modules and their code caches while starting),
+// so each call reads into storage of its own; no scratch buffer is shared.
+
+std::string tns::ReadText(const std::string& filePath) {
   FILE* file = fopen(filePath.c_str(), "rb");
   if (file == nullptr) {
     tns::Assert(false);
   }
 
   fseek(file, 0, SEEK_END);
-
-  length = ftell(file);
-  isNew = length > BUFFER_SIZE;
-
+  long length = ftell(file);
   rewind(file);
 
-  if (isNew) {
-    char* newBuffer = new char[length];
-    fread(newBuffer, 1, length, file);
-    fclose(file);
-
-    return newBuffer;
+  std::string result;
+  if (length > 0) {
+    result.resize(length);
+    size_t readBytes = fread(result.data(), 1, length, file);
+    result.resize(readBytes);
   }
-
-  fread(Buffer, 1, length, file);
   fclose(file);
-
-  return Buffer;
-}
-
-std::string tns::ReadText(const std::string& file) {
-  long length;
-  bool isNew;
-  const char* content = tns::ReadText(file, length, isNew);
-
-  std::string result(content, length);
-
-  if (isNew) {
-    delete[] content;
-  }
 
   return result;
 }
 
-uint8_t* tns::ReadBinary(const std::string path, long& length, bool& isNew) {
+uint8_t* tns::ReadBinary(const std::string& path, long& length) {
   length = 0;
-  std::ifstream ifs(path);
-  if (ifs.fail()) {
-    return nullptr;
-  }
-
   FILE* file = fopen(path.c_str(), "rb");
   if (!file) {
     return nullptr;
   }
 
   fseek(file, 0, SEEK_END);
-  length = ftell(file);
+  long fileLength = ftell(file);
   rewind(file);
-
-  isNew = length > BUFFER_SIZE;
-
-  if (isNew) {
-    uint8_t* data = new uint8_t[length];
-    fread(data, sizeof(uint8_t), length, file);
+  if (fileLength <= 0) {
     fclose(file);
-    return data;
+    return nullptr;
   }
 
-  fread(BinBuffer, 1, length, file);
+  uint8_t* data = new uint8_t[fileLength];
+  size_t readBytes = fread(data, sizeof(uint8_t), fileLength, file);
   fclose(file);
+  if (readBytes != static_cast<size_t>(fileLength)) {
+    delete[] data;
+    return nullptr;
+  }
 
-  return BinBuffer;
+  length = fileLength;
+  return data;
 }
 
-bool tns::WriteBinary(const std::string& path, const void* data, long length) {
-  FILE* file = fopen(path.c_str(), "wb");
-  if (!file) {
+bool tns::WriteBinary(const std::string& path, const void* data, long length,
+                      time_t modificationTime) {
+  // Written to a private temp file in the same directory, then renamed over the
+  // target: rename is atomic on the local file system, so a concurrent reader
+  // of `path` never observes a truncated or half-written file, and two writers
+  // racing on the same path leave whichever complete file landed last.
+  std::string tmpTemplate = path + ".XXXXXX";
+  std::vector<char> tmpPath(tmpTemplate.begin(), tmpTemplate.end());
+  tmpPath.push_back('\0');
+  int fd = mkstemp(tmpPath.data());
+  if (fd < 0) {
     return false;
   }
 
-  size_t writtenBytes = fwrite(data, sizeof(uint8_t), length, file);
-  fclose(file);
+  bool ok = true;
+  const uint8_t* cursor = static_cast<const uint8_t*>(data);
+  long remaining = length;
+  while (remaining > 0) {
+    ssize_t written = write(fd, cursor, remaining);
+    if (written < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      ok = false;
+      break;
+    }
+    cursor += written;
+    remaining -= written;
+  }
 
-  return writtenBytes == length;
+  if (ok && modificationTime >= 0) {
+    struct timespec times[2];
+    times[0].tv_sec = time(nullptr);
+    times[0].tv_nsec = 0;
+    times[1].tv_sec = modificationTime;
+    times[1].tv_nsec = 0;
+    ok = futimens(fd, times) == 0;
+  }
+
+  close(fd);
+
+  if (ok && rename(tmpPath.data(), path.c_str()) != 0) {
+    ok = false;
+  }
+  if (!ok) {
+    unlink(tmpPath.data());
+  }
+
+  return ok;
 }
 
 void tns::SetPrivateValue(const Local<Object>& obj, const Local<v8::String>& propName,

--- a/NativeScript/runtime/ModuleInternal.mm
+++ b/NativeScript/runtime/ModuleInternal.mm
@@ -3,7 +3,6 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
-#include <utime.h>
 #include <cmath>
 #include <cstring>
 #include <string>
@@ -1894,15 +1893,24 @@ ScriptCompiler::CachedData* ModuleInternal::LoadScriptCache(const std::string& p
     }
   }
 
-  bool isNew = false;
-  uint8_t* data = tns::ReadBinary(cachePath, length, isNew);
+  uint8_t* data = tns::ReadBinary(cachePath, length);
   if (!data) {
     return nullptr;
   }
 
-  return new ScriptCompiler::CachedData(
-      data, (int)length,
-      isNew ? ScriptCompiler::CachedData::BufferOwned : ScriptCompiler::CachedData::BufferNotOwned);
+  return new ScriptCompiler::CachedData(data, (int)length, ScriptCompiler::CachedData::BufferOwned);
+}
+
+// A blob is published carrying its source file's modification time; that is
+// the freshness check LoadScriptCache applies, so the two must land together.
+static void WriteScriptCache(const std::string& cachePath, const std::string& sourcePath,
+                             const uint8_t* data, long length) {
+  time_t sourceModifiedTime = -1;
+  struct stat result;
+  if (stat(sourcePath.c_str(), &result) == 0) {
+    sourceModifiedTime = result.st_mtime;
+  }
+  tns::WriteBinary(cachePath, data, length, sourceModifiedTime);
 }
 
 void ModuleInternal::SaveScriptCache(const ScriptCompiler::CachedData* cache,
@@ -1911,27 +1919,8 @@ void ModuleInternal::SaveScriptCache(const ScriptCompiler::CachedData* cache,
   std::string cachePath = ModuleInternal::GetCacheFileName(
       canonicalPath + ScriptCacheSuffix(kind == ScriptCacheKind::kEsModule));
 
-  // std::ofstream ofs(cachePath, std::ios::binary);
-  // if (!ofs) return;  // or throw
-
-  // ofs.write(reinterpret_cast<const char*>(cache->data),
-  //           cache->length);
-  // ofs.close();
-
-  int length = cache->length;
-  tns::WriteBinary(cachePath, cache->data, length);
+  WriteScriptCache(cachePath, canonicalPath, cache->data, cache->length);
   delete cache;
-
-  // make sure cache and js file have the same modification date
-  struct stat result;
-  struct utimbuf new_times;
-  new_times.actime = time(nullptr);
-  new_times.modtime = time(nullptr);
-  if (stat(canonicalPath.c_str(), &result) == 0) {
-    auto jsLastModifiedTime = result.st_mtime;
-    new_times.modtime = jsLastModifiedTime;
-  }
-  utime(cachePath.c_str(), &new_times);
 }
 
 void ModuleInternal::SaveScriptCache(const Local<Script> script, const std::string& path) {
@@ -1945,23 +1934,11 @@ void ModuleInternal::SaveScriptCache(const Local<Script> script, const std::stri
   // CachedData returned by this function should be owned by the caller (v8 docs)
   ScriptCompiler::CachedData* cachedData = ScriptCompiler::CreateCodeCache(unboundScript);
 
-  int length = cachedData->length;
   // Always a classic script: this overload takes a v8::Script.
   std::string cachePath =
       ModuleInternal::GetCacheFileName(canonicalPath + ScriptCacheSuffix(false));
-  tns::WriteBinary(cachePath, cachedData->data, length);
+  WriteScriptCache(cachePath, canonicalPath, cachedData->data, cachedData->length);
   delete cachedData;
-
-  // make sure cache and js file have the same modification date
-  struct stat result;
-  struct utimbuf new_times;
-  new_times.actime = time(nullptr);
-  new_times.modtime = time(nullptr);
-  if (stat(canonicalPath.c_str(), &result) == 0) {
-    auto jsLastModifiedTime = result.st_mtime;
-    new_times.modtime = jsLastModifiedTime;
-  }
-  utime(cachePath.c_str(), &new_times);
 }
 
 std::string ModuleInternal::GetCacheFileName(const std::string& path) {

--- a/NativeScript/runtime/ModuleInternal.mm
+++ b/NativeScript/runtime/ModuleInternal.mm
@@ -1915,6 +1915,11 @@ static void WriteScriptCache(const std::string& cachePath, const std::string& so
 
 void ModuleInternal::SaveScriptCache(const ScriptCompiler::CachedData* cache,
                                      const std::string& path, ScriptCacheKind kind) {
+  // CreateCodeCache yields nullptr for a script V8 declines to serialize.
+  if (cache == nullptr) {
+    return;
+  }
+
   std::string canonicalPath = NormalizePath(path);
   std::string cachePath = ModuleInternal::GetCacheFileName(
       canonicalPath + ScriptCacheSuffix(kind == ScriptCacheKind::kEsModule));
@@ -1933,6 +1938,9 @@ void ModuleInternal::SaveScriptCache(const Local<Script> script, const std::stri
   Local<UnboundScript> unboundScript = script->GetUnboundScript();
   // CachedData returned by this function should be owned by the caller (v8 docs)
   ScriptCompiler::CachedData* cachedData = ScriptCompiler::CreateCodeCache(unboundScript);
+  if (cachedData == nullptr) {
+    return;
+  }
 
   // Always a classic script: this overload takes a v8::Script.
   std::string cachePath =

--- a/TestRunner/app/tests/WorkerConcurrentStartupTests.js
+++ b/TestRunner/app/tests/WorkerConcurrentStartupTests.js
@@ -6,22 +6,29 @@ describe("Worker startup", function () {
         expected[name] = require("./concurrentStartup/" + name).value;
     });
 
+    // Jasmine arms a spec's async timeout before calling it, so the interval
+    // has to be raised ahead of the spec, not inside it.
+    var originalTimeout;
+    beforeEach(function () {
+        originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+    });
+    afterEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+    });
+
     // Every worker thread reads script sources and code caches while it starts;
     // a batch started together loads the same files at the same moment, which
     // is how an app that spins up its workers at launch behaves. The entries
     // load the modules in rotated orders, so concurrent workers are reading
     // different files at any instant.
     it("many workers start at once against warm script caches", function (done) {
-        var originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
-
         var finished = false;
         var finish = function () {
             if (finished) {
                 return;
             }
             finished = true;
-            jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
             done();
         };
 

--- a/TestRunner/app/tests/WorkerConcurrentStartupTests.js
+++ b/TestRunner/app/tests/WorkerConcurrentStartupTests.js
@@ -1,0 +1,68 @@
+describe("Worker startup", function () {
+    var moduleNames = ["modA", "modB", "modC", "modD", "modE", "modF"];
+    var entryCount = 6;
+    var expected = {};
+    moduleNames.forEach(function (name) {
+        expected[name] = require("./concurrentStartup/" + name).value;
+    });
+
+    // Every worker thread reads script sources and code caches while it starts;
+    // a batch started together loads the same files at the same moment, which
+    // is how an app that spins up its workers at launch behaves. The entries
+    // load the modules in rotated orders, so concurrent workers are reading
+    // different files at any instant.
+    it("many workers start at once against warm script caches", function (done) {
+        var originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+
+        var finished = false;
+        var finish = function () {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+            done();
+        };
+
+        var start = function (entry, onValues) {
+            var worker = new Worker("./concurrentStartup/worker" + entry + ".js");
+            worker.onmessage = function (msg) {
+                expect(msg.data.values).toEqual(expected);
+                worker.terminate();
+                onValues();
+            };
+            worker.onerror = function (e) {
+                expect(String(e && e.message ? e.message : e)).toBe("<no worker error>");
+                worker.terminate();
+                finish();
+            };
+        };
+
+        var startBatch = function () {
+            var total = entryCount * 2;
+            var remaining = total;
+            for (var i = 0; i < total; i++) {
+                start(i % entryCount, function () {
+                    remaining--;
+                    if (remaining === 0) {
+                        finish();
+                    }
+                });
+            }
+        };
+
+        // Each entry once, one after another, so every entry's own code cache
+        // exists before the batch.
+        var warm = function (entry) {
+            if (entry === entryCount) {
+                startBatch();
+                return;
+            }
+            start(entry, function () {
+                warm(entry + 1);
+            });
+        };
+        warm(0);
+    });
+});

--- a/TestRunner/app/tests/concurrentStartup/modA.js
+++ b/TestRunner/app/tests/concurrentStartup/modA.js
@@ -1,0 +1,608 @@
+// Fixture for WorkerConcurrentStartupTests: many small functions so the
+// module's code cache is large enough that several workers consuming it
+// at once overlap in time. `value` folds every function over a seed, so a
+// corrupted load changes it or throws.
+var fns = [];
+function f0(x) { var y = (x * 31 + 0) % 1000003; return y ^ (x >>> 1); }
+fns.push(f0);
+function f1(x) { var y = (x * 31 + 1) % 1000003; return y ^ (x >>> 2); }
+fns.push(f1);
+function f2(x) { var y = (x * 31 + 2) % 1000003; return y ^ (x >>> 3); }
+fns.push(f2);
+function f3(x) { var y = (x * 31 + 3) % 1000003; return y ^ (x >>> 4); }
+fns.push(f3);
+function f4(x) { var y = (x * 31 + 4) % 1000003; return y ^ (x >>> 5); }
+fns.push(f4);
+function f5(x) { var y = (x * 31 + 5) % 1000003; return y ^ (x >>> 6); }
+fns.push(f5);
+function f6(x) { var y = (x * 31 + 6) % 1000003; return y ^ (x >>> 7); }
+fns.push(f6);
+function f7(x) { var y = (x * 31 + 7) % 1000003; return y ^ (x >>> 1); }
+fns.push(f7);
+function f8(x) { var y = (x * 31 + 8) % 1000003; return y ^ (x >>> 2); }
+fns.push(f8);
+function f9(x) { var y = (x * 31 + 9) % 1000003; return y ^ (x >>> 3); }
+fns.push(f9);
+function f10(x) { var y = (x * 31 + 10) % 1000003; return y ^ (x >>> 4); }
+fns.push(f10);
+function f11(x) { var y = (x * 31 + 11) % 1000003; return y ^ (x >>> 5); }
+fns.push(f11);
+function f12(x) { var y = (x * 31 + 12) % 1000003; return y ^ (x >>> 6); }
+fns.push(f12);
+function f13(x) { var y = (x * 31 + 13) % 1000003; return y ^ (x >>> 7); }
+fns.push(f13);
+function f14(x) { var y = (x * 31 + 14) % 1000003; return y ^ (x >>> 1); }
+fns.push(f14);
+function f15(x) { var y = (x * 31 + 15) % 1000003; return y ^ (x >>> 2); }
+fns.push(f15);
+function f16(x) { var y = (x * 31 + 16) % 1000003; return y ^ (x >>> 3); }
+fns.push(f16);
+function f17(x) { var y = (x * 31 + 17) % 1000003; return y ^ (x >>> 4); }
+fns.push(f17);
+function f18(x) { var y = (x * 31 + 18) % 1000003; return y ^ (x >>> 5); }
+fns.push(f18);
+function f19(x) { var y = (x * 31 + 19) % 1000003; return y ^ (x >>> 6); }
+fns.push(f19);
+function f20(x) { var y = (x * 31 + 20) % 1000003; return y ^ (x >>> 7); }
+fns.push(f20);
+function f21(x) { var y = (x * 31 + 21) % 1000003; return y ^ (x >>> 1); }
+fns.push(f21);
+function f22(x) { var y = (x * 31 + 22) % 1000003; return y ^ (x >>> 2); }
+fns.push(f22);
+function f23(x) { var y = (x * 31 + 23) % 1000003; return y ^ (x >>> 3); }
+fns.push(f23);
+function f24(x) { var y = (x * 31 + 24) % 1000003; return y ^ (x >>> 4); }
+fns.push(f24);
+function f25(x) { var y = (x * 31 + 25) % 1000003; return y ^ (x >>> 5); }
+fns.push(f25);
+function f26(x) { var y = (x * 31 + 26) % 1000003; return y ^ (x >>> 6); }
+fns.push(f26);
+function f27(x) { var y = (x * 31 + 27) % 1000003; return y ^ (x >>> 7); }
+fns.push(f27);
+function f28(x) { var y = (x * 31 + 28) % 1000003; return y ^ (x >>> 1); }
+fns.push(f28);
+function f29(x) { var y = (x * 31 + 29) % 1000003; return y ^ (x >>> 2); }
+fns.push(f29);
+function f30(x) { var y = (x * 31 + 30) % 1000003; return y ^ (x >>> 3); }
+fns.push(f30);
+function f31(x) { var y = (x * 31 + 31) % 1000003; return y ^ (x >>> 4); }
+fns.push(f31);
+function f32(x) { var y = (x * 31 + 32) % 1000003; return y ^ (x >>> 5); }
+fns.push(f32);
+function f33(x) { var y = (x * 31 + 33) % 1000003; return y ^ (x >>> 6); }
+fns.push(f33);
+function f34(x) { var y = (x * 31 + 34) % 1000003; return y ^ (x >>> 7); }
+fns.push(f34);
+function f35(x) { var y = (x * 31 + 35) % 1000003; return y ^ (x >>> 1); }
+fns.push(f35);
+function f36(x) { var y = (x * 31 + 36) % 1000003; return y ^ (x >>> 2); }
+fns.push(f36);
+function f37(x) { var y = (x * 31 + 37) % 1000003; return y ^ (x >>> 3); }
+fns.push(f37);
+function f38(x) { var y = (x * 31 + 38) % 1000003; return y ^ (x >>> 4); }
+fns.push(f38);
+function f39(x) { var y = (x * 31 + 39) % 1000003; return y ^ (x >>> 5); }
+fns.push(f39);
+function f40(x) { var y = (x * 31 + 40) % 1000003; return y ^ (x >>> 6); }
+fns.push(f40);
+function f41(x) { var y = (x * 31 + 41) % 1000003; return y ^ (x >>> 7); }
+fns.push(f41);
+function f42(x) { var y = (x * 31 + 42) % 1000003; return y ^ (x >>> 1); }
+fns.push(f42);
+function f43(x) { var y = (x * 31 + 43) % 1000003; return y ^ (x >>> 2); }
+fns.push(f43);
+function f44(x) { var y = (x * 31 + 44) % 1000003; return y ^ (x >>> 3); }
+fns.push(f44);
+function f45(x) { var y = (x * 31 + 45) % 1000003; return y ^ (x >>> 4); }
+fns.push(f45);
+function f46(x) { var y = (x * 31 + 46) % 1000003; return y ^ (x >>> 5); }
+fns.push(f46);
+function f47(x) { var y = (x * 31 + 47) % 1000003; return y ^ (x >>> 6); }
+fns.push(f47);
+function f48(x) { var y = (x * 31 + 48) % 1000003; return y ^ (x >>> 7); }
+fns.push(f48);
+function f49(x) { var y = (x * 31 + 49) % 1000003; return y ^ (x >>> 1); }
+fns.push(f49);
+function f50(x) { var y = (x * 31 + 50) % 1000003; return y ^ (x >>> 2); }
+fns.push(f50);
+function f51(x) { var y = (x * 31 + 51) % 1000003; return y ^ (x >>> 3); }
+fns.push(f51);
+function f52(x) { var y = (x * 31 + 52) % 1000003; return y ^ (x >>> 4); }
+fns.push(f52);
+function f53(x) { var y = (x * 31 + 53) % 1000003; return y ^ (x >>> 5); }
+fns.push(f53);
+function f54(x) { var y = (x * 31 + 54) % 1000003; return y ^ (x >>> 6); }
+fns.push(f54);
+function f55(x) { var y = (x * 31 + 55) % 1000003; return y ^ (x >>> 7); }
+fns.push(f55);
+function f56(x) { var y = (x * 31 + 56) % 1000003; return y ^ (x >>> 1); }
+fns.push(f56);
+function f57(x) { var y = (x * 31 + 57) % 1000003; return y ^ (x >>> 2); }
+fns.push(f57);
+function f58(x) { var y = (x * 31 + 58) % 1000003; return y ^ (x >>> 3); }
+fns.push(f58);
+function f59(x) { var y = (x * 31 + 59) % 1000003; return y ^ (x >>> 4); }
+fns.push(f59);
+function f60(x) { var y = (x * 31 + 60) % 1000003; return y ^ (x >>> 5); }
+fns.push(f60);
+function f61(x) { var y = (x * 31 + 61) % 1000003; return y ^ (x >>> 6); }
+fns.push(f61);
+function f62(x) { var y = (x * 31 + 62) % 1000003; return y ^ (x >>> 7); }
+fns.push(f62);
+function f63(x) { var y = (x * 31 + 63) % 1000003; return y ^ (x >>> 1); }
+fns.push(f63);
+function f64(x) { var y = (x * 31 + 64) % 1000003; return y ^ (x >>> 2); }
+fns.push(f64);
+function f65(x) { var y = (x * 31 + 65) % 1000003; return y ^ (x >>> 3); }
+fns.push(f65);
+function f66(x) { var y = (x * 31 + 66) % 1000003; return y ^ (x >>> 4); }
+fns.push(f66);
+function f67(x) { var y = (x * 31 + 67) % 1000003; return y ^ (x >>> 5); }
+fns.push(f67);
+function f68(x) { var y = (x * 31 + 68) % 1000003; return y ^ (x >>> 6); }
+fns.push(f68);
+function f69(x) { var y = (x * 31 + 69) % 1000003; return y ^ (x >>> 7); }
+fns.push(f69);
+function f70(x) { var y = (x * 31 + 70) % 1000003; return y ^ (x >>> 1); }
+fns.push(f70);
+function f71(x) { var y = (x * 31 + 71) % 1000003; return y ^ (x >>> 2); }
+fns.push(f71);
+function f72(x) { var y = (x * 31 + 72) % 1000003; return y ^ (x >>> 3); }
+fns.push(f72);
+function f73(x) { var y = (x * 31 + 73) % 1000003; return y ^ (x >>> 4); }
+fns.push(f73);
+function f74(x) { var y = (x * 31 + 74) % 1000003; return y ^ (x >>> 5); }
+fns.push(f74);
+function f75(x) { var y = (x * 31 + 75) % 1000003; return y ^ (x >>> 6); }
+fns.push(f75);
+function f76(x) { var y = (x * 31 + 76) % 1000003; return y ^ (x >>> 7); }
+fns.push(f76);
+function f77(x) { var y = (x * 31 + 77) % 1000003; return y ^ (x >>> 1); }
+fns.push(f77);
+function f78(x) { var y = (x * 31 + 78) % 1000003; return y ^ (x >>> 2); }
+fns.push(f78);
+function f79(x) { var y = (x * 31 + 79) % 1000003; return y ^ (x >>> 3); }
+fns.push(f79);
+function f80(x) { var y = (x * 31 + 80) % 1000003; return y ^ (x >>> 4); }
+fns.push(f80);
+function f81(x) { var y = (x * 31 + 81) % 1000003; return y ^ (x >>> 5); }
+fns.push(f81);
+function f82(x) { var y = (x * 31 + 82) % 1000003; return y ^ (x >>> 6); }
+fns.push(f82);
+function f83(x) { var y = (x * 31 + 83) % 1000003; return y ^ (x >>> 7); }
+fns.push(f83);
+function f84(x) { var y = (x * 31 + 84) % 1000003; return y ^ (x >>> 1); }
+fns.push(f84);
+function f85(x) { var y = (x * 31 + 85) % 1000003; return y ^ (x >>> 2); }
+fns.push(f85);
+function f86(x) { var y = (x * 31 + 86) % 1000003; return y ^ (x >>> 3); }
+fns.push(f86);
+function f87(x) { var y = (x * 31 + 87) % 1000003; return y ^ (x >>> 4); }
+fns.push(f87);
+function f88(x) { var y = (x * 31 + 88) % 1000003; return y ^ (x >>> 5); }
+fns.push(f88);
+function f89(x) { var y = (x * 31 + 89) % 1000003; return y ^ (x >>> 6); }
+fns.push(f89);
+function f90(x) { var y = (x * 31 + 90) % 1000003; return y ^ (x >>> 7); }
+fns.push(f90);
+function f91(x) { var y = (x * 31 + 91) % 1000003; return y ^ (x >>> 1); }
+fns.push(f91);
+function f92(x) { var y = (x * 31 + 92) % 1000003; return y ^ (x >>> 2); }
+fns.push(f92);
+function f93(x) { var y = (x * 31 + 93) % 1000003; return y ^ (x >>> 3); }
+fns.push(f93);
+function f94(x) { var y = (x * 31 + 94) % 1000003; return y ^ (x >>> 4); }
+fns.push(f94);
+function f95(x) { var y = (x * 31 + 95) % 1000003; return y ^ (x >>> 5); }
+fns.push(f95);
+function f96(x) { var y = (x * 31 + 96) % 1000003; return y ^ (x >>> 6); }
+fns.push(f96);
+function f97(x) { var y = (x * 31 + 97) % 1000003; return y ^ (x >>> 7); }
+fns.push(f97);
+function f98(x) { var y = (x * 31 + 98) % 1000003; return y ^ (x >>> 1); }
+fns.push(f98);
+function f99(x) { var y = (x * 31 + 99) % 1000003; return y ^ (x >>> 2); }
+fns.push(f99);
+function f100(x) { var y = (x * 31 + 100) % 1000003; return y ^ (x >>> 3); }
+fns.push(f100);
+function f101(x) { var y = (x * 31 + 101) % 1000003; return y ^ (x >>> 4); }
+fns.push(f101);
+function f102(x) { var y = (x * 31 + 102) % 1000003; return y ^ (x >>> 5); }
+fns.push(f102);
+function f103(x) { var y = (x * 31 + 103) % 1000003; return y ^ (x >>> 6); }
+fns.push(f103);
+function f104(x) { var y = (x * 31 + 104) % 1000003; return y ^ (x >>> 7); }
+fns.push(f104);
+function f105(x) { var y = (x * 31 + 105) % 1000003; return y ^ (x >>> 1); }
+fns.push(f105);
+function f106(x) { var y = (x * 31 + 106) % 1000003; return y ^ (x >>> 2); }
+fns.push(f106);
+function f107(x) { var y = (x * 31 + 107) % 1000003; return y ^ (x >>> 3); }
+fns.push(f107);
+function f108(x) { var y = (x * 31 + 108) % 1000003; return y ^ (x >>> 4); }
+fns.push(f108);
+function f109(x) { var y = (x * 31 + 109) % 1000003; return y ^ (x >>> 5); }
+fns.push(f109);
+function f110(x) { var y = (x * 31 + 110) % 1000003; return y ^ (x >>> 6); }
+fns.push(f110);
+function f111(x) { var y = (x * 31 + 111) % 1000003; return y ^ (x >>> 7); }
+fns.push(f111);
+function f112(x) { var y = (x * 31 + 112) % 1000003; return y ^ (x >>> 1); }
+fns.push(f112);
+function f113(x) { var y = (x * 31 + 113) % 1000003; return y ^ (x >>> 2); }
+fns.push(f113);
+function f114(x) { var y = (x * 31 + 114) % 1000003; return y ^ (x >>> 3); }
+fns.push(f114);
+function f115(x) { var y = (x * 31 + 115) % 1000003; return y ^ (x >>> 4); }
+fns.push(f115);
+function f116(x) { var y = (x * 31 + 116) % 1000003; return y ^ (x >>> 5); }
+fns.push(f116);
+function f117(x) { var y = (x * 31 + 117) % 1000003; return y ^ (x >>> 6); }
+fns.push(f117);
+function f118(x) { var y = (x * 31 + 118) % 1000003; return y ^ (x >>> 7); }
+fns.push(f118);
+function f119(x) { var y = (x * 31 + 119) % 1000003; return y ^ (x >>> 1); }
+fns.push(f119);
+function f120(x) { var y = (x * 31 + 120) % 1000003; return y ^ (x >>> 2); }
+fns.push(f120);
+function f121(x) { var y = (x * 31 + 121) % 1000003; return y ^ (x >>> 3); }
+fns.push(f121);
+function f122(x) { var y = (x * 31 + 122) % 1000003; return y ^ (x >>> 4); }
+fns.push(f122);
+function f123(x) { var y = (x * 31 + 123) % 1000003; return y ^ (x >>> 5); }
+fns.push(f123);
+function f124(x) { var y = (x * 31 + 124) % 1000003; return y ^ (x >>> 6); }
+fns.push(f124);
+function f125(x) { var y = (x * 31 + 125) % 1000003; return y ^ (x >>> 7); }
+fns.push(f125);
+function f126(x) { var y = (x * 31 + 126) % 1000003; return y ^ (x >>> 1); }
+fns.push(f126);
+function f127(x) { var y = (x * 31 + 127) % 1000003; return y ^ (x >>> 2); }
+fns.push(f127);
+function f128(x) { var y = (x * 31 + 128) % 1000003; return y ^ (x >>> 3); }
+fns.push(f128);
+function f129(x) { var y = (x * 31 + 129) % 1000003; return y ^ (x >>> 4); }
+fns.push(f129);
+function f130(x) { var y = (x * 31 + 130) % 1000003; return y ^ (x >>> 5); }
+fns.push(f130);
+function f131(x) { var y = (x * 31 + 131) % 1000003; return y ^ (x >>> 6); }
+fns.push(f131);
+function f132(x) { var y = (x * 31 + 132) % 1000003; return y ^ (x >>> 7); }
+fns.push(f132);
+function f133(x) { var y = (x * 31 + 133) % 1000003; return y ^ (x >>> 1); }
+fns.push(f133);
+function f134(x) { var y = (x * 31 + 134) % 1000003; return y ^ (x >>> 2); }
+fns.push(f134);
+function f135(x) { var y = (x * 31 + 135) % 1000003; return y ^ (x >>> 3); }
+fns.push(f135);
+function f136(x) { var y = (x * 31 + 136) % 1000003; return y ^ (x >>> 4); }
+fns.push(f136);
+function f137(x) { var y = (x * 31 + 137) % 1000003; return y ^ (x >>> 5); }
+fns.push(f137);
+function f138(x) { var y = (x * 31 + 138) % 1000003; return y ^ (x >>> 6); }
+fns.push(f138);
+function f139(x) { var y = (x * 31 + 139) % 1000003; return y ^ (x >>> 7); }
+fns.push(f139);
+function f140(x) { var y = (x * 31 + 140) % 1000003; return y ^ (x >>> 1); }
+fns.push(f140);
+function f141(x) { var y = (x * 31 + 141) % 1000003; return y ^ (x >>> 2); }
+fns.push(f141);
+function f142(x) { var y = (x * 31 + 142) % 1000003; return y ^ (x >>> 3); }
+fns.push(f142);
+function f143(x) { var y = (x * 31 + 143) % 1000003; return y ^ (x >>> 4); }
+fns.push(f143);
+function f144(x) { var y = (x * 31 + 144) % 1000003; return y ^ (x >>> 5); }
+fns.push(f144);
+function f145(x) { var y = (x * 31 + 145) % 1000003; return y ^ (x >>> 6); }
+fns.push(f145);
+function f146(x) { var y = (x * 31 + 146) % 1000003; return y ^ (x >>> 7); }
+fns.push(f146);
+function f147(x) { var y = (x * 31 + 147) % 1000003; return y ^ (x >>> 1); }
+fns.push(f147);
+function f148(x) { var y = (x * 31 + 148) % 1000003; return y ^ (x >>> 2); }
+fns.push(f148);
+function f149(x) { var y = (x * 31 + 149) % 1000003; return y ^ (x >>> 3); }
+fns.push(f149);
+function f150(x) { var y = (x * 31 + 150) % 1000003; return y ^ (x >>> 4); }
+fns.push(f150);
+function f151(x) { var y = (x * 31 + 151) % 1000003; return y ^ (x >>> 5); }
+fns.push(f151);
+function f152(x) { var y = (x * 31 + 152) % 1000003; return y ^ (x >>> 6); }
+fns.push(f152);
+function f153(x) { var y = (x * 31 + 153) % 1000003; return y ^ (x >>> 7); }
+fns.push(f153);
+function f154(x) { var y = (x * 31 + 154) % 1000003; return y ^ (x >>> 1); }
+fns.push(f154);
+function f155(x) { var y = (x * 31 + 155) % 1000003; return y ^ (x >>> 2); }
+fns.push(f155);
+function f156(x) { var y = (x * 31 + 156) % 1000003; return y ^ (x >>> 3); }
+fns.push(f156);
+function f157(x) { var y = (x * 31 + 157) % 1000003; return y ^ (x >>> 4); }
+fns.push(f157);
+function f158(x) { var y = (x * 31 + 158) % 1000003; return y ^ (x >>> 5); }
+fns.push(f158);
+function f159(x) { var y = (x * 31 + 159) % 1000003; return y ^ (x >>> 6); }
+fns.push(f159);
+function f160(x) { var y = (x * 31 + 160) % 1000003; return y ^ (x >>> 7); }
+fns.push(f160);
+function f161(x) { var y = (x * 31 + 161) % 1000003; return y ^ (x >>> 1); }
+fns.push(f161);
+function f162(x) { var y = (x * 31 + 162) % 1000003; return y ^ (x >>> 2); }
+fns.push(f162);
+function f163(x) { var y = (x * 31 + 163) % 1000003; return y ^ (x >>> 3); }
+fns.push(f163);
+function f164(x) { var y = (x * 31 + 164) % 1000003; return y ^ (x >>> 4); }
+fns.push(f164);
+function f165(x) { var y = (x * 31 + 165) % 1000003; return y ^ (x >>> 5); }
+fns.push(f165);
+function f166(x) { var y = (x * 31 + 166) % 1000003; return y ^ (x >>> 6); }
+fns.push(f166);
+function f167(x) { var y = (x * 31 + 167) % 1000003; return y ^ (x >>> 7); }
+fns.push(f167);
+function f168(x) { var y = (x * 31 + 168) % 1000003; return y ^ (x >>> 1); }
+fns.push(f168);
+function f169(x) { var y = (x * 31 + 169) % 1000003; return y ^ (x >>> 2); }
+fns.push(f169);
+function f170(x) { var y = (x * 31 + 170) % 1000003; return y ^ (x >>> 3); }
+fns.push(f170);
+function f171(x) { var y = (x * 31 + 171) % 1000003; return y ^ (x >>> 4); }
+fns.push(f171);
+function f172(x) { var y = (x * 31 + 172) % 1000003; return y ^ (x >>> 5); }
+fns.push(f172);
+function f173(x) { var y = (x * 31 + 173) % 1000003; return y ^ (x >>> 6); }
+fns.push(f173);
+function f174(x) { var y = (x * 31 + 174) % 1000003; return y ^ (x >>> 7); }
+fns.push(f174);
+function f175(x) { var y = (x * 31 + 175) % 1000003; return y ^ (x >>> 1); }
+fns.push(f175);
+function f176(x) { var y = (x * 31 + 176) % 1000003; return y ^ (x >>> 2); }
+fns.push(f176);
+function f177(x) { var y = (x * 31 + 177) % 1000003; return y ^ (x >>> 3); }
+fns.push(f177);
+function f178(x) { var y = (x * 31 + 178) % 1000003; return y ^ (x >>> 4); }
+fns.push(f178);
+function f179(x) { var y = (x * 31 + 179) % 1000003; return y ^ (x >>> 5); }
+fns.push(f179);
+function f180(x) { var y = (x * 31 + 180) % 1000003; return y ^ (x >>> 6); }
+fns.push(f180);
+function f181(x) { var y = (x * 31 + 181) % 1000003; return y ^ (x >>> 7); }
+fns.push(f181);
+function f182(x) { var y = (x * 31 + 182) % 1000003; return y ^ (x >>> 1); }
+fns.push(f182);
+function f183(x) { var y = (x * 31 + 183) % 1000003; return y ^ (x >>> 2); }
+fns.push(f183);
+function f184(x) { var y = (x * 31 + 184) % 1000003; return y ^ (x >>> 3); }
+fns.push(f184);
+function f185(x) { var y = (x * 31 + 185) % 1000003; return y ^ (x >>> 4); }
+fns.push(f185);
+function f186(x) { var y = (x * 31 + 186) % 1000003; return y ^ (x >>> 5); }
+fns.push(f186);
+function f187(x) { var y = (x * 31 + 187) % 1000003; return y ^ (x >>> 6); }
+fns.push(f187);
+function f188(x) { var y = (x * 31 + 188) % 1000003; return y ^ (x >>> 7); }
+fns.push(f188);
+function f189(x) { var y = (x * 31 + 189) % 1000003; return y ^ (x >>> 1); }
+fns.push(f189);
+function f190(x) { var y = (x * 31 + 190) % 1000003; return y ^ (x >>> 2); }
+fns.push(f190);
+function f191(x) { var y = (x * 31 + 191) % 1000003; return y ^ (x >>> 3); }
+fns.push(f191);
+function f192(x) { var y = (x * 31 + 192) % 1000003; return y ^ (x >>> 4); }
+fns.push(f192);
+function f193(x) { var y = (x * 31 + 193) % 1000003; return y ^ (x >>> 5); }
+fns.push(f193);
+function f194(x) { var y = (x * 31 + 194) % 1000003; return y ^ (x >>> 6); }
+fns.push(f194);
+function f195(x) { var y = (x * 31 + 195) % 1000003; return y ^ (x >>> 7); }
+fns.push(f195);
+function f196(x) { var y = (x * 31 + 196) % 1000003; return y ^ (x >>> 1); }
+fns.push(f196);
+function f197(x) { var y = (x * 31 + 197) % 1000003; return y ^ (x >>> 2); }
+fns.push(f197);
+function f198(x) { var y = (x * 31 + 198) % 1000003; return y ^ (x >>> 3); }
+fns.push(f198);
+function f199(x) { var y = (x * 31 + 199) % 1000003; return y ^ (x >>> 4); }
+fns.push(f199);
+function f200(x) { var y = (x * 31 + 200) % 1000003; return y ^ (x >>> 5); }
+fns.push(f200);
+function f201(x) { var y = (x * 31 + 201) % 1000003; return y ^ (x >>> 6); }
+fns.push(f201);
+function f202(x) { var y = (x * 31 + 202) % 1000003; return y ^ (x >>> 7); }
+fns.push(f202);
+function f203(x) { var y = (x * 31 + 203) % 1000003; return y ^ (x >>> 1); }
+fns.push(f203);
+function f204(x) { var y = (x * 31 + 204) % 1000003; return y ^ (x >>> 2); }
+fns.push(f204);
+function f205(x) { var y = (x * 31 + 205) % 1000003; return y ^ (x >>> 3); }
+fns.push(f205);
+function f206(x) { var y = (x * 31 + 206) % 1000003; return y ^ (x >>> 4); }
+fns.push(f206);
+function f207(x) { var y = (x * 31 + 207) % 1000003; return y ^ (x >>> 5); }
+fns.push(f207);
+function f208(x) { var y = (x * 31 + 208) % 1000003; return y ^ (x >>> 6); }
+fns.push(f208);
+function f209(x) { var y = (x * 31 + 209) % 1000003; return y ^ (x >>> 7); }
+fns.push(f209);
+function f210(x) { var y = (x * 31 + 210) % 1000003; return y ^ (x >>> 1); }
+fns.push(f210);
+function f211(x) { var y = (x * 31 + 211) % 1000003; return y ^ (x >>> 2); }
+fns.push(f211);
+function f212(x) { var y = (x * 31 + 212) % 1000003; return y ^ (x >>> 3); }
+fns.push(f212);
+function f213(x) { var y = (x * 31 + 213) % 1000003; return y ^ (x >>> 4); }
+fns.push(f213);
+function f214(x) { var y = (x * 31 + 214) % 1000003; return y ^ (x >>> 5); }
+fns.push(f214);
+function f215(x) { var y = (x * 31 + 215) % 1000003; return y ^ (x >>> 6); }
+fns.push(f215);
+function f216(x) { var y = (x * 31 + 216) % 1000003; return y ^ (x >>> 7); }
+fns.push(f216);
+function f217(x) { var y = (x * 31 + 217) % 1000003; return y ^ (x >>> 1); }
+fns.push(f217);
+function f218(x) { var y = (x * 31 + 218) % 1000003; return y ^ (x >>> 2); }
+fns.push(f218);
+function f219(x) { var y = (x * 31 + 219) % 1000003; return y ^ (x >>> 3); }
+fns.push(f219);
+function f220(x) { var y = (x * 31 + 220) % 1000003; return y ^ (x >>> 4); }
+fns.push(f220);
+function f221(x) { var y = (x * 31 + 221) % 1000003; return y ^ (x >>> 5); }
+fns.push(f221);
+function f222(x) { var y = (x * 31 + 222) % 1000003; return y ^ (x >>> 6); }
+fns.push(f222);
+function f223(x) { var y = (x * 31 + 223) % 1000003; return y ^ (x >>> 7); }
+fns.push(f223);
+function f224(x) { var y = (x * 31 + 224) % 1000003; return y ^ (x >>> 1); }
+fns.push(f224);
+function f225(x) { var y = (x * 31 + 225) % 1000003; return y ^ (x >>> 2); }
+fns.push(f225);
+function f226(x) { var y = (x * 31 + 226) % 1000003; return y ^ (x >>> 3); }
+fns.push(f226);
+function f227(x) { var y = (x * 31 + 227) % 1000003; return y ^ (x >>> 4); }
+fns.push(f227);
+function f228(x) { var y = (x * 31 + 228) % 1000003; return y ^ (x >>> 5); }
+fns.push(f228);
+function f229(x) { var y = (x * 31 + 229) % 1000003; return y ^ (x >>> 6); }
+fns.push(f229);
+function f230(x) { var y = (x * 31 + 230) % 1000003; return y ^ (x >>> 7); }
+fns.push(f230);
+function f231(x) { var y = (x * 31 + 231) % 1000003; return y ^ (x >>> 1); }
+fns.push(f231);
+function f232(x) { var y = (x * 31 + 232) % 1000003; return y ^ (x >>> 2); }
+fns.push(f232);
+function f233(x) { var y = (x * 31 + 233) % 1000003; return y ^ (x >>> 3); }
+fns.push(f233);
+function f234(x) { var y = (x * 31 + 234) % 1000003; return y ^ (x >>> 4); }
+fns.push(f234);
+function f235(x) { var y = (x * 31 + 235) % 1000003; return y ^ (x >>> 5); }
+fns.push(f235);
+function f236(x) { var y = (x * 31 + 236) % 1000003; return y ^ (x >>> 6); }
+fns.push(f236);
+function f237(x) { var y = (x * 31 + 237) % 1000003; return y ^ (x >>> 7); }
+fns.push(f237);
+function f238(x) { var y = (x * 31 + 238) % 1000003; return y ^ (x >>> 1); }
+fns.push(f238);
+function f239(x) { var y = (x * 31 + 239) % 1000003; return y ^ (x >>> 2); }
+fns.push(f239);
+function f240(x) { var y = (x * 31 + 240) % 1000003; return y ^ (x >>> 3); }
+fns.push(f240);
+function f241(x) { var y = (x * 31 + 241) % 1000003; return y ^ (x >>> 4); }
+fns.push(f241);
+function f242(x) { var y = (x * 31 + 242) % 1000003; return y ^ (x >>> 5); }
+fns.push(f242);
+function f243(x) { var y = (x * 31 + 243) % 1000003; return y ^ (x >>> 6); }
+fns.push(f243);
+function f244(x) { var y = (x * 31 + 244) % 1000003; return y ^ (x >>> 7); }
+fns.push(f244);
+function f245(x) { var y = (x * 31 + 245) % 1000003; return y ^ (x >>> 1); }
+fns.push(f245);
+function f246(x) { var y = (x * 31 + 246) % 1000003; return y ^ (x >>> 2); }
+fns.push(f246);
+function f247(x) { var y = (x * 31 + 247) % 1000003; return y ^ (x >>> 3); }
+fns.push(f247);
+function f248(x) { var y = (x * 31 + 248) % 1000003; return y ^ (x >>> 4); }
+fns.push(f248);
+function f249(x) { var y = (x * 31 + 249) % 1000003; return y ^ (x >>> 5); }
+fns.push(f249);
+function f250(x) { var y = (x * 31 + 250) % 1000003; return y ^ (x >>> 6); }
+fns.push(f250);
+function f251(x) { var y = (x * 31 + 251) % 1000003; return y ^ (x >>> 7); }
+fns.push(f251);
+function f252(x) { var y = (x * 31 + 252) % 1000003; return y ^ (x >>> 1); }
+fns.push(f252);
+function f253(x) { var y = (x * 31 + 253) % 1000003; return y ^ (x >>> 2); }
+fns.push(f253);
+function f254(x) { var y = (x * 31 + 254) % 1000003; return y ^ (x >>> 3); }
+fns.push(f254);
+function f255(x) { var y = (x * 31 + 255) % 1000003; return y ^ (x >>> 4); }
+fns.push(f255);
+function f256(x) { var y = (x * 31 + 256) % 1000003; return y ^ (x >>> 5); }
+fns.push(f256);
+function f257(x) { var y = (x * 31 + 257) % 1000003; return y ^ (x >>> 6); }
+fns.push(f257);
+function f258(x) { var y = (x * 31 + 258) % 1000003; return y ^ (x >>> 7); }
+fns.push(f258);
+function f259(x) { var y = (x * 31 + 259) % 1000003; return y ^ (x >>> 1); }
+fns.push(f259);
+function f260(x) { var y = (x * 31 + 260) % 1000003; return y ^ (x >>> 2); }
+fns.push(f260);
+function f261(x) { var y = (x * 31 + 261) % 1000003; return y ^ (x >>> 3); }
+fns.push(f261);
+function f262(x) { var y = (x * 31 + 262) % 1000003; return y ^ (x >>> 4); }
+fns.push(f262);
+function f263(x) { var y = (x * 31 + 263) % 1000003; return y ^ (x >>> 5); }
+fns.push(f263);
+function f264(x) { var y = (x * 31 + 264) % 1000003; return y ^ (x >>> 6); }
+fns.push(f264);
+function f265(x) { var y = (x * 31 + 265) % 1000003; return y ^ (x >>> 7); }
+fns.push(f265);
+function f266(x) { var y = (x * 31 + 266) % 1000003; return y ^ (x >>> 1); }
+fns.push(f266);
+function f267(x) { var y = (x * 31 + 267) % 1000003; return y ^ (x >>> 2); }
+fns.push(f267);
+function f268(x) { var y = (x * 31 + 268) % 1000003; return y ^ (x >>> 3); }
+fns.push(f268);
+function f269(x) { var y = (x * 31 + 269) % 1000003; return y ^ (x >>> 4); }
+fns.push(f269);
+function f270(x) { var y = (x * 31 + 270) % 1000003; return y ^ (x >>> 5); }
+fns.push(f270);
+function f271(x) { var y = (x * 31 + 271) % 1000003; return y ^ (x >>> 6); }
+fns.push(f271);
+function f272(x) { var y = (x * 31 + 272) % 1000003; return y ^ (x >>> 7); }
+fns.push(f272);
+function f273(x) { var y = (x * 31 + 273) % 1000003; return y ^ (x >>> 1); }
+fns.push(f273);
+function f274(x) { var y = (x * 31 + 274) % 1000003; return y ^ (x >>> 2); }
+fns.push(f274);
+function f275(x) { var y = (x * 31 + 275) % 1000003; return y ^ (x >>> 3); }
+fns.push(f275);
+function f276(x) { var y = (x * 31 + 276) % 1000003; return y ^ (x >>> 4); }
+fns.push(f276);
+function f277(x) { var y = (x * 31 + 277) % 1000003; return y ^ (x >>> 5); }
+fns.push(f277);
+function f278(x) { var y = (x * 31 + 278) % 1000003; return y ^ (x >>> 6); }
+fns.push(f278);
+function f279(x) { var y = (x * 31 + 279) % 1000003; return y ^ (x >>> 7); }
+fns.push(f279);
+function f280(x) { var y = (x * 31 + 280) % 1000003; return y ^ (x >>> 1); }
+fns.push(f280);
+function f281(x) { var y = (x * 31 + 281) % 1000003; return y ^ (x >>> 2); }
+fns.push(f281);
+function f282(x) { var y = (x * 31 + 282) % 1000003; return y ^ (x >>> 3); }
+fns.push(f282);
+function f283(x) { var y = (x * 31 + 283) % 1000003; return y ^ (x >>> 4); }
+fns.push(f283);
+function f284(x) { var y = (x * 31 + 284) % 1000003; return y ^ (x >>> 5); }
+fns.push(f284);
+function f285(x) { var y = (x * 31 + 285) % 1000003; return y ^ (x >>> 6); }
+fns.push(f285);
+function f286(x) { var y = (x * 31 + 286) % 1000003; return y ^ (x >>> 7); }
+fns.push(f286);
+function f287(x) { var y = (x * 31 + 287) % 1000003; return y ^ (x >>> 1); }
+fns.push(f287);
+function f288(x) { var y = (x * 31 + 288) % 1000003; return y ^ (x >>> 2); }
+fns.push(f288);
+function f289(x) { var y = (x * 31 + 289) % 1000003; return y ^ (x >>> 3); }
+fns.push(f289);
+function f290(x) { var y = (x * 31 + 290) % 1000003; return y ^ (x >>> 4); }
+fns.push(f290);
+function f291(x) { var y = (x * 31 + 291) % 1000003; return y ^ (x >>> 5); }
+fns.push(f291);
+function f292(x) { var y = (x * 31 + 292) % 1000003; return y ^ (x >>> 6); }
+fns.push(f292);
+function f293(x) { var y = (x * 31 + 293) % 1000003; return y ^ (x >>> 7); }
+fns.push(f293);
+function f294(x) { var y = (x * 31 + 294) % 1000003; return y ^ (x >>> 1); }
+fns.push(f294);
+function f295(x) { var y = (x * 31 + 295) % 1000003; return y ^ (x >>> 2); }
+fns.push(f295);
+function f296(x) { var y = (x * 31 + 296) % 1000003; return y ^ (x >>> 3); }
+fns.push(f296);
+function f297(x) { var y = (x * 31 + 297) % 1000003; return y ^ (x >>> 4); }
+fns.push(f297);
+function f298(x) { var y = (x * 31 + 298) % 1000003; return y ^ (x >>> 5); }
+fns.push(f298);
+function f299(x) { var y = (x * 31 + 299) % 1000003; return y ^ (x >>> 6); }
+fns.push(f299);
+
+exports.name = 'modA';
+exports.value = fns.reduce(function (acc, f) { return f(acc); }, 7);

--- a/TestRunner/app/tests/concurrentStartup/modB.js
+++ b/TestRunner/app/tests/concurrentStartup/modB.js
@@ -1,0 +1,608 @@
+// Fixture for WorkerConcurrentStartupTests: many small functions so the
+// module's code cache is large enough that several workers consuming it
+// at once overlap in time. `value` folds every function over a seed, so a
+// corrupted load changes it or throws.
+var fns = [];
+function f0(x) { var y = (x * 31 + 1000) % 1000003; return y ^ (x >>> 1); }
+fns.push(f0);
+function f1(x) { var y = (x * 31 + 1001) % 1000003; return y ^ (x >>> 2); }
+fns.push(f1);
+function f2(x) { var y = (x * 31 + 1002) % 1000003; return y ^ (x >>> 3); }
+fns.push(f2);
+function f3(x) { var y = (x * 31 + 1003) % 1000003; return y ^ (x >>> 4); }
+fns.push(f3);
+function f4(x) { var y = (x * 31 + 1004) % 1000003; return y ^ (x >>> 5); }
+fns.push(f4);
+function f5(x) { var y = (x * 31 + 1005) % 1000003; return y ^ (x >>> 6); }
+fns.push(f5);
+function f6(x) { var y = (x * 31 + 1006) % 1000003; return y ^ (x >>> 7); }
+fns.push(f6);
+function f7(x) { var y = (x * 31 + 1007) % 1000003; return y ^ (x >>> 1); }
+fns.push(f7);
+function f8(x) { var y = (x * 31 + 1008) % 1000003; return y ^ (x >>> 2); }
+fns.push(f8);
+function f9(x) { var y = (x * 31 + 1009) % 1000003; return y ^ (x >>> 3); }
+fns.push(f9);
+function f10(x) { var y = (x * 31 + 1010) % 1000003; return y ^ (x >>> 4); }
+fns.push(f10);
+function f11(x) { var y = (x * 31 + 1011) % 1000003; return y ^ (x >>> 5); }
+fns.push(f11);
+function f12(x) { var y = (x * 31 + 1012) % 1000003; return y ^ (x >>> 6); }
+fns.push(f12);
+function f13(x) { var y = (x * 31 + 1013) % 1000003; return y ^ (x >>> 7); }
+fns.push(f13);
+function f14(x) { var y = (x * 31 + 1014) % 1000003; return y ^ (x >>> 1); }
+fns.push(f14);
+function f15(x) { var y = (x * 31 + 1015) % 1000003; return y ^ (x >>> 2); }
+fns.push(f15);
+function f16(x) { var y = (x * 31 + 1016) % 1000003; return y ^ (x >>> 3); }
+fns.push(f16);
+function f17(x) { var y = (x * 31 + 1017) % 1000003; return y ^ (x >>> 4); }
+fns.push(f17);
+function f18(x) { var y = (x * 31 + 1018) % 1000003; return y ^ (x >>> 5); }
+fns.push(f18);
+function f19(x) { var y = (x * 31 + 1019) % 1000003; return y ^ (x >>> 6); }
+fns.push(f19);
+function f20(x) { var y = (x * 31 + 1020) % 1000003; return y ^ (x >>> 7); }
+fns.push(f20);
+function f21(x) { var y = (x * 31 + 1021) % 1000003; return y ^ (x >>> 1); }
+fns.push(f21);
+function f22(x) { var y = (x * 31 + 1022) % 1000003; return y ^ (x >>> 2); }
+fns.push(f22);
+function f23(x) { var y = (x * 31 + 1023) % 1000003; return y ^ (x >>> 3); }
+fns.push(f23);
+function f24(x) { var y = (x * 31 + 1024) % 1000003; return y ^ (x >>> 4); }
+fns.push(f24);
+function f25(x) { var y = (x * 31 + 1025) % 1000003; return y ^ (x >>> 5); }
+fns.push(f25);
+function f26(x) { var y = (x * 31 + 1026) % 1000003; return y ^ (x >>> 6); }
+fns.push(f26);
+function f27(x) { var y = (x * 31 + 1027) % 1000003; return y ^ (x >>> 7); }
+fns.push(f27);
+function f28(x) { var y = (x * 31 + 1028) % 1000003; return y ^ (x >>> 1); }
+fns.push(f28);
+function f29(x) { var y = (x * 31 + 1029) % 1000003; return y ^ (x >>> 2); }
+fns.push(f29);
+function f30(x) { var y = (x * 31 + 1030) % 1000003; return y ^ (x >>> 3); }
+fns.push(f30);
+function f31(x) { var y = (x * 31 + 1031) % 1000003; return y ^ (x >>> 4); }
+fns.push(f31);
+function f32(x) { var y = (x * 31 + 1032) % 1000003; return y ^ (x >>> 5); }
+fns.push(f32);
+function f33(x) { var y = (x * 31 + 1033) % 1000003; return y ^ (x >>> 6); }
+fns.push(f33);
+function f34(x) { var y = (x * 31 + 1034) % 1000003; return y ^ (x >>> 7); }
+fns.push(f34);
+function f35(x) { var y = (x * 31 + 1035) % 1000003; return y ^ (x >>> 1); }
+fns.push(f35);
+function f36(x) { var y = (x * 31 + 1036) % 1000003; return y ^ (x >>> 2); }
+fns.push(f36);
+function f37(x) { var y = (x * 31 + 1037) % 1000003; return y ^ (x >>> 3); }
+fns.push(f37);
+function f38(x) { var y = (x * 31 + 1038) % 1000003; return y ^ (x >>> 4); }
+fns.push(f38);
+function f39(x) { var y = (x * 31 + 1039) % 1000003; return y ^ (x >>> 5); }
+fns.push(f39);
+function f40(x) { var y = (x * 31 + 1040) % 1000003; return y ^ (x >>> 6); }
+fns.push(f40);
+function f41(x) { var y = (x * 31 + 1041) % 1000003; return y ^ (x >>> 7); }
+fns.push(f41);
+function f42(x) { var y = (x * 31 + 1042) % 1000003; return y ^ (x >>> 1); }
+fns.push(f42);
+function f43(x) { var y = (x * 31 + 1043) % 1000003; return y ^ (x >>> 2); }
+fns.push(f43);
+function f44(x) { var y = (x * 31 + 1044) % 1000003; return y ^ (x >>> 3); }
+fns.push(f44);
+function f45(x) { var y = (x * 31 + 1045) % 1000003; return y ^ (x >>> 4); }
+fns.push(f45);
+function f46(x) { var y = (x * 31 + 1046) % 1000003; return y ^ (x >>> 5); }
+fns.push(f46);
+function f47(x) { var y = (x * 31 + 1047) % 1000003; return y ^ (x >>> 6); }
+fns.push(f47);
+function f48(x) { var y = (x * 31 + 1048) % 1000003; return y ^ (x >>> 7); }
+fns.push(f48);
+function f49(x) { var y = (x * 31 + 1049) % 1000003; return y ^ (x >>> 1); }
+fns.push(f49);
+function f50(x) { var y = (x * 31 + 1050) % 1000003; return y ^ (x >>> 2); }
+fns.push(f50);
+function f51(x) { var y = (x * 31 + 1051) % 1000003; return y ^ (x >>> 3); }
+fns.push(f51);
+function f52(x) { var y = (x * 31 + 1052) % 1000003; return y ^ (x >>> 4); }
+fns.push(f52);
+function f53(x) { var y = (x * 31 + 1053) % 1000003; return y ^ (x >>> 5); }
+fns.push(f53);
+function f54(x) { var y = (x * 31 + 1054) % 1000003; return y ^ (x >>> 6); }
+fns.push(f54);
+function f55(x) { var y = (x * 31 + 1055) % 1000003; return y ^ (x >>> 7); }
+fns.push(f55);
+function f56(x) { var y = (x * 31 + 1056) % 1000003; return y ^ (x >>> 1); }
+fns.push(f56);
+function f57(x) { var y = (x * 31 + 1057) % 1000003; return y ^ (x >>> 2); }
+fns.push(f57);
+function f58(x) { var y = (x * 31 + 1058) % 1000003; return y ^ (x >>> 3); }
+fns.push(f58);
+function f59(x) { var y = (x * 31 + 1059) % 1000003; return y ^ (x >>> 4); }
+fns.push(f59);
+function f60(x) { var y = (x * 31 + 1060) % 1000003; return y ^ (x >>> 5); }
+fns.push(f60);
+function f61(x) { var y = (x * 31 + 1061) % 1000003; return y ^ (x >>> 6); }
+fns.push(f61);
+function f62(x) { var y = (x * 31 + 1062) % 1000003; return y ^ (x >>> 7); }
+fns.push(f62);
+function f63(x) { var y = (x * 31 + 1063) % 1000003; return y ^ (x >>> 1); }
+fns.push(f63);
+function f64(x) { var y = (x * 31 + 1064) % 1000003; return y ^ (x >>> 2); }
+fns.push(f64);
+function f65(x) { var y = (x * 31 + 1065) % 1000003; return y ^ (x >>> 3); }
+fns.push(f65);
+function f66(x) { var y = (x * 31 + 1066) % 1000003; return y ^ (x >>> 4); }
+fns.push(f66);
+function f67(x) { var y = (x * 31 + 1067) % 1000003; return y ^ (x >>> 5); }
+fns.push(f67);
+function f68(x) { var y = (x * 31 + 1068) % 1000003; return y ^ (x >>> 6); }
+fns.push(f68);
+function f69(x) { var y = (x * 31 + 1069) % 1000003; return y ^ (x >>> 7); }
+fns.push(f69);
+function f70(x) { var y = (x * 31 + 1070) % 1000003; return y ^ (x >>> 1); }
+fns.push(f70);
+function f71(x) { var y = (x * 31 + 1071) % 1000003; return y ^ (x >>> 2); }
+fns.push(f71);
+function f72(x) { var y = (x * 31 + 1072) % 1000003; return y ^ (x >>> 3); }
+fns.push(f72);
+function f73(x) { var y = (x * 31 + 1073) % 1000003; return y ^ (x >>> 4); }
+fns.push(f73);
+function f74(x) { var y = (x * 31 + 1074) % 1000003; return y ^ (x >>> 5); }
+fns.push(f74);
+function f75(x) { var y = (x * 31 + 1075) % 1000003; return y ^ (x >>> 6); }
+fns.push(f75);
+function f76(x) { var y = (x * 31 + 1076) % 1000003; return y ^ (x >>> 7); }
+fns.push(f76);
+function f77(x) { var y = (x * 31 + 1077) % 1000003; return y ^ (x >>> 1); }
+fns.push(f77);
+function f78(x) { var y = (x * 31 + 1078) % 1000003; return y ^ (x >>> 2); }
+fns.push(f78);
+function f79(x) { var y = (x * 31 + 1079) % 1000003; return y ^ (x >>> 3); }
+fns.push(f79);
+function f80(x) { var y = (x * 31 + 1080) % 1000003; return y ^ (x >>> 4); }
+fns.push(f80);
+function f81(x) { var y = (x * 31 + 1081) % 1000003; return y ^ (x >>> 5); }
+fns.push(f81);
+function f82(x) { var y = (x * 31 + 1082) % 1000003; return y ^ (x >>> 6); }
+fns.push(f82);
+function f83(x) { var y = (x * 31 + 1083) % 1000003; return y ^ (x >>> 7); }
+fns.push(f83);
+function f84(x) { var y = (x * 31 + 1084) % 1000003; return y ^ (x >>> 1); }
+fns.push(f84);
+function f85(x) { var y = (x * 31 + 1085) % 1000003; return y ^ (x >>> 2); }
+fns.push(f85);
+function f86(x) { var y = (x * 31 + 1086) % 1000003; return y ^ (x >>> 3); }
+fns.push(f86);
+function f87(x) { var y = (x * 31 + 1087) % 1000003; return y ^ (x >>> 4); }
+fns.push(f87);
+function f88(x) { var y = (x * 31 + 1088) % 1000003; return y ^ (x >>> 5); }
+fns.push(f88);
+function f89(x) { var y = (x * 31 + 1089) % 1000003; return y ^ (x >>> 6); }
+fns.push(f89);
+function f90(x) { var y = (x * 31 + 1090) % 1000003; return y ^ (x >>> 7); }
+fns.push(f90);
+function f91(x) { var y = (x * 31 + 1091) % 1000003; return y ^ (x >>> 1); }
+fns.push(f91);
+function f92(x) { var y = (x * 31 + 1092) % 1000003; return y ^ (x >>> 2); }
+fns.push(f92);
+function f93(x) { var y = (x * 31 + 1093) % 1000003; return y ^ (x >>> 3); }
+fns.push(f93);
+function f94(x) { var y = (x * 31 + 1094) % 1000003; return y ^ (x >>> 4); }
+fns.push(f94);
+function f95(x) { var y = (x * 31 + 1095) % 1000003; return y ^ (x >>> 5); }
+fns.push(f95);
+function f96(x) { var y = (x * 31 + 1096) % 1000003; return y ^ (x >>> 6); }
+fns.push(f96);
+function f97(x) { var y = (x * 31 + 1097) % 1000003; return y ^ (x >>> 7); }
+fns.push(f97);
+function f98(x) { var y = (x * 31 + 1098) % 1000003; return y ^ (x >>> 1); }
+fns.push(f98);
+function f99(x) { var y = (x * 31 + 1099) % 1000003; return y ^ (x >>> 2); }
+fns.push(f99);
+function f100(x) { var y = (x * 31 + 1100) % 1000003; return y ^ (x >>> 3); }
+fns.push(f100);
+function f101(x) { var y = (x * 31 + 1101) % 1000003; return y ^ (x >>> 4); }
+fns.push(f101);
+function f102(x) { var y = (x * 31 + 1102) % 1000003; return y ^ (x >>> 5); }
+fns.push(f102);
+function f103(x) { var y = (x * 31 + 1103) % 1000003; return y ^ (x >>> 6); }
+fns.push(f103);
+function f104(x) { var y = (x * 31 + 1104) % 1000003; return y ^ (x >>> 7); }
+fns.push(f104);
+function f105(x) { var y = (x * 31 + 1105) % 1000003; return y ^ (x >>> 1); }
+fns.push(f105);
+function f106(x) { var y = (x * 31 + 1106) % 1000003; return y ^ (x >>> 2); }
+fns.push(f106);
+function f107(x) { var y = (x * 31 + 1107) % 1000003; return y ^ (x >>> 3); }
+fns.push(f107);
+function f108(x) { var y = (x * 31 + 1108) % 1000003; return y ^ (x >>> 4); }
+fns.push(f108);
+function f109(x) { var y = (x * 31 + 1109) % 1000003; return y ^ (x >>> 5); }
+fns.push(f109);
+function f110(x) { var y = (x * 31 + 1110) % 1000003; return y ^ (x >>> 6); }
+fns.push(f110);
+function f111(x) { var y = (x * 31 + 1111) % 1000003; return y ^ (x >>> 7); }
+fns.push(f111);
+function f112(x) { var y = (x * 31 + 1112) % 1000003; return y ^ (x >>> 1); }
+fns.push(f112);
+function f113(x) { var y = (x * 31 + 1113) % 1000003; return y ^ (x >>> 2); }
+fns.push(f113);
+function f114(x) { var y = (x * 31 + 1114) % 1000003; return y ^ (x >>> 3); }
+fns.push(f114);
+function f115(x) { var y = (x * 31 + 1115) % 1000003; return y ^ (x >>> 4); }
+fns.push(f115);
+function f116(x) { var y = (x * 31 + 1116) % 1000003; return y ^ (x >>> 5); }
+fns.push(f116);
+function f117(x) { var y = (x * 31 + 1117) % 1000003; return y ^ (x >>> 6); }
+fns.push(f117);
+function f118(x) { var y = (x * 31 + 1118) % 1000003; return y ^ (x >>> 7); }
+fns.push(f118);
+function f119(x) { var y = (x * 31 + 1119) % 1000003; return y ^ (x >>> 1); }
+fns.push(f119);
+function f120(x) { var y = (x * 31 + 1120) % 1000003; return y ^ (x >>> 2); }
+fns.push(f120);
+function f121(x) { var y = (x * 31 + 1121) % 1000003; return y ^ (x >>> 3); }
+fns.push(f121);
+function f122(x) { var y = (x * 31 + 1122) % 1000003; return y ^ (x >>> 4); }
+fns.push(f122);
+function f123(x) { var y = (x * 31 + 1123) % 1000003; return y ^ (x >>> 5); }
+fns.push(f123);
+function f124(x) { var y = (x * 31 + 1124) % 1000003; return y ^ (x >>> 6); }
+fns.push(f124);
+function f125(x) { var y = (x * 31 + 1125) % 1000003; return y ^ (x >>> 7); }
+fns.push(f125);
+function f126(x) { var y = (x * 31 + 1126) % 1000003; return y ^ (x >>> 1); }
+fns.push(f126);
+function f127(x) { var y = (x * 31 + 1127) % 1000003; return y ^ (x >>> 2); }
+fns.push(f127);
+function f128(x) { var y = (x * 31 + 1128) % 1000003; return y ^ (x >>> 3); }
+fns.push(f128);
+function f129(x) { var y = (x * 31 + 1129) % 1000003; return y ^ (x >>> 4); }
+fns.push(f129);
+function f130(x) { var y = (x * 31 + 1130) % 1000003; return y ^ (x >>> 5); }
+fns.push(f130);
+function f131(x) { var y = (x * 31 + 1131) % 1000003; return y ^ (x >>> 6); }
+fns.push(f131);
+function f132(x) { var y = (x * 31 + 1132) % 1000003; return y ^ (x >>> 7); }
+fns.push(f132);
+function f133(x) { var y = (x * 31 + 1133) % 1000003; return y ^ (x >>> 1); }
+fns.push(f133);
+function f134(x) { var y = (x * 31 + 1134) % 1000003; return y ^ (x >>> 2); }
+fns.push(f134);
+function f135(x) { var y = (x * 31 + 1135) % 1000003; return y ^ (x >>> 3); }
+fns.push(f135);
+function f136(x) { var y = (x * 31 + 1136) % 1000003; return y ^ (x >>> 4); }
+fns.push(f136);
+function f137(x) { var y = (x * 31 + 1137) % 1000003; return y ^ (x >>> 5); }
+fns.push(f137);
+function f138(x) { var y = (x * 31 + 1138) % 1000003; return y ^ (x >>> 6); }
+fns.push(f138);
+function f139(x) { var y = (x * 31 + 1139) % 1000003; return y ^ (x >>> 7); }
+fns.push(f139);
+function f140(x) { var y = (x * 31 + 1140) % 1000003; return y ^ (x >>> 1); }
+fns.push(f140);
+function f141(x) { var y = (x * 31 + 1141) % 1000003; return y ^ (x >>> 2); }
+fns.push(f141);
+function f142(x) { var y = (x * 31 + 1142) % 1000003; return y ^ (x >>> 3); }
+fns.push(f142);
+function f143(x) { var y = (x * 31 + 1143) % 1000003; return y ^ (x >>> 4); }
+fns.push(f143);
+function f144(x) { var y = (x * 31 + 1144) % 1000003; return y ^ (x >>> 5); }
+fns.push(f144);
+function f145(x) { var y = (x * 31 + 1145) % 1000003; return y ^ (x >>> 6); }
+fns.push(f145);
+function f146(x) { var y = (x * 31 + 1146) % 1000003; return y ^ (x >>> 7); }
+fns.push(f146);
+function f147(x) { var y = (x * 31 + 1147) % 1000003; return y ^ (x >>> 1); }
+fns.push(f147);
+function f148(x) { var y = (x * 31 + 1148) % 1000003; return y ^ (x >>> 2); }
+fns.push(f148);
+function f149(x) { var y = (x * 31 + 1149) % 1000003; return y ^ (x >>> 3); }
+fns.push(f149);
+function f150(x) { var y = (x * 31 + 1150) % 1000003; return y ^ (x >>> 4); }
+fns.push(f150);
+function f151(x) { var y = (x * 31 + 1151) % 1000003; return y ^ (x >>> 5); }
+fns.push(f151);
+function f152(x) { var y = (x * 31 + 1152) % 1000003; return y ^ (x >>> 6); }
+fns.push(f152);
+function f153(x) { var y = (x * 31 + 1153) % 1000003; return y ^ (x >>> 7); }
+fns.push(f153);
+function f154(x) { var y = (x * 31 + 1154) % 1000003; return y ^ (x >>> 1); }
+fns.push(f154);
+function f155(x) { var y = (x * 31 + 1155) % 1000003; return y ^ (x >>> 2); }
+fns.push(f155);
+function f156(x) { var y = (x * 31 + 1156) % 1000003; return y ^ (x >>> 3); }
+fns.push(f156);
+function f157(x) { var y = (x * 31 + 1157) % 1000003; return y ^ (x >>> 4); }
+fns.push(f157);
+function f158(x) { var y = (x * 31 + 1158) % 1000003; return y ^ (x >>> 5); }
+fns.push(f158);
+function f159(x) { var y = (x * 31 + 1159) % 1000003; return y ^ (x >>> 6); }
+fns.push(f159);
+function f160(x) { var y = (x * 31 + 1160) % 1000003; return y ^ (x >>> 7); }
+fns.push(f160);
+function f161(x) { var y = (x * 31 + 1161) % 1000003; return y ^ (x >>> 1); }
+fns.push(f161);
+function f162(x) { var y = (x * 31 + 1162) % 1000003; return y ^ (x >>> 2); }
+fns.push(f162);
+function f163(x) { var y = (x * 31 + 1163) % 1000003; return y ^ (x >>> 3); }
+fns.push(f163);
+function f164(x) { var y = (x * 31 + 1164) % 1000003; return y ^ (x >>> 4); }
+fns.push(f164);
+function f165(x) { var y = (x * 31 + 1165) % 1000003; return y ^ (x >>> 5); }
+fns.push(f165);
+function f166(x) { var y = (x * 31 + 1166) % 1000003; return y ^ (x >>> 6); }
+fns.push(f166);
+function f167(x) { var y = (x * 31 + 1167) % 1000003; return y ^ (x >>> 7); }
+fns.push(f167);
+function f168(x) { var y = (x * 31 + 1168) % 1000003; return y ^ (x >>> 1); }
+fns.push(f168);
+function f169(x) { var y = (x * 31 + 1169) % 1000003; return y ^ (x >>> 2); }
+fns.push(f169);
+function f170(x) { var y = (x * 31 + 1170) % 1000003; return y ^ (x >>> 3); }
+fns.push(f170);
+function f171(x) { var y = (x * 31 + 1171) % 1000003; return y ^ (x >>> 4); }
+fns.push(f171);
+function f172(x) { var y = (x * 31 + 1172) % 1000003; return y ^ (x >>> 5); }
+fns.push(f172);
+function f173(x) { var y = (x * 31 + 1173) % 1000003; return y ^ (x >>> 6); }
+fns.push(f173);
+function f174(x) { var y = (x * 31 + 1174) % 1000003; return y ^ (x >>> 7); }
+fns.push(f174);
+function f175(x) { var y = (x * 31 + 1175) % 1000003; return y ^ (x >>> 1); }
+fns.push(f175);
+function f176(x) { var y = (x * 31 + 1176) % 1000003; return y ^ (x >>> 2); }
+fns.push(f176);
+function f177(x) { var y = (x * 31 + 1177) % 1000003; return y ^ (x >>> 3); }
+fns.push(f177);
+function f178(x) { var y = (x * 31 + 1178) % 1000003; return y ^ (x >>> 4); }
+fns.push(f178);
+function f179(x) { var y = (x * 31 + 1179) % 1000003; return y ^ (x >>> 5); }
+fns.push(f179);
+function f180(x) { var y = (x * 31 + 1180) % 1000003; return y ^ (x >>> 6); }
+fns.push(f180);
+function f181(x) { var y = (x * 31 + 1181) % 1000003; return y ^ (x >>> 7); }
+fns.push(f181);
+function f182(x) { var y = (x * 31 + 1182) % 1000003; return y ^ (x >>> 1); }
+fns.push(f182);
+function f183(x) { var y = (x * 31 + 1183) % 1000003; return y ^ (x >>> 2); }
+fns.push(f183);
+function f184(x) { var y = (x * 31 + 1184) % 1000003; return y ^ (x >>> 3); }
+fns.push(f184);
+function f185(x) { var y = (x * 31 + 1185) % 1000003; return y ^ (x >>> 4); }
+fns.push(f185);
+function f186(x) { var y = (x * 31 + 1186) % 1000003; return y ^ (x >>> 5); }
+fns.push(f186);
+function f187(x) { var y = (x * 31 + 1187) % 1000003; return y ^ (x >>> 6); }
+fns.push(f187);
+function f188(x) { var y = (x * 31 + 1188) % 1000003; return y ^ (x >>> 7); }
+fns.push(f188);
+function f189(x) { var y = (x * 31 + 1189) % 1000003; return y ^ (x >>> 1); }
+fns.push(f189);
+function f190(x) { var y = (x * 31 + 1190) % 1000003; return y ^ (x >>> 2); }
+fns.push(f190);
+function f191(x) { var y = (x * 31 + 1191) % 1000003; return y ^ (x >>> 3); }
+fns.push(f191);
+function f192(x) { var y = (x * 31 + 1192) % 1000003; return y ^ (x >>> 4); }
+fns.push(f192);
+function f193(x) { var y = (x * 31 + 1193) % 1000003; return y ^ (x >>> 5); }
+fns.push(f193);
+function f194(x) { var y = (x * 31 + 1194) % 1000003; return y ^ (x >>> 6); }
+fns.push(f194);
+function f195(x) { var y = (x * 31 + 1195) % 1000003; return y ^ (x >>> 7); }
+fns.push(f195);
+function f196(x) { var y = (x * 31 + 1196) % 1000003; return y ^ (x >>> 1); }
+fns.push(f196);
+function f197(x) { var y = (x * 31 + 1197) % 1000003; return y ^ (x >>> 2); }
+fns.push(f197);
+function f198(x) { var y = (x * 31 + 1198) % 1000003; return y ^ (x >>> 3); }
+fns.push(f198);
+function f199(x) { var y = (x * 31 + 1199) % 1000003; return y ^ (x >>> 4); }
+fns.push(f199);
+function f200(x) { var y = (x * 31 + 1200) % 1000003; return y ^ (x >>> 5); }
+fns.push(f200);
+function f201(x) { var y = (x * 31 + 1201) % 1000003; return y ^ (x >>> 6); }
+fns.push(f201);
+function f202(x) { var y = (x * 31 + 1202) % 1000003; return y ^ (x >>> 7); }
+fns.push(f202);
+function f203(x) { var y = (x * 31 + 1203) % 1000003; return y ^ (x >>> 1); }
+fns.push(f203);
+function f204(x) { var y = (x * 31 + 1204) % 1000003; return y ^ (x >>> 2); }
+fns.push(f204);
+function f205(x) { var y = (x * 31 + 1205) % 1000003; return y ^ (x >>> 3); }
+fns.push(f205);
+function f206(x) { var y = (x * 31 + 1206) % 1000003; return y ^ (x >>> 4); }
+fns.push(f206);
+function f207(x) { var y = (x * 31 + 1207) % 1000003; return y ^ (x >>> 5); }
+fns.push(f207);
+function f208(x) { var y = (x * 31 + 1208) % 1000003; return y ^ (x >>> 6); }
+fns.push(f208);
+function f209(x) { var y = (x * 31 + 1209) % 1000003; return y ^ (x >>> 7); }
+fns.push(f209);
+function f210(x) { var y = (x * 31 + 1210) % 1000003; return y ^ (x >>> 1); }
+fns.push(f210);
+function f211(x) { var y = (x * 31 + 1211) % 1000003; return y ^ (x >>> 2); }
+fns.push(f211);
+function f212(x) { var y = (x * 31 + 1212) % 1000003; return y ^ (x >>> 3); }
+fns.push(f212);
+function f213(x) { var y = (x * 31 + 1213) % 1000003; return y ^ (x >>> 4); }
+fns.push(f213);
+function f214(x) { var y = (x * 31 + 1214) % 1000003; return y ^ (x >>> 5); }
+fns.push(f214);
+function f215(x) { var y = (x * 31 + 1215) % 1000003; return y ^ (x >>> 6); }
+fns.push(f215);
+function f216(x) { var y = (x * 31 + 1216) % 1000003; return y ^ (x >>> 7); }
+fns.push(f216);
+function f217(x) { var y = (x * 31 + 1217) % 1000003; return y ^ (x >>> 1); }
+fns.push(f217);
+function f218(x) { var y = (x * 31 + 1218) % 1000003; return y ^ (x >>> 2); }
+fns.push(f218);
+function f219(x) { var y = (x * 31 + 1219) % 1000003; return y ^ (x >>> 3); }
+fns.push(f219);
+function f220(x) { var y = (x * 31 + 1220) % 1000003; return y ^ (x >>> 4); }
+fns.push(f220);
+function f221(x) { var y = (x * 31 + 1221) % 1000003; return y ^ (x >>> 5); }
+fns.push(f221);
+function f222(x) { var y = (x * 31 + 1222) % 1000003; return y ^ (x >>> 6); }
+fns.push(f222);
+function f223(x) { var y = (x * 31 + 1223) % 1000003; return y ^ (x >>> 7); }
+fns.push(f223);
+function f224(x) { var y = (x * 31 + 1224) % 1000003; return y ^ (x >>> 1); }
+fns.push(f224);
+function f225(x) { var y = (x * 31 + 1225) % 1000003; return y ^ (x >>> 2); }
+fns.push(f225);
+function f226(x) { var y = (x * 31 + 1226) % 1000003; return y ^ (x >>> 3); }
+fns.push(f226);
+function f227(x) { var y = (x * 31 + 1227) % 1000003; return y ^ (x >>> 4); }
+fns.push(f227);
+function f228(x) { var y = (x * 31 + 1228) % 1000003; return y ^ (x >>> 5); }
+fns.push(f228);
+function f229(x) { var y = (x * 31 + 1229) % 1000003; return y ^ (x >>> 6); }
+fns.push(f229);
+function f230(x) { var y = (x * 31 + 1230) % 1000003; return y ^ (x >>> 7); }
+fns.push(f230);
+function f231(x) { var y = (x * 31 + 1231) % 1000003; return y ^ (x >>> 1); }
+fns.push(f231);
+function f232(x) { var y = (x * 31 + 1232) % 1000003; return y ^ (x >>> 2); }
+fns.push(f232);
+function f233(x) { var y = (x * 31 + 1233) % 1000003; return y ^ (x >>> 3); }
+fns.push(f233);
+function f234(x) { var y = (x * 31 + 1234) % 1000003; return y ^ (x >>> 4); }
+fns.push(f234);
+function f235(x) { var y = (x * 31 + 1235) % 1000003; return y ^ (x >>> 5); }
+fns.push(f235);
+function f236(x) { var y = (x * 31 + 1236) % 1000003; return y ^ (x >>> 6); }
+fns.push(f236);
+function f237(x) { var y = (x * 31 + 1237) % 1000003; return y ^ (x >>> 7); }
+fns.push(f237);
+function f238(x) { var y = (x * 31 + 1238) % 1000003; return y ^ (x >>> 1); }
+fns.push(f238);
+function f239(x) { var y = (x * 31 + 1239) % 1000003; return y ^ (x >>> 2); }
+fns.push(f239);
+function f240(x) { var y = (x * 31 + 1240) % 1000003; return y ^ (x >>> 3); }
+fns.push(f240);
+function f241(x) { var y = (x * 31 + 1241) % 1000003; return y ^ (x >>> 4); }
+fns.push(f241);
+function f242(x) { var y = (x * 31 + 1242) % 1000003; return y ^ (x >>> 5); }
+fns.push(f242);
+function f243(x) { var y = (x * 31 + 1243) % 1000003; return y ^ (x >>> 6); }
+fns.push(f243);
+function f244(x) { var y = (x * 31 + 1244) % 1000003; return y ^ (x >>> 7); }
+fns.push(f244);
+function f245(x) { var y = (x * 31 + 1245) % 1000003; return y ^ (x >>> 1); }
+fns.push(f245);
+function f246(x) { var y = (x * 31 + 1246) % 1000003; return y ^ (x >>> 2); }
+fns.push(f246);
+function f247(x) { var y = (x * 31 + 1247) % 1000003; return y ^ (x >>> 3); }
+fns.push(f247);
+function f248(x) { var y = (x * 31 + 1248) % 1000003; return y ^ (x >>> 4); }
+fns.push(f248);
+function f249(x) { var y = (x * 31 + 1249) % 1000003; return y ^ (x >>> 5); }
+fns.push(f249);
+function f250(x) { var y = (x * 31 + 1250) % 1000003; return y ^ (x >>> 6); }
+fns.push(f250);
+function f251(x) { var y = (x * 31 + 1251) % 1000003; return y ^ (x >>> 7); }
+fns.push(f251);
+function f252(x) { var y = (x * 31 + 1252) % 1000003; return y ^ (x >>> 1); }
+fns.push(f252);
+function f253(x) { var y = (x * 31 + 1253) % 1000003; return y ^ (x >>> 2); }
+fns.push(f253);
+function f254(x) { var y = (x * 31 + 1254) % 1000003; return y ^ (x >>> 3); }
+fns.push(f254);
+function f255(x) { var y = (x * 31 + 1255) % 1000003; return y ^ (x >>> 4); }
+fns.push(f255);
+function f256(x) { var y = (x * 31 + 1256) % 1000003; return y ^ (x >>> 5); }
+fns.push(f256);
+function f257(x) { var y = (x * 31 + 1257) % 1000003; return y ^ (x >>> 6); }
+fns.push(f257);
+function f258(x) { var y = (x * 31 + 1258) % 1000003; return y ^ (x >>> 7); }
+fns.push(f258);
+function f259(x) { var y = (x * 31 + 1259) % 1000003; return y ^ (x >>> 1); }
+fns.push(f259);
+function f260(x) { var y = (x * 31 + 1260) % 1000003; return y ^ (x >>> 2); }
+fns.push(f260);
+function f261(x) { var y = (x * 31 + 1261) % 1000003; return y ^ (x >>> 3); }
+fns.push(f261);
+function f262(x) { var y = (x * 31 + 1262) % 1000003; return y ^ (x >>> 4); }
+fns.push(f262);
+function f263(x) { var y = (x * 31 + 1263) % 1000003; return y ^ (x >>> 5); }
+fns.push(f263);
+function f264(x) { var y = (x * 31 + 1264) % 1000003; return y ^ (x >>> 6); }
+fns.push(f264);
+function f265(x) { var y = (x * 31 + 1265) % 1000003; return y ^ (x >>> 7); }
+fns.push(f265);
+function f266(x) { var y = (x * 31 + 1266) % 1000003; return y ^ (x >>> 1); }
+fns.push(f266);
+function f267(x) { var y = (x * 31 + 1267) % 1000003; return y ^ (x >>> 2); }
+fns.push(f267);
+function f268(x) { var y = (x * 31 + 1268) % 1000003; return y ^ (x >>> 3); }
+fns.push(f268);
+function f269(x) { var y = (x * 31 + 1269) % 1000003; return y ^ (x >>> 4); }
+fns.push(f269);
+function f270(x) { var y = (x * 31 + 1270) % 1000003; return y ^ (x >>> 5); }
+fns.push(f270);
+function f271(x) { var y = (x * 31 + 1271) % 1000003; return y ^ (x >>> 6); }
+fns.push(f271);
+function f272(x) { var y = (x * 31 + 1272) % 1000003; return y ^ (x >>> 7); }
+fns.push(f272);
+function f273(x) { var y = (x * 31 + 1273) % 1000003; return y ^ (x >>> 1); }
+fns.push(f273);
+function f274(x) { var y = (x * 31 + 1274) % 1000003; return y ^ (x >>> 2); }
+fns.push(f274);
+function f275(x) { var y = (x * 31 + 1275) % 1000003; return y ^ (x >>> 3); }
+fns.push(f275);
+function f276(x) { var y = (x * 31 + 1276) % 1000003; return y ^ (x >>> 4); }
+fns.push(f276);
+function f277(x) { var y = (x * 31 + 1277) % 1000003; return y ^ (x >>> 5); }
+fns.push(f277);
+function f278(x) { var y = (x * 31 + 1278) % 1000003; return y ^ (x >>> 6); }
+fns.push(f278);
+function f279(x) { var y = (x * 31 + 1279) % 1000003; return y ^ (x >>> 7); }
+fns.push(f279);
+function f280(x) { var y = (x * 31 + 1280) % 1000003; return y ^ (x >>> 1); }
+fns.push(f280);
+function f281(x) { var y = (x * 31 + 1281) % 1000003; return y ^ (x >>> 2); }
+fns.push(f281);
+function f282(x) { var y = (x * 31 + 1282) % 1000003; return y ^ (x >>> 3); }
+fns.push(f282);
+function f283(x) { var y = (x * 31 + 1283) % 1000003; return y ^ (x >>> 4); }
+fns.push(f283);
+function f284(x) { var y = (x * 31 + 1284) % 1000003; return y ^ (x >>> 5); }
+fns.push(f284);
+function f285(x) { var y = (x * 31 + 1285) % 1000003; return y ^ (x >>> 6); }
+fns.push(f285);
+function f286(x) { var y = (x * 31 + 1286) % 1000003; return y ^ (x >>> 7); }
+fns.push(f286);
+function f287(x) { var y = (x * 31 + 1287) % 1000003; return y ^ (x >>> 1); }
+fns.push(f287);
+function f288(x) { var y = (x * 31 + 1288) % 1000003; return y ^ (x >>> 2); }
+fns.push(f288);
+function f289(x) { var y = (x * 31 + 1289) % 1000003; return y ^ (x >>> 3); }
+fns.push(f289);
+function f290(x) { var y = (x * 31 + 1290) % 1000003; return y ^ (x >>> 4); }
+fns.push(f290);
+function f291(x) { var y = (x * 31 + 1291) % 1000003; return y ^ (x >>> 5); }
+fns.push(f291);
+function f292(x) { var y = (x * 31 + 1292) % 1000003; return y ^ (x >>> 6); }
+fns.push(f292);
+function f293(x) { var y = (x * 31 + 1293) % 1000003; return y ^ (x >>> 7); }
+fns.push(f293);
+function f294(x) { var y = (x * 31 + 1294) % 1000003; return y ^ (x >>> 1); }
+fns.push(f294);
+function f295(x) { var y = (x * 31 + 1295) % 1000003; return y ^ (x >>> 2); }
+fns.push(f295);
+function f296(x) { var y = (x * 31 + 1296) % 1000003; return y ^ (x >>> 3); }
+fns.push(f296);
+function f297(x) { var y = (x * 31 + 1297) % 1000003; return y ^ (x >>> 4); }
+fns.push(f297);
+function f298(x) { var y = (x * 31 + 1298) % 1000003; return y ^ (x >>> 5); }
+fns.push(f298);
+function f299(x) { var y = (x * 31 + 1299) % 1000003; return y ^ (x >>> 6); }
+fns.push(f299);
+
+exports.name = 'modB';
+exports.value = fns.reduce(function (acc, f) { return f(acc); }, 8);

--- a/TestRunner/app/tests/concurrentStartup/modC.js
+++ b/TestRunner/app/tests/concurrentStartup/modC.js
@@ -1,0 +1,608 @@
+// Fixture for WorkerConcurrentStartupTests: many small functions so the
+// module's code cache is large enough that several workers consuming it
+// at once overlap in time. `value` folds every function over a seed, so a
+// corrupted load changes it or throws.
+var fns = [];
+function f0(x) { var y = (x * 31 + 2000) % 1000003; return y ^ (x >>> 1); }
+fns.push(f0);
+function f1(x) { var y = (x * 31 + 2001) % 1000003; return y ^ (x >>> 2); }
+fns.push(f1);
+function f2(x) { var y = (x * 31 + 2002) % 1000003; return y ^ (x >>> 3); }
+fns.push(f2);
+function f3(x) { var y = (x * 31 + 2003) % 1000003; return y ^ (x >>> 4); }
+fns.push(f3);
+function f4(x) { var y = (x * 31 + 2004) % 1000003; return y ^ (x >>> 5); }
+fns.push(f4);
+function f5(x) { var y = (x * 31 + 2005) % 1000003; return y ^ (x >>> 6); }
+fns.push(f5);
+function f6(x) { var y = (x * 31 + 2006) % 1000003; return y ^ (x >>> 7); }
+fns.push(f6);
+function f7(x) { var y = (x * 31 + 2007) % 1000003; return y ^ (x >>> 1); }
+fns.push(f7);
+function f8(x) { var y = (x * 31 + 2008) % 1000003; return y ^ (x >>> 2); }
+fns.push(f8);
+function f9(x) { var y = (x * 31 + 2009) % 1000003; return y ^ (x >>> 3); }
+fns.push(f9);
+function f10(x) { var y = (x * 31 + 2010) % 1000003; return y ^ (x >>> 4); }
+fns.push(f10);
+function f11(x) { var y = (x * 31 + 2011) % 1000003; return y ^ (x >>> 5); }
+fns.push(f11);
+function f12(x) { var y = (x * 31 + 2012) % 1000003; return y ^ (x >>> 6); }
+fns.push(f12);
+function f13(x) { var y = (x * 31 + 2013) % 1000003; return y ^ (x >>> 7); }
+fns.push(f13);
+function f14(x) { var y = (x * 31 + 2014) % 1000003; return y ^ (x >>> 1); }
+fns.push(f14);
+function f15(x) { var y = (x * 31 + 2015) % 1000003; return y ^ (x >>> 2); }
+fns.push(f15);
+function f16(x) { var y = (x * 31 + 2016) % 1000003; return y ^ (x >>> 3); }
+fns.push(f16);
+function f17(x) { var y = (x * 31 + 2017) % 1000003; return y ^ (x >>> 4); }
+fns.push(f17);
+function f18(x) { var y = (x * 31 + 2018) % 1000003; return y ^ (x >>> 5); }
+fns.push(f18);
+function f19(x) { var y = (x * 31 + 2019) % 1000003; return y ^ (x >>> 6); }
+fns.push(f19);
+function f20(x) { var y = (x * 31 + 2020) % 1000003; return y ^ (x >>> 7); }
+fns.push(f20);
+function f21(x) { var y = (x * 31 + 2021) % 1000003; return y ^ (x >>> 1); }
+fns.push(f21);
+function f22(x) { var y = (x * 31 + 2022) % 1000003; return y ^ (x >>> 2); }
+fns.push(f22);
+function f23(x) { var y = (x * 31 + 2023) % 1000003; return y ^ (x >>> 3); }
+fns.push(f23);
+function f24(x) { var y = (x * 31 + 2024) % 1000003; return y ^ (x >>> 4); }
+fns.push(f24);
+function f25(x) { var y = (x * 31 + 2025) % 1000003; return y ^ (x >>> 5); }
+fns.push(f25);
+function f26(x) { var y = (x * 31 + 2026) % 1000003; return y ^ (x >>> 6); }
+fns.push(f26);
+function f27(x) { var y = (x * 31 + 2027) % 1000003; return y ^ (x >>> 7); }
+fns.push(f27);
+function f28(x) { var y = (x * 31 + 2028) % 1000003; return y ^ (x >>> 1); }
+fns.push(f28);
+function f29(x) { var y = (x * 31 + 2029) % 1000003; return y ^ (x >>> 2); }
+fns.push(f29);
+function f30(x) { var y = (x * 31 + 2030) % 1000003; return y ^ (x >>> 3); }
+fns.push(f30);
+function f31(x) { var y = (x * 31 + 2031) % 1000003; return y ^ (x >>> 4); }
+fns.push(f31);
+function f32(x) { var y = (x * 31 + 2032) % 1000003; return y ^ (x >>> 5); }
+fns.push(f32);
+function f33(x) { var y = (x * 31 + 2033) % 1000003; return y ^ (x >>> 6); }
+fns.push(f33);
+function f34(x) { var y = (x * 31 + 2034) % 1000003; return y ^ (x >>> 7); }
+fns.push(f34);
+function f35(x) { var y = (x * 31 + 2035) % 1000003; return y ^ (x >>> 1); }
+fns.push(f35);
+function f36(x) { var y = (x * 31 + 2036) % 1000003; return y ^ (x >>> 2); }
+fns.push(f36);
+function f37(x) { var y = (x * 31 + 2037) % 1000003; return y ^ (x >>> 3); }
+fns.push(f37);
+function f38(x) { var y = (x * 31 + 2038) % 1000003; return y ^ (x >>> 4); }
+fns.push(f38);
+function f39(x) { var y = (x * 31 + 2039) % 1000003; return y ^ (x >>> 5); }
+fns.push(f39);
+function f40(x) { var y = (x * 31 + 2040) % 1000003; return y ^ (x >>> 6); }
+fns.push(f40);
+function f41(x) { var y = (x * 31 + 2041) % 1000003; return y ^ (x >>> 7); }
+fns.push(f41);
+function f42(x) { var y = (x * 31 + 2042) % 1000003; return y ^ (x >>> 1); }
+fns.push(f42);
+function f43(x) { var y = (x * 31 + 2043) % 1000003; return y ^ (x >>> 2); }
+fns.push(f43);
+function f44(x) { var y = (x * 31 + 2044) % 1000003; return y ^ (x >>> 3); }
+fns.push(f44);
+function f45(x) { var y = (x * 31 + 2045) % 1000003; return y ^ (x >>> 4); }
+fns.push(f45);
+function f46(x) { var y = (x * 31 + 2046) % 1000003; return y ^ (x >>> 5); }
+fns.push(f46);
+function f47(x) { var y = (x * 31 + 2047) % 1000003; return y ^ (x >>> 6); }
+fns.push(f47);
+function f48(x) { var y = (x * 31 + 2048) % 1000003; return y ^ (x >>> 7); }
+fns.push(f48);
+function f49(x) { var y = (x * 31 + 2049) % 1000003; return y ^ (x >>> 1); }
+fns.push(f49);
+function f50(x) { var y = (x * 31 + 2050) % 1000003; return y ^ (x >>> 2); }
+fns.push(f50);
+function f51(x) { var y = (x * 31 + 2051) % 1000003; return y ^ (x >>> 3); }
+fns.push(f51);
+function f52(x) { var y = (x * 31 + 2052) % 1000003; return y ^ (x >>> 4); }
+fns.push(f52);
+function f53(x) { var y = (x * 31 + 2053) % 1000003; return y ^ (x >>> 5); }
+fns.push(f53);
+function f54(x) { var y = (x * 31 + 2054) % 1000003; return y ^ (x >>> 6); }
+fns.push(f54);
+function f55(x) { var y = (x * 31 + 2055) % 1000003; return y ^ (x >>> 7); }
+fns.push(f55);
+function f56(x) { var y = (x * 31 + 2056) % 1000003; return y ^ (x >>> 1); }
+fns.push(f56);
+function f57(x) { var y = (x * 31 + 2057) % 1000003; return y ^ (x >>> 2); }
+fns.push(f57);
+function f58(x) { var y = (x * 31 + 2058) % 1000003; return y ^ (x >>> 3); }
+fns.push(f58);
+function f59(x) { var y = (x * 31 + 2059) % 1000003; return y ^ (x >>> 4); }
+fns.push(f59);
+function f60(x) { var y = (x * 31 + 2060) % 1000003; return y ^ (x >>> 5); }
+fns.push(f60);
+function f61(x) { var y = (x * 31 + 2061) % 1000003; return y ^ (x >>> 6); }
+fns.push(f61);
+function f62(x) { var y = (x * 31 + 2062) % 1000003; return y ^ (x >>> 7); }
+fns.push(f62);
+function f63(x) { var y = (x * 31 + 2063) % 1000003; return y ^ (x >>> 1); }
+fns.push(f63);
+function f64(x) { var y = (x * 31 + 2064) % 1000003; return y ^ (x >>> 2); }
+fns.push(f64);
+function f65(x) { var y = (x * 31 + 2065) % 1000003; return y ^ (x >>> 3); }
+fns.push(f65);
+function f66(x) { var y = (x * 31 + 2066) % 1000003; return y ^ (x >>> 4); }
+fns.push(f66);
+function f67(x) { var y = (x * 31 + 2067) % 1000003; return y ^ (x >>> 5); }
+fns.push(f67);
+function f68(x) { var y = (x * 31 + 2068) % 1000003; return y ^ (x >>> 6); }
+fns.push(f68);
+function f69(x) { var y = (x * 31 + 2069) % 1000003; return y ^ (x >>> 7); }
+fns.push(f69);
+function f70(x) { var y = (x * 31 + 2070) % 1000003; return y ^ (x >>> 1); }
+fns.push(f70);
+function f71(x) { var y = (x * 31 + 2071) % 1000003; return y ^ (x >>> 2); }
+fns.push(f71);
+function f72(x) { var y = (x * 31 + 2072) % 1000003; return y ^ (x >>> 3); }
+fns.push(f72);
+function f73(x) { var y = (x * 31 + 2073) % 1000003; return y ^ (x >>> 4); }
+fns.push(f73);
+function f74(x) { var y = (x * 31 + 2074) % 1000003; return y ^ (x >>> 5); }
+fns.push(f74);
+function f75(x) { var y = (x * 31 + 2075) % 1000003; return y ^ (x >>> 6); }
+fns.push(f75);
+function f76(x) { var y = (x * 31 + 2076) % 1000003; return y ^ (x >>> 7); }
+fns.push(f76);
+function f77(x) { var y = (x * 31 + 2077) % 1000003; return y ^ (x >>> 1); }
+fns.push(f77);
+function f78(x) { var y = (x * 31 + 2078) % 1000003; return y ^ (x >>> 2); }
+fns.push(f78);
+function f79(x) { var y = (x * 31 + 2079) % 1000003; return y ^ (x >>> 3); }
+fns.push(f79);
+function f80(x) { var y = (x * 31 + 2080) % 1000003; return y ^ (x >>> 4); }
+fns.push(f80);
+function f81(x) { var y = (x * 31 + 2081) % 1000003; return y ^ (x >>> 5); }
+fns.push(f81);
+function f82(x) { var y = (x * 31 + 2082) % 1000003; return y ^ (x >>> 6); }
+fns.push(f82);
+function f83(x) { var y = (x * 31 + 2083) % 1000003; return y ^ (x >>> 7); }
+fns.push(f83);
+function f84(x) { var y = (x * 31 + 2084) % 1000003; return y ^ (x >>> 1); }
+fns.push(f84);
+function f85(x) { var y = (x * 31 + 2085) % 1000003; return y ^ (x >>> 2); }
+fns.push(f85);
+function f86(x) { var y = (x * 31 + 2086) % 1000003; return y ^ (x >>> 3); }
+fns.push(f86);
+function f87(x) { var y = (x * 31 + 2087) % 1000003; return y ^ (x >>> 4); }
+fns.push(f87);
+function f88(x) { var y = (x * 31 + 2088) % 1000003; return y ^ (x >>> 5); }
+fns.push(f88);
+function f89(x) { var y = (x * 31 + 2089) % 1000003; return y ^ (x >>> 6); }
+fns.push(f89);
+function f90(x) { var y = (x * 31 + 2090) % 1000003; return y ^ (x >>> 7); }
+fns.push(f90);
+function f91(x) { var y = (x * 31 + 2091) % 1000003; return y ^ (x >>> 1); }
+fns.push(f91);
+function f92(x) { var y = (x * 31 + 2092) % 1000003; return y ^ (x >>> 2); }
+fns.push(f92);
+function f93(x) { var y = (x * 31 + 2093) % 1000003; return y ^ (x >>> 3); }
+fns.push(f93);
+function f94(x) { var y = (x * 31 + 2094) % 1000003; return y ^ (x >>> 4); }
+fns.push(f94);
+function f95(x) { var y = (x * 31 + 2095) % 1000003; return y ^ (x >>> 5); }
+fns.push(f95);
+function f96(x) { var y = (x * 31 + 2096) % 1000003; return y ^ (x >>> 6); }
+fns.push(f96);
+function f97(x) { var y = (x * 31 + 2097) % 1000003; return y ^ (x >>> 7); }
+fns.push(f97);
+function f98(x) { var y = (x * 31 + 2098) % 1000003; return y ^ (x >>> 1); }
+fns.push(f98);
+function f99(x) { var y = (x * 31 + 2099) % 1000003; return y ^ (x >>> 2); }
+fns.push(f99);
+function f100(x) { var y = (x * 31 + 2100) % 1000003; return y ^ (x >>> 3); }
+fns.push(f100);
+function f101(x) { var y = (x * 31 + 2101) % 1000003; return y ^ (x >>> 4); }
+fns.push(f101);
+function f102(x) { var y = (x * 31 + 2102) % 1000003; return y ^ (x >>> 5); }
+fns.push(f102);
+function f103(x) { var y = (x * 31 + 2103) % 1000003; return y ^ (x >>> 6); }
+fns.push(f103);
+function f104(x) { var y = (x * 31 + 2104) % 1000003; return y ^ (x >>> 7); }
+fns.push(f104);
+function f105(x) { var y = (x * 31 + 2105) % 1000003; return y ^ (x >>> 1); }
+fns.push(f105);
+function f106(x) { var y = (x * 31 + 2106) % 1000003; return y ^ (x >>> 2); }
+fns.push(f106);
+function f107(x) { var y = (x * 31 + 2107) % 1000003; return y ^ (x >>> 3); }
+fns.push(f107);
+function f108(x) { var y = (x * 31 + 2108) % 1000003; return y ^ (x >>> 4); }
+fns.push(f108);
+function f109(x) { var y = (x * 31 + 2109) % 1000003; return y ^ (x >>> 5); }
+fns.push(f109);
+function f110(x) { var y = (x * 31 + 2110) % 1000003; return y ^ (x >>> 6); }
+fns.push(f110);
+function f111(x) { var y = (x * 31 + 2111) % 1000003; return y ^ (x >>> 7); }
+fns.push(f111);
+function f112(x) { var y = (x * 31 + 2112) % 1000003; return y ^ (x >>> 1); }
+fns.push(f112);
+function f113(x) { var y = (x * 31 + 2113) % 1000003; return y ^ (x >>> 2); }
+fns.push(f113);
+function f114(x) { var y = (x * 31 + 2114) % 1000003; return y ^ (x >>> 3); }
+fns.push(f114);
+function f115(x) { var y = (x * 31 + 2115) % 1000003; return y ^ (x >>> 4); }
+fns.push(f115);
+function f116(x) { var y = (x * 31 + 2116) % 1000003; return y ^ (x >>> 5); }
+fns.push(f116);
+function f117(x) { var y = (x * 31 + 2117) % 1000003; return y ^ (x >>> 6); }
+fns.push(f117);
+function f118(x) { var y = (x * 31 + 2118) % 1000003; return y ^ (x >>> 7); }
+fns.push(f118);
+function f119(x) { var y = (x * 31 + 2119) % 1000003; return y ^ (x >>> 1); }
+fns.push(f119);
+function f120(x) { var y = (x * 31 + 2120) % 1000003; return y ^ (x >>> 2); }
+fns.push(f120);
+function f121(x) { var y = (x * 31 + 2121) % 1000003; return y ^ (x >>> 3); }
+fns.push(f121);
+function f122(x) { var y = (x * 31 + 2122) % 1000003; return y ^ (x >>> 4); }
+fns.push(f122);
+function f123(x) { var y = (x * 31 + 2123) % 1000003; return y ^ (x >>> 5); }
+fns.push(f123);
+function f124(x) { var y = (x * 31 + 2124) % 1000003; return y ^ (x >>> 6); }
+fns.push(f124);
+function f125(x) { var y = (x * 31 + 2125) % 1000003; return y ^ (x >>> 7); }
+fns.push(f125);
+function f126(x) { var y = (x * 31 + 2126) % 1000003; return y ^ (x >>> 1); }
+fns.push(f126);
+function f127(x) { var y = (x * 31 + 2127) % 1000003; return y ^ (x >>> 2); }
+fns.push(f127);
+function f128(x) { var y = (x * 31 + 2128) % 1000003; return y ^ (x >>> 3); }
+fns.push(f128);
+function f129(x) { var y = (x * 31 + 2129) % 1000003; return y ^ (x >>> 4); }
+fns.push(f129);
+function f130(x) { var y = (x * 31 + 2130) % 1000003; return y ^ (x >>> 5); }
+fns.push(f130);
+function f131(x) { var y = (x * 31 + 2131) % 1000003; return y ^ (x >>> 6); }
+fns.push(f131);
+function f132(x) { var y = (x * 31 + 2132) % 1000003; return y ^ (x >>> 7); }
+fns.push(f132);
+function f133(x) { var y = (x * 31 + 2133) % 1000003; return y ^ (x >>> 1); }
+fns.push(f133);
+function f134(x) { var y = (x * 31 + 2134) % 1000003; return y ^ (x >>> 2); }
+fns.push(f134);
+function f135(x) { var y = (x * 31 + 2135) % 1000003; return y ^ (x >>> 3); }
+fns.push(f135);
+function f136(x) { var y = (x * 31 + 2136) % 1000003; return y ^ (x >>> 4); }
+fns.push(f136);
+function f137(x) { var y = (x * 31 + 2137) % 1000003; return y ^ (x >>> 5); }
+fns.push(f137);
+function f138(x) { var y = (x * 31 + 2138) % 1000003; return y ^ (x >>> 6); }
+fns.push(f138);
+function f139(x) { var y = (x * 31 + 2139) % 1000003; return y ^ (x >>> 7); }
+fns.push(f139);
+function f140(x) { var y = (x * 31 + 2140) % 1000003; return y ^ (x >>> 1); }
+fns.push(f140);
+function f141(x) { var y = (x * 31 + 2141) % 1000003; return y ^ (x >>> 2); }
+fns.push(f141);
+function f142(x) { var y = (x * 31 + 2142) % 1000003; return y ^ (x >>> 3); }
+fns.push(f142);
+function f143(x) { var y = (x * 31 + 2143) % 1000003; return y ^ (x >>> 4); }
+fns.push(f143);
+function f144(x) { var y = (x * 31 + 2144) % 1000003; return y ^ (x >>> 5); }
+fns.push(f144);
+function f145(x) { var y = (x * 31 + 2145) % 1000003; return y ^ (x >>> 6); }
+fns.push(f145);
+function f146(x) { var y = (x * 31 + 2146) % 1000003; return y ^ (x >>> 7); }
+fns.push(f146);
+function f147(x) { var y = (x * 31 + 2147) % 1000003; return y ^ (x >>> 1); }
+fns.push(f147);
+function f148(x) { var y = (x * 31 + 2148) % 1000003; return y ^ (x >>> 2); }
+fns.push(f148);
+function f149(x) { var y = (x * 31 + 2149) % 1000003; return y ^ (x >>> 3); }
+fns.push(f149);
+function f150(x) { var y = (x * 31 + 2150) % 1000003; return y ^ (x >>> 4); }
+fns.push(f150);
+function f151(x) { var y = (x * 31 + 2151) % 1000003; return y ^ (x >>> 5); }
+fns.push(f151);
+function f152(x) { var y = (x * 31 + 2152) % 1000003; return y ^ (x >>> 6); }
+fns.push(f152);
+function f153(x) { var y = (x * 31 + 2153) % 1000003; return y ^ (x >>> 7); }
+fns.push(f153);
+function f154(x) { var y = (x * 31 + 2154) % 1000003; return y ^ (x >>> 1); }
+fns.push(f154);
+function f155(x) { var y = (x * 31 + 2155) % 1000003; return y ^ (x >>> 2); }
+fns.push(f155);
+function f156(x) { var y = (x * 31 + 2156) % 1000003; return y ^ (x >>> 3); }
+fns.push(f156);
+function f157(x) { var y = (x * 31 + 2157) % 1000003; return y ^ (x >>> 4); }
+fns.push(f157);
+function f158(x) { var y = (x * 31 + 2158) % 1000003; return y ^ (x >>> 5); }
+fns.push(f158);
+function f159(x) { var y = (x * 31 + 2159) % 1000003; return y ^ (x >>> 6); }
+fns.push(f159);
+function f160(x) { var y = (x * 31 + 2160) % 1000003; return y ^ (x >>> 7); }
+fns.push(f160);
+function f161(x) { var y = (x * 31 + 2161) % 1000003; return y ^ (x >>> 1); }
+fns.push(f161);
+function f162(x) { var y = (x * 31 + 2162) % 1000003; return y ^ (x >>> 2); }
+fns.push(f162);
+function f163(x) { var y = (x * 31 + 2163) % 1000003; return y ^ (x >>> 3); }
+fns.push(f163);
+function f164(x) { var y = (x * 31 + 2164) % 1000003; return y ^ (x >>> 4); }
+fns.push(f164);
+function f165(x) { var y = (x * 31 + 2165) % 1000003; return y ^ (x >>> 5); }
+fns.push(f165);
+function f166(x) { var y = (x * 31 + 2166) % 1000003; return y ^ (x >>> 6); }
+fns.push(f166);
+function f167(x) { var y = (x * 31 + 2167) % 1000003; return y ^ (x >>> 7); }
+fns.push(f167);
+function f168(x) { var y = (x * 31 + 2168) % 1000003; return y ^ (x >>> 1); }
+fns.push(f168);
+function f169(x) { var y = (x * 31 + 2169) % 1000003; return y ^ (x >>> 2); }
+fns.push(f169);
+function f170(x) { var y = (x * 31 + 2170) % 1000003; return y ^ (x >>> 3); }
+fns.push(f170);
+function f171(x) { var y = (x * 31 + 2171) % 1000003; return y ^ (x >>> 4); }
+fns.push(f171);
+function f172(x) { var y = (x * 31 + 2172) % 1000003; return y ^ (x >>> 5); }
+fns.push(f172);
+function f173(x) { var y = (x * 31 + 2173) % 1000003; return y ^ (x >>> 6); }
+fns.push(f173);
+function f174(x) { var y = (x * 31 + 2174) % 1000003; return y ^ (x >>> 7); }
+fns.push(f174);
+function f175(x) { var y = (x * 31 + 2175) % 1000003; return y ^ (x >>> 1); }
+fns.push(f175);
+function f176(x) { var y = (x * 31 + 2176) % 1000003; return y ^ (x >>> 2); }
+fns.push(f176);
+function f177(x) { var y = (x * 31 + 2177) % 1000003; return y ^ (x >>> 3); }
+fns.push(f177);
+function f178(x) { var y = (x * 31 + 2178) % 1000003; return y ^ (x >>> 4); }
+fns.push(f178);
+function f179(x) { var y = (x * 31 + 2179) % 1000003; return y ^ (x >>> 5); }
+fns.push(f179);
+function f180(x) { var y = (x * 31 + 2180) % 1000003; return y ^ (x >>> 6); }
+fns.push(f180);
+function f181(x) { var y = (x * 31 + 2181) % 1000003; return y ^ (x >>> 7); }
+fns.push(f181);
+function f182(x) { var y = (x * 31 + 2182) % 1000003; return y ^ (x >>> 1); }
+fns.push(f182);
+function f183(x) { var y = (x * 31 + 2183) % 1000003; return y ^ (x >>> 2); }
+fns.push(f183);
+function f184(x) { var y = (x * 31 + 2184) % 1000003; return y ^ (x >>> 3); }
+fns.push(f184);
+function f185(x) { var y = (x * 31 + 2185) % 1000003; return y ^ (x >>> 4); }
+fns.push(f185);
+function f186(x) { var y = (x * 31 + 2186) % 1000003; return y ^ (x >>> 5); }
+fns.push(f186);
+function f187(x) { var y = (x * 31 + 2187) % 1000003; return y ^ (x >>> 6); }
+fns.push(f187);
+function f188(x) { var y = (x * 31 + 2188) % 1000003; return y ^ (x >>> 7); }
+fns.push(f188);
+function f189(x) { var y = (x * 31 + 2189) % 1000003; return y ^ (x >>> 1); }
+fns.push(f189);
+function f190(x) { var y = (x * 31 + 2190) % 1000003; return y ^ (x >>> 2); }
+fns.push(f190);
+function f191(x) { var y = (x * 31 + 2191) % 1000003; return y ^ (x >>> 3); }
+fns.push(f191);
+function f192(x) { var y = (x * 31 + 2192) % 1000003; return y ^ (x >>> 4); }
+fns.push(f192);
+function f193(x) { var y = (x * 31 + 2193) % 1000003; return y ^ (x >>> 5); }
+fns.push(f193);
+function f194(x) { var y = (x * 31 + 2194) % 1000003; return y ^ (x >>> 6); }
+fns.push(f194);
+function f195(x) { var y = (x * 31 + 2195) % 1000003; return y ^ (x >>> 7); }
+fns.push(f195);
+function f196(x) { var y = (x * 31 + 2196) % 1000003; return y ^ (x >>> 1); }
+fns.push(f196);
+function f197(x) { var y = (x * 31 + 2197) % 1000003; return y ^ (x >>> 2); }
+fns.push(f197);
+function f198(x) { var y = (x * 31 + 2198) % 1000003; return y ^ (x >>> 3); }
+fns.push(f198);
+function f199(x) { var y = (x * 31 + 2199) % 1000003; return y ^ (x >>> 4); }
+fns.push(f199);
+function f200(x) { var y = (x * 31 + 2200) % 1000003; return y ^ (x >>> 5); }
+fns.push(f200);
+function f201(x) { var y = (x * 31 + 2201) % 1000003; return y ^ (x >>> 6); }
+fns.push(f201);
+function f202(x) { var y = (x * 31 + 2202) % 1000003; return y ^ (x >>> 7); }
+fns.push(f202);
+function f203(x) { var y = (x * 31 + 2203) % 1000003; return y ^ (x >>> 1); }
+fns.push(f203);
+function f204(x) { var y = (x * 31 + 2204) % 1000003; return y ^ (x >>> 2); }
+fns.push(f204);
+function f205(x) { var y = (x * 31 + 2205) % 1000003; return y ^ (x >>> 3); }
+fns.push(f205);
+function f206(x) { var y = (x * 31 + 2206) % 1000003; return y ^ (x >>> 4); }
+fns.push(f206);
+function f207(x) { var y = (x * 31 + 2207) % 1000003; return y ^ (x >>> 5); }
+fns.push(f207);
+function f208(x) { var y = (x * 31 + 2208) % 1000003; return y ^ (x >>> 6); }
+fns.push(f208);
+function f209(x) { var y = (x * 31 + 2209) % 1000003; return y ^ (x >>> 7); }
+fns.push(f209);
+function f210(x) { var y = (x * 31 + 2210) % 1000003; return y ^ (x >>> 1); }
+fns.push(f210);
+function f211(x) { var y = (x * 31 + 2211) % 1000003; return y ^ (x >>> 2); }
+fns.push(f211);
+function f212(x) { var y = (x * 31 + 2212) % 1000003; return y ^ (x >>> 3); }
+fns.push(f212);
+function f213(x) { var y = (x * 31 + 2213) % 1000003; return y ^ (x >>> 4); }
+fns.push(f213);
+function f214(x) { var y = (x * 31 + 2214) % 1000003; return y ^ (x >>> 5); }
+fns.push(f214);
+function f215(x) { var y = (x * 31 + 2215) % 1000003; return y ^ (x >>> 6); }
+fns.push(f215);
+function f216(x) { var y = (x * 31 + 2216) % 1000003; return y ^ (x >>> 7); }
+fns.push(f216);
+function f217(x) { var y = (x * 31 + 2217) % 1000003; return y ^ (x >>> 1); }
+fns.push(f217);
+function f218(x) { var y = (x * 31 + 2218) % 1000003; return y ^ (x >>> 2); }
+fns.push(f218);
+function f219(x) { var y = (x * 31 + 2219) % 1000003; return y ^ (x >>> 3); }
+fns.push(f219);
+function f220(x) { var y = (x * 31 + 2220) % 1000003; return y ^ (x >>> 4); }
+fns.push(f220);
+function f221(x) { var y = (x * 31 + 2221) % 1000003; return y ^ (x >>> 5); }
+fns.push(f221);
+function f222(x) { var y = (x * 31 + 2222) % 1000003; return y ^ (x >>> 6); }
+fns.push(f222);
+function f223(x) { var y = (x * 31 + 2223) % 1000003; return y ^ (x >>> 7); }
+fns.push(f223);
+function f224(x) { var y = (x * 31 + 2224) % 1000003; return y ^ (x >>> 1); }
+fns.push(f224);
+function f225(x) { var y = (x * 31 + 2225) % 1000003; return y ^ (x >>> 2); }
+fns.push(f225);
+function f226(x) { var y = (x * 31 + 2226) % 1000003; return y ^ (x >>> 3); }
+fns.push(f226);
+function f227(x) { var y = (x * 31 + 2227) % 1000003; return y ^ (x >>> 4); }
+fns.push(f227);
+function f228(x) { var y = (x * 31 + 2228) % 1000003; return y ^ (x >>> 5); }
+fns.push(f228);
+function f229(x) { var y = (x * 31 + 2229) % 1000003; return y ^ (x >>> 6); }
+fns.push(f229);
+function f230(x) { var y = (x * 31 + 2230) % 1000003; return y ^ (x >>> 7); }
+fns.push(f230);
+function f231(x) { var y = (x * 31 + 2231) % 1000003; return y ^ (x >>> 1); }
+fns.push(f231);
+function f232(x) { var y = (x * 31 + 2232) % 1000003; return y ^ (x >>> 2); }
+fns.push(f232);
+function f233(x) { var y = (x * 31 + 2233) % 1000003; return y ^ (x >>> 3); }
+fns.push(f233);
+function f234(x) { var y = (x * 31 + 2234) % 1000003; return y ^ (x >>> 4); }
+fns.push(f234);
+function f235(x) { var y = (x * 31 + 2235) % 1000003; return y ^ (x >>> 5); }
+fns.push(f235);
+function f236(x) { var y = (x * 31 + 2236) % 1000003; return y ^ (x >>> 6); }
+fns.push(f236);
+function f237(x) { var y = (x * 31 + 2237) % 1000003; return y ^ (x >>> 7); }
+fns.push(f237);
+function f238(x) { var y = (x * 31 + 2238) % 1000003; return y ^ (x >>> 1); }
+fns.push(f238);
+function f239(x) { var y = (x * 31 + 2239) % 1000003; return y ^ (x >>> 2); }
+fns.push(f239);
+function f240(x) { var y = (x * 31 + 2240) % 1000003; return y ^ (x >>> 3); }
+fns.push(f240);
+function f241(x) { var y = (x * 31 + 2241) % 1000003; return y ^ (x >>> 4); }
+fns.push(f241);
+function f242(x) { var y = (x * 31 + 2242) % 1000003; return y ^ (x >>> 5); }
+fns.push(f242);
+function f243(x) { var y = (x * 31 + 2243) % 1000003; return y ^ (x >>> 6); }
+fns.push(f243);
+function f244(x) { var y = (x * 31 + 2244) % 1000003; return y ^ (x >>> 7); }
+fns.push(f244);
+function f245(x) { var y = (x * 31 + 2245) % 1000003; return y ^ (x >>> 1); }
+fns.push(f245);
+function f246(x) { var y = (x * 31 + 2246) % 1000003; return y ^ (x >>> 2); }
+fns.push(f246);
+function f247(x) { var y = (x * 31 + 2247) % 1000003; return y ^ (x >>> 3); }
+fns.push(f247);
+function f248(x) { var y = (x * 31 + 2248) % 1000003; return y ^ (x >>> 4); }
+fns.push(f248);
+function f249(x) { var y = (x * 31 + 2249) % 1000003; return y ^ (x >>> 5); }
+fns.push(f249);
+function f250(x) { var y = (x * 31 + 2250) % 1000003; return y ^ (x >>> 6); }
+fns.push(f250);
+function f251(x) { var y = (x * 31 + 2251) % 1000003; return y ^ (x >>> 7); }
+fns.push(f251);
+function f252(x) { var y = (x * 31 + 2252) % 1000003; return y ^ (x >>> 1); }
+fns.push(f252);
+function f253(x) { var y = (x * 31 + 2253) % 1000003; return y ^ (x >>> 2); }
+fns.push(f253);
+function f254(x) { var y = (x * 31 + 2254) % 1000003; return y ^ (x >>> 3); }
+fns.push(f254);
+function f255(x) { var y = (x * 31 + 2255) % 1000003; return y ^ (x >>> 4); }
+fns.push(f255);
+function f256(x) { var y = (x * 31 + 2256) % 1000003; return y ^ (x >>> 5); }
+fns.push(f256);
+function f257(x) { var y = (x * 31 + 2257) % 1000003; return y ^ (x >>> 6); }
+fns.push(f257);
+function f258(x) { var y = (x * 31 + 2258) % 1000003; return y ^ (x >>> 7); }
+fns.push(f258);
+function f259(x) { var y = (x * 31 + 2259) % 1000003; return y ^ (x >>> 1); }
+fns.push(f259);
+function f260(x) { var y = (x * 31 + 2260) % 1000003; return y ^ (x >>> 2); }
+fns.push(f260);
+function f261(x) { var y = (x * 31 + 2261) % 1000003; return y ^ (x >>> 3); }
+fns.push(f261);
+function f262(x) { var y = (x * 31 + 2262) % 1000003; return y ^ (x >>> 4); }
+fns.push(f262);
+function f263(x) { var y = (x * 31 + 2263) % 1000003; return y ^ (x >>> 5); }
+fns.push(f263);
+function f264(x) { var y = (x * 31 + 2264) % 1000003; return y ^ (x >>> 6); }
+fns.push(f264);
+function f265(x) { var y = (x * 31 + 2265) % 1000003; return y ^ (x >>> 7); }
+fns.push(f265);
+function f266(x) { var y = (x * 31 + 2266) % 1000003; return y ^ (x >>> 1); }
+fns.push(f266);
+function f267(x) { var y = (x * 31 + 2267) % 1000003; return y ^ (x >>> 2); }
+fns.push(f267);
+function f268(x) { var y = (x * 31 + 2268) % 1000003; return y ^ (x >>> 3); }
+fns.push(f268);
+function f269(x) { var y = (x * 31 + 2269) % 1000003; return y ^ (x >>> 4); }
+fns.push(f269);
+function f270(x) { var y = (x * 31 + 2270) % 1000003; return y ^ (x >>> 5); }
+fns.push(f270);
+function f271(x) { var y = (x * 31 + 2271) % 1000003; return y ^ (x >>> 6); }
+fns.push(f271);
+function f272(x) { var y = (x * 31 + 2272) % 1000003; return y ^ (x >>> 7); }
+fns.push(f272);
+function f273(x) { var y = (x * 31 + 2273) % 1000003; return y ^ (x >>> 1); }
+fns.push(f273);
+function f274(x) { var y = (x * 31 + 2274) % 1000003; return y ^ (x >>> 2); }
+fns.push(f274);
+function f275(x) { var y = (x * 31 + 2275) % 1000003; return y ^ (x >>> 3); }
+fns.push(f275);
+function f276(x) { var y = (x * 31 + 2276) % 1000003; return y ^ (x >>> 4); }
+fns.push(f276);
+function f277(x) { var y = (x * 31 + 2277) % 1000003; return y ^ (x >>> 5); }
+fns.push(f277);
+function f278(x) { var y = (x * 31 + 2278) % 1000003; return y ^ (x >>> 6); }
+fns.push(f278);
+function f279(x) { var y = (x * 31 + 2279) % 1000003; return y ^ (x >>> 7); }
+fns.push(f279);
+function f280(x) { var y = (x * 31 + 2280) % 1000003; return y ^ (x >>> 1); }
+fns.push(f280);
+function f281(x) { var y = (x * 31 + 2281) % 1000003; return y ^ (x >>> 2); }
+fns.push(f281);
+function f282(x) { var y = (x * 31 + 2282) % 1000003; return y ^ (x >>> 3); }
+fns.push(f282);
+function f283(x) { var y = (x * 31 + 2283) % 1000003; return y ^ (x >>> 4); }
+fns.push(f283);
+function f284(x) { var y = (x * 31 + 2284) % 1000003; return y ^ (x >>> 5); }
+fns.push(f284);
+function f285(x) { var y = (x * 31 + 2285) % 1000003; return y ^ (x >>> 6); }
+fns.push(f285);
+function f286(x) { var y = (x * 31 + 2286) % 1000003; return y ^ (x >>> 7); }
+fns.push(f286);
+function f287(x) { var y = (x * 31 + 2287) % 1000003; return y ^ (x >>> 1); }
+fns.push(f287);
+function f288(x) { var y = (x * 31 + 2288) % 1000003; return y ^ (x >>> 2); }
+fns.push(f288);
+function f289(x) { var y = (x * 31 + 2289) % 1000003; return y ^ (x >>> 3); }
+fns.push(f289);
+function f290(x) { var y = (x * 31 + 2290) % 1000003; return y ^ (x >>> 4); }
+fns.push(f290);
+function f291(x) { var y = (x * 31 + 2291) % 1000003; return y ^ (x >>> 5); }
+fns.push(f291);
+function f292(x) { var y = (x * 31 + 2292) % 1000003; return y ^ (x >>> 6); }
+fns.push(f292);
+function f293(x) { var y = (x * 31 + 2293) % 1000003; return y ^ (x >>> 7); }
+fns.push(f293);
+function f294(x) { var y = (x * 31 + 2294) % 1000003; return y ^ (x >>> 1); }
+fns.push(f294);
+function f295(x) { var y = (x * 31 + 2295) % 1000003; return y ^ (x >>> 2); }
+fns.push(f295);
+function f296(x) { var y = (x * 31 + 2296) % 1000003; return y ^ (x >>> 3); }
+fns.push(f296);
+function f297(x) { var y = (x * 31 + 2297) % 1000003; return y ^ (x >>> 4); }
+fns.push(f297);
+function f298(x) { var y = (x * 31 + 2298) % 1000003; return y ^ (x >>> 5); }
+fns.push(f298);
+function f299(x) { var y = (x * 31 + 2299) % 1000003; return y ^ (x >>> 6); }
+fns.push(f299);
+
+exports.name = 'modC';
+exports.value = fns.reduce(function (acc, f) { return f(acc); }, 9);

--- a/TestRunner/app/tests/concurrentStartup/modD.js
+++ b/TestRunner/app/tests/concurrentStartup/modD.js
@@ -1,0 +1,608 @@
+// Fixture for WorkerConcurrentStartupTests: many small functions so the
+// module's code cache is large enough that several workers consuming it
+// at once overlap in time. `value` folds every function over a seed, so a
+// corrupted load changes it or throws.
+var fns = [];
+function f0(x) { var y = (x * 31 + 3000) % 1000003; return y ^ (x >>> 1); }
+fns.push(f0);
+function f1(x) { var y = (x * 31 + 3001) % 1000003; return y ^ (x >>> 2); }
+fns.push(f1);
+function f2(x) { var y = (x * 31 + 3002) % 1000003; return y ^ (x >>> 3); }
+fns.push(f2);
+function f3(x) { var y = (x * 31 + 3003) % 1000003; return y ^ (x >>> 4); }
+fns.push(f3);
+function f4(x) { var y = (x * 31 + 3004) % 1000003; return y ^ (x >>> 5); }
+fns.push(f4);
+function f5(x) { var y = (x * 31 + 3005) % 1000003; return y ^ (x >>> 6); }
+fns.push(f5);
+function f6(x) { var y = (x * 31 + 3006) % 1000003; return y ^ (x >>> 7); }
+fns.push(f6);
+function f7(x) { var y = (x * 31 + 3007) % 1000003; return y ^ (x >>> 1); }
+fns.push(f7);
+function f8(x) { var y = (x * 31 + 3008) % 1000003; return y ^ (x >>> 2); }
+fns.push(f8);
+function f9(x) { var y = (x * 31 + 3009) % 1000003; return y ^ (x >>> 3); }
+fns.push(f9);
+function f10(x) { var y = (x * 31 + 3010) % 1000003; return y ^ (x >>> 4); }
+fns.push(f10);
+function f11(x) { var y = (x * 31 + 3011) % 1000003; return y ^ (x >>> 5); }
+fns.push(f11);
+function f12(x) { var y = (x * 31 + 3012) % 1000003; return y ^ (x >>> 6); }
+fns.push(f12);
+function f13(x) { var y = (x * 31 + 3013) % 1000003; return y ^ (x >>> 7); }
+fns.push(f13);
+function f14(x) { var y = (x * 31 + 3014) % 1000003; return y ^ (x >>> 1); }
+fns.push(f14);
+function f15(x) { var y = (x * 31 + 3015) % 1000003; return y ^ (x >>> 2); }
+fns.push(f15);
+function f16(x) { var y = (x * 31 + 3016) % 1000003; return y ^ (x >>> 3); }
+fns.push(f16);
+function f17(x) { var y = (x * 31 + 3017) % 1000003; return y ^ (x >>> 4); }
+fns.push(f17);
+function f18(x) { var y = (x * 31 + 3018) % 1000003; return y ^ (x >>> 5); }
+fns.push(f18);
+function f19(x) { var y = (x * 31 + 3019) % 1000003; return y ^ (x >>> 6); }
+fns.push(f19);
+function f20(x) { var y = (x * 31 + 3020) % 1000003; return y ^ (x >>> 7); }
+fns.push(f20);
+function f21(x) { var y = (x * 31 + 3021) % 1000003; return y ^ (x >>> 1); }
+fns.push(f21);
+function f22(x) { var y = (x * 31 + 3022) % 1000003; return y ^ (x >>> 2); }
+fns.push(f22);
+function f23(x) { var y = (x * 31 + 3023) % 1000003; return y ^ (x >>> 3); }
+fns.push(f23);
+function f24(x) { var y = (x * 31 + 3024) % 1000003; return y ^ (x >>> 4); }
+fns.push(f24);
+function f25(x) { var y = (x * 31 + 3025) % 1000003; return y ^ (x >>> 5); }
+fns.push(f25);
+function f26(x) { var y = (x * 31 + 3026) % 1000003; return y ^ (x >>> 6); }
+fns.push(f26);
+function f27(x) { var y = (x * 31 + 3027) % 1000003; return y ^ (x >>> 7); }
+fns.push(f27);
+function f28(x) { var y = (x * 31 + 3028) % 1000003; return y ^ (x >>> 1); }
+fns.push(f28);
+function f29(x) { var y = (x * 31 + 3029) % 1000003; return y ^ (x >>> 2); }
+fns.push(f29);
+function f30(x) { var y = (x * 31 + 3030) % 1000003; return y ^ (x >>> 3); }
+fns.push(f30);
+function f31(x) { var y = (x * 31 + 3031) % 1000003; return y ^ (x >>> 4); }
+fns.push(f31);
+function f32(x) { var y = (x * 31 + 3032) % 1000003; return y ^ (x >>> 5); }
+fns.push(f32);
+function f33(x) { var y = (x * 31 + 3033) % 1000003; return y ^ (x >>> 6); }
+fns.push(f33);
+function f34(x) { var y = (x * 31 + 3034) % 1000003; return y ^ (x >>> 7); }
+fns.push(f34);
+function f35(x) { var y = (x * 31 + 3035) % 1000003; return y ^ (x >>> 1); }
+fns.push(f35);
+function f36(x) { var y = (x * 31 + 3036) % 1000003; return y ^ (x >>> 2); }
+fns.push(f36);
+function f37(x) { var y = (x * 31 + 3037) % 1000003; return y ^ (x >>> 3); }
+fns.push(f37);
+function f38(x) { var y = (x * 31 + 3038) % 1000003; return y ^ (x >>> 4); }
+fns.push(f38);
+function f39(x) { var y = (x * 31 + 3039) % 1000003; return y ^ (x >>> 5); }
+fns.push(f39);
+function f40(x) { var y = (x * 31 + 3040) % 1000003; return y ^ (x >>> 6); }
+fns.push(f40);
+function f41(x) { var y = (x * 31 + 3041) % 1000003; return y ^ (x >>> 7); }
+fns.push(f41);
+function f42(x) { var y = (x * 31 + 3042) % 1000003; return y ^ (x >>> 1); }
+fns.push(f42);
+function f43(x) { var y = (x * 31 + 3043) % 1000003; return y ^ (x >>> 2); }
+fns.push(f43);
+function f44(x) { var y = (x * 31 + 3044) % 1000003; return y ^ (x >>> 3); }
+fns.push(f44);
+function f45(x) { var y = (x * 31 + 3045) % 1000003; return y ^ (x >>> 4); }
+fns.push(f45);
+function f46(x) { var y = (x * 31 + 3046) % 1000003; return y ^ (x >>> 5); }
+fns.push(f46);
+function f47(x) { var y = (x * 31 + 3047) % 1000003; return y ^ (x >>> 6); }
+fns.push(f47);
+function f48(x) { var y = (x * 31 + 3048) % 1000003; return y ^ (x >>> 7); }
+fns.push(f48);
+function f49(x) { var y = (x * 31 + 3049) % 1000003; return y ^ (x >>> 1); }
+fns.push(f49);
+function f50(x) { var y = (x * 31 + 3050) % 1000003; return y ^ (x >>> 2); }
+fns.push(f50);
+function f51(x) { var y = (x * 31 + 3051) % 1000003; return y ^ (x >>> 3); }
+fns.push(f51);
+function f52(x) { var y = (x * 31 + 3052) % 1000003; return y ^ (x >>> 4); }
+fns.push(f52);
+function f53(x) { var y = (x * 31 + 3053) % 1000003; return y ^ (x >>> 5); }
+fns.push(f53);
+function f54(x) { var y = (x * 31 + 3054) % 1000003; return y ^ (x >>> 6); }
+fns.push(f54);
+function f55(x) { var y = (x * 31 + 3055) % 1000003; return y ^ (x >>> 7); }
+fns.push(f55);
+function f56(x) { var y = (x * 31 + 3056) % 1000003; return y ^ (x >>> 1); }
+fns.push(f56);
+function f57(x) { var y = (x * 31 + 3057) % 1000003; return y ^ (x >>> 2); }
+fns.push(f57);
+function f58(x) { var y = (x * 31 + 3058) % 1000003; return y ^ (x >>> 3); }
+fns.push(f58);
+function f59(x) { var y = (x * 31 + 3059) % 1000003; return y ^ (x >>> 4); }
+fns.push(f59);
+function f60(x) { var y = (x * 31 + 3060) % 1000003; return y ^ (x >>> 5); }
+fns.push(f60);
+function f61(x) { var y = (x * 31 + 3061) % 1000003; return y ^ (x >>> 6); }
+fns.push(f61);
+function f62(x) { var y = (x * 31 + 3062) % 1000003; return y ^ (x >>> 7); }
+fns.push(f62);
+function f63(x) { var y = (x * 31 + 3063) % 1000003; return y ^ (x >>> 1); }
+fns.push(f63);
+function f64(x) { var y = (x * 31 + 3064) % 1000003; return y ^ (x >>> 2); }
+fns.push(f64);
+function f65(x) { var y = (x * 31 + 3065) % 1000003; return y ^ (x >>> 3); }
+fns.push(f65);
+function f66(x) { var y = (x * 31 + 3066) % 1000003; return y ^ (x >>> 4); }
+fns.push(f66);
+function f67(x) { var y = (x * 31 + 3067) % 1000003; return y ^ (x >>> 5); }
+fns.push(f67);
+function f68(x) { var y = (x * 31 + 3068) % 1000003; return y ^ (x >>> 6); }
+fns.push(f68);
+function f69(x) { var y = (x * 31 + 3069) % 1000003; return y ^ (x >>> 7); }
+fns.push(f69);
+function f70(x) { var y = (x * 31 + 3070) % 1000003; return y ^ (x >>> 1); }
+fns.push(f70);
+function f71(x) { var y = (x * 31 + 3071) % 1000003; return y ^ (x >>> 2); }
+fns.push(f71);
+function f72(x) { var y = (x * 31 + 3072) % 1000003; return y ^ (x >>> 3); }
+fns.push(f72);
+function f73(x) { var y = (x * 31 + 3073) % 1000003; return y ^ (x >>> 4); }
+fns.push(f73);
+function f74(x) { var y = (x * 31 + 3074) % 1000003; return y ^ (x >>> 5); }
+fns.push(f74);
+function f75(x) { var y = (x * 31 + 3075) % 1000003; return y ^ (x >>> 6); }
+fns.push(f75);
+function f76(x) { var y = (x * 31 + 3076) % 1000003; return y ^ (x >>> 7); }
+fns.push(f76);
+function f77(x) { var y = (x * 31 + 3077) % 1000003; return y ^ (x >>> 1); }
+fns.push(f77);
+function f78(x) { var y = (x * 31 + 3078) % 1000003; return y ^ (x >>> 2); }
+fns.push(f78);
+function f79(x) { var y = (x * 31 + 3079) % 1000003; return y ^ (x >>> 3); }
+fns.push(f79);
+function f80(x) { var y = (x * 31 + 3080) % 1000003; return y ^ (x >>> 4); }
+fns.push(f80);
+function f81(x) { var y = (x * 31 + 3081) % 1000003; return y ^ (x >>> 5); }
+fns.push(f81);
+function f82(x) { var y = (x * 31 + 3082) % 1000003; return y ^ (x >>> 6); }
+fns.push(f82);
+function f83(x) { var y = (x * 31 + 3083) % 1000003; return y ^ (x >>> 7); }
+fns.push(f83);
+function f84(x) { var y = (x * 31 + 3084) % 1000003; return y ^ (x >>> 1); }
+fns.push(f84);
+function f85(x) { var y = (x * 31 + 3085) % 1000003; return y ^ (x >>> 2); }
+fns.push(f85);
+function f86(x) { var y = (x * 31 + 3086) % 1000003; return y ^ (x >>> 3); }
+fns.push(f86);
+function f87(x) { var y = (x * 31 + 3087) % 1000003; return y ^ (x >>> 4); }
+fns.push(f87);
+function f88(x) { var y = (x * 31 + 3088) % 1000003; return y ^ (x >>> 5); }
+fns.push(f88);
+function f89(x) { var y = (x * 31 + 3089) % 1000003; return y ^ (x >>> 6); }
+fns.push(f89);
+function f90(x) { var y = (x * 31 + 3090) % 1000003; return y ^ (x >>> 7); }
+fns.push(f90);
+function f91(x) { var y = (x * 31 + 3091) % 1000003; return y ^ (x >>> 1); }
+fns.push(f91);
+function f92(x) { var y = (x * 31 + 3092) % 1000003; return y ^ (x >>> 2); }
+fns.push(f92);
+function f93(x) { var y = (x * 31 + 3093) % 1000003; return y ^ (x >>> 3); }
+fns.push(f93);
+function f94(x) { var y = (x * 31 + 3094) % 1000003; return y ^ (x >>> 4); }
+fns.push(f94);
+function f95(x) { var y = (x * 31 + 3095) % 1000003; return y ^ (x >>> 5); }
+fns.push(f95);
+function f96(x) { var y = (x * 31 + 3096) % 1000003; return y ^ (x >>> 6); }
+fns.push(f96);
+function f97(x) { var y = (x * 31 + 3097) % 1000003; return y ^ (x >>> 7); }
+fns.push(f97);
+function f98(x) { var y = (x * 31 + 3098) % 1000003; return y ^ (x >>> 1); }
+fns.push(f98);
+function f99(x) { var y = (x * 31 + 3099) % 1000003; return y ^ (x >>> 2); }
+fns.push(f99);
+function f100(x) { var y = (x * 31 + 3100) % 1000003; return y ^ (x >>> 3); }
+fns.push(f100);
+function f101(x) { var y = (x * 31 + 3101) % 1000003; return y ^ (x >>> 4); }
+fns.push(f101);
+function f102(x) { var y = (x * 31 + 3102) % 1000003; return y ^ (x >>> 5); }
+fns.push(f102);
+function f103(x) { var y = (x * 31 + 3103) % 1000003; return y ^ (x >>> 6); }
+fns.push(f103);
+function f104(x) { var y = (x * 31 + 3104) % 1000003; return y ^ (x >>> 7); }
+fns.push(f104);
+function f105(x) { var y = (x * 31 + 3105) % 1000003; return y ^ (x >>> 1); }
+fns.push(f105);
+function f106(x) { var y = (x * 31 + 3106) % 1000003; return y ^ (x >>> 2); }
+fns.push(f106);
+function f107(x) { var y = (x * 31 + 3107) % 1000003; return y ^ (x >>> 3); }
+fns.push(f107);
+function f108(x) { var y = (x * 31 + 3108) % 1000003; return y ^ (x >>> 4); }
+fns.push(f108);
+function f109(x) { var y = (x * 31 + 3109) % 1000003; return y ^ (x >>> 5); }
+fns.push(f109);
+function f110(x) { var y = (x * 31 + 3110) % 1000003; return y ^ (x >>> 6); }
+fns.push(f110);
+function f111(x) { var y = (x * 31 + 3111) % 1000003; return y ^ (x >>> 7); }
+fns.push(f111);
+function f112(x) { var y = (x * 31 + 3112) % 1000003; return y ^ (x >>> 1); }
+fns.push(f112);
+function f113(x) { var y = (x * 31 + 3113) % 1000003; return y ^ (x >>> 2); }
+fns.push(f113);
+function f114(x) { var y = (x * 31 + 3114) % 1000003; return y ^ (x >>> 3); }
+fns.push(f114);
+function f115(x) { var y = (x * 31 + 3115) % 1000003; return y ^ (x >>> 4); }
+fns.push(f115);
+function f116(x) { var y = (x * 31 + 3116) % 1000003; return y ^ (x >>> 5); }
+fns.push(f116);
+function f117(x) { var y = (x * 31 + 3117) % 1000003; return y ^ (x >>> 6); }
+fns.push(f117);
+function f118(x) { var y = (x * 31 + 3118) % 1000003; return y ^ (x >>> 7); }
+fns.push(f118);
+function f119(x) { var y = (x * 31 + 3119) % 1000003; return y ^ (x >>> 1); }
+fns.push(f119);
+function f120(x) { var y = (x * 31 + 3120) % 1000003; return y ^ (x >>> 2); }
+fns.push(f120);
+function f121(x) { var y = (x * 31 + 3121) % 1000003; return y ^ (x >>> 3); }
+fns.push(f121);
+function f122(x) { var y = (x * 31 + 3122) % 1000003; return y ^ (x >>> 4); }
+fns.push(f122);
+function f123(x) { var y = (x * 31 + 3123) % 1000003; return y ^ (x >>> 5); }
+fns.push(f123);
+function f124(x) { var y = (x * 31 + 3124) % 1000003; return y ^ (x >>> 6); }
+fns.push(f124);
+function f125(x) { var y = (x * 31 + 3125) % 1000003; return y ^ (x >>> 7); }
+fns.push(f125);
+function f126(x) { var y = (x * 31 + 3126) % 1000003; return y ^ (x >>> 1); }
+fns.push(f126);
+function f127(x) { var y = (x * 31 + 3127) % 1000003; return y ^ (x >>> 2); }
+fns.push(f127);
+function f128(x) { var y = (x * 31 + 3128) % 1000003; return y ^ (x >>> 3); }
+fns.push(f128);
+function f129(x) { var y = (x * 31 + 3129) % 1000003; return y ^ (x >>> 4); }
+fns.push(f129);
+function f130(x) { var y = (x * 31 + 3130) % 1000003; return y ^ (x >>> 5); }
+fns.push(f130);
+function f131(x) { var y = (x * 31 + 3131) % 1000003; return y ^ (x >>> 6); }
+fns.push(f131);
+function f132(x) { var y = (x * 31 + 3132) % 1000003; return y ^ (x >>> 7); }
+fns.push(f132);
+function f133(x) { var y = (x * 31 + 3133) % 1000003; return y ^ (x >>> 1); }
+fns.push(f133);
+function f134(x) { var y = (x * 31 + 3134) % 1000003; return y ^ (x >>> 2); }
+fns.push(f134);
+function f135(x) { var y = (x * 31 + 3135) % 1000003; return y ^ (x >>> 3); }
+fns.push(f135);
+function f136(x) { var y = (x * 31 + 3136) % 1000003; return y ^ (x >>> 4); }
+fns.push(f136);
+function f137(x) { var y = (x * 31 + 3137) % 1000003; return y ^ (x >>> 5); }
+fns.push(f137);
+function f138(x) { var y = (x * 31 + 3138) % 1000003; return y ^ (x >>> 6); }
+fns.push(f138);
+function f139(x) { var y = (x * 31 + 3139) % 1000003; return y ^ (x >>> 7); }
+fns.push(f139);
+function f140(x) { var y = (x * 31 + 3140) % 1000003; return y ^ (x >>> 1); }
+fns.push(f140);
+function f141(x) { var y = (x * 31 + 3141) % 1000003; return y ^ (x >>> 2); }
+fns.push(f141);
+function f142(x) { var y = (x * 31 + 3142) % 1000003; return y ^ (x >>> 3); }
+fns.push(f142);
+function f143(x) { var y = (x * 31 + 3143) % 1000003; return y ^ (x >>> 4); }
+fns.push(f143);
+function f144(x) { var y = (x * 31 + 3144) % 1000003; return y ^ (x >>> 5); }
+fns.push(f144);
+function f145(x) { var y = (x * 31 + 3145) % 1000003; return y ^ (x >>> 6); }
+fns.push(f145);
+function f146(x) { var y = (x * 31 + 3146) % 1000003; return y ^ (x >>> 7); }
+fns.push(f146);
+function f147(x) { var y = (x * 31 + 3147) % 1000003; return y ^ (x >>> 1); }
+fns.push(f147);
+function f148(x) { var y = (x * 31 + 3148) % 1000003; return y ^ (x >>> 2); }
+fns.push(f148);
+function f149(x) { var y = (x * 31 + 3149) % 1000003; return y ^ (x >>> 3); }
+fns.push(f149);
+function f150(x) { var y = (x * 31 + 3150) % 1000003; return y ^ (x >>> 4); }
+fns.push(f150);
+function f151(x) { var y = (x * 31 + 3151) % 1000003; return y ^ (x >>> 5); }
+fns.push(f151);
+function f152(x) { var y = (x * 31 + 3152) % 1000003; return y ^ (x >>> 6); }
+fns.push(f152);
+function f153(x) { var y = (x * 31 + 3153) % 1000003; return y ^ (x >>> 7); }
+fns.push(f153);
+function f154(x) { var y = (x * 31 + 3154) % 1000003; return y ^ (x >>> 1); }
+fns.push(f154);
+function f155(x) { var y = (x * 31 + 3155) % 1000003; return y ^ (x >>> 2); }
+fns.push(f155);
+function f156(x) { var y = (x * 31 + 3156) % 1000003; return y ^ (x >>> 3); }
+fns.push(f156);
+function f157(x) { var y = (x * 31 + 3157) % 1000003; return y ^ (x >>> 4); }
+fns.push(f157);
+function f158(x) { var y = (x * 31 + 3158) % 1000003; return y ^ (x >>> 5); }
+fns.push(f158);
+function f159(x) { var y = (x * 31 + 3159) % 1000003; return y ^ (x >>> 6); }
+fns.push(f159);
+function f160(x) { var y = (x * 31 + 3160) % 1000003; return y ^ (x >>> 7); }
+fns.push(f160);
+function f161(x) { var y = (x * 31 + 3161) % 1000003; return y ^ (x >>> 1); }
+fns.push(f161);
+function f162(x) { var y = (x * 31 + 3162) % 1000003; return y ^ (x >>> 2); }
+fns.push(f162);
+function f163(x) { var y = (x * 31 + 3163) % 1000003; return y ^ (x >>> 3); }
+fns.push(f163);
+function f164(x) { var y = (x * 31 + 3164) % 1000003; return y ^ (x >>> 4); }
+fns.push(f164);
+function f165(x) { var y = (x * 31 + 3165) % 1000003; return y ^ (x >>> 5); }
+fns.push(f165);
+function f166(x) { var y = (x * 31 + 3166) % 1000003; return y ^ (x >>> 6); }
+fns.push(f166);
+function f167(x) { var y = (x * 31 + 3167) % 1000003; return y ^ (x >>> 7); }
+fns.push(f167);
+function f168(x) { var y = (x * 31 + 3168) % 1000003; return y ^ (x >>> 1); }
+fns.push(f168);
+function f169(x) { var y = (x * 31 + 3169) % 1000003; return y ^ (x >>> 2); }
+fns.push(f169);
+function f170(x) { var y = (x * 31 + 3170) % 1000003; return y ^ (x >>> 3); }
+fns.push(f170);
+function f171(x) { var y = (x * 31 + 3171) % 1000003; return y ^ (x >>> 4); }
+fns.push(f171);
+function f172(x) { var y = (x * 31 + 3172) % 1000003; return y ^ (x >>> 5); }
+fns.push(f172);
+function f173(x) { var y = (x * 31 + 3173) % 1000003; return y ^ (x >>> 6); }
+fns.push(f173);
+function f174(x) { var y = (x * 31 + 3174) % 1000003; return y ^ (x >>> 7); }
+fns.push(f174);
+function f175(x) { var y = (x * 31 + 3175) % 1000003; return y ^ (x >>> 1); }
+fns.push(f175);
+function f176(x) { var y = (x * 31 + 3176) % 1000003; return y ^ (x >>> 2); }
+fns.push(f176);
+function f177(x) { var y = (x * 31 + 3177) % 1000003; return y ^ (x >>> 3); }
+fns.push(f177);
+function f178(x) { var y = (x * 31 + 3178) % 1000003; return y ^ (x >>> 4); }
+fns.push(f178);
+function f179(x) { var y = (x * 31 + 3179) % 1000003; return y ^ (x >>> 5); }
+fns.push(f179);
+function f180(x) { var y = (x * 31 + 3180) % 1000003; return y ^ (x >>> 6); }
+fns.push(f180);
+function f181(x) { var y = (x * 31 + 3181) % 1000003; return y ^ (x >>> 7); }
+fns.push(f181);
+function f182(x) { var y = (x * 31 + 3182) % 1000003; return y ^ (x >>> 1); }
+fns.push(f182);
+function f183(x) { var y = (x * 31 + 3183) % 1000003; return y ^ (x >>> 2); }
+fns.push(f183);
+function f184(x) { var y = (x * 31 + 3184) % 1000003; return y ^ (x >>> 3); }
+fns.push(f184);
+function f185(x) { var y = (x * 31 + 3185) % 1000003; return y ^ (x >>> 4); }
+fns.push(f185);
+function f186(x) { var y = (x * 31 + 3186) % 1000003; return y ^ (x >>> 5); }
+fns.push(f186);
+function f187(x) { var y = (x * 31 + 3187) % 1000003; return y ^ (x >>> 6); }
+fns.push(f187);
+function f188(x) { var y = (x * 31 + 3188) % 1000003; return y ^ (x >>> 7); }
+fns.push(f188);
+function f189(x) { var y = (x * 31 + 3189) % 1000003; return y ^ (x >>> 1); }
+fns.push(f189);
+function f190(x) { var y = (x * 31 + 3190) % 1000003; return y ^ (x >>> 2); }
+fns.push(f190);
+function f191(x) { var y = (x * 31 + 3191) % 1000003; return y ^ (x >>> 3); }
+fns.push(f191);
+function f192(x) { var y = (x * 31 + 3192) % 1000003; return y ^ (x >>> 4); }
+fns.push(f192);
+function f193(x) { var y = (x * 31 + 3193) % 1000003; return y ^ (x >>> 5); }
+fns.push(f193);
+function f194(x) { var y = (x * 31 + 3194) % 1000003; return y ^ (x >>> 6); }
+fns.push(f194);
+function f195(x) { var y = (x * 31 + 3195) % 1000003; return y ^ (x >>> 7); }
+fns.push(f195);
+function f196(x) { var y = (x * 31 + 3196) % 1000003; return y ^ (x >>> 1); }
+fns.push(f196);
+function f197(x) { var y = (x * 31 + 3197) % 1000003; return y ^ (x >>> 2); }
+fns.push(f197);
+function f198(x) { var y = (x * 31 + 3198) % 1000003; return y ^ (x >>> 3); }
+fns.push(f198);
+function f199(x) { var y = (x * 31 + 3199) % 1000003; return y ^ (x >>> 4); }
+fns.push(f199);
+function f200(x) { var y = (x * 31 + 3200) % 1000003; return y ^ (x >>> 5); }
+fns.push(f200);
+function f201(x) { var y = (x * 31 + 3201) % 1000003; return y ^ (x >>> 6); }
+fns.push(f201);
+function f202(x) { var y = (x * 31 + 3202) % 1000003; return y ^ (x >>> 7); }
+fns.push(f202);
+function f203(x) { var y = (x * 31 + 3203) % 1000003; return y ^ (x >>> 1); }
+fns.push(f203);
+function f204(x) { var y = (x * 31 + 3204) % 1000003; return y ^ (x >>> 2); }
+fns.push(f204);
+function f205(x) { var y = (x * 31 + 3205) % 1000003; return y ^ (x >>> 3); }
+fns.push(f205);
+function f206(x) { var y = (x * 31 + 3206) % 1000003; return y ^ (x >>> 4); }
+fns.push(f206);
+function f207(x) { var y = (x * 31 + 3207) % 1000003; return y ^ (x >>> 5); }
+fns.push(f207);
+function f208(x) { var y = (x * 31 + 3208) % 1000003; return y ^ (x >>> 6); }
+fns.push(f208);
+function f209(x) { var y = (x * 31 + 3209) % 1000003; return y ^ (x >>> 7); }
+fns.push(f209);
+function f210(x) { var y = (x * 31 + 3210) % 1000003; return y ^ (x >>> 1); }
+fns.push(f210);
+function f211(x) { var y = (x * 31 + 3211) % 1000003; return y ^ (x >>> 2); }
+fns.push(f211);
+function f212(x) { var y = (x * 31 + 3212) % 1000003; return y ^ (x >>> 3); }
+fns.push(f212);
+function f213(x) { var y = (x * 31 + 3213) % 1000003; return y ^ (x >>> 4); }
+fns.push(f213);
+function f214(x) { var y = (x * 31 + 3214) % 1000003; return y ^ (x >>> 5); }
+fns.push(f214);
+function f215(x) { var y = (x * 31 + 3215) % 1000003; return y ^ (x >>> 6); }
+fns.push(f215);
+function f216(x) { var y = (x * 31 + 3216) % 1000003; return y ^ (x >>> 7); }
+fns.push(f216);
+function f217(x) { var y = (x * 31 + 3217) % 1000003; return y ^ (x >>> 1); }
+fns.push(f217);
+function f218(x) { var y = (x * 31 + 3218) % 1000003; return y ^ (x >>> 2); }
+fns.push(f218);
+function f219(x) { var y = (x * 31 + 3219) % 1000003; return y ^ (x >>> 3); }
+fns.push(f219);
+function f220(x) { var y = (x * 31 + 3220) % 1000003; return y ^ (x >>> 4); }
+fns.push(f220);
+function f221(x) { var y = (x * 31 + 3221) % 1000003; return y ^ (x >>> 5); }
+fns.push(f221);
+function f222(x) { var y = (x * 31 + 3222) % 1000003; return y ^ (x >>> 6); }
+fns.push(f222);
+function f223(x) { var y = (x * 31 + 3223) % 1000003; return y ^ (x >>> 7); }
+fns.push(f223);
+function f224(x) { var y = (x * 31 + 3224) % 1000003; return y ^ (x >>> 1); }
+fns.push(f224);
+function f225(x) { var y = (x * 31 + 3225) % 1000003; return y ^ (x >>> 2); }
+fns.push(f225);
+function f226(x) { var y = (x * 31 + 3226) % 1000003; return y ^ (x >>> 3); }
+fns.push(f226);
+function f227(x) { var y = (x * 31 + 3227) % 1000003; return y ^ (x >>> 4); }
+fns.push(f227);
+function f228(x) { var y = (x * 31 + 3228) % 1000003; return y ^ (x >>> 5); }
+fns.push(f228);
+function f229(x) { var y = (x * 31 + 3229) % 1000003; return y ^ (x >>> 6); }
+fns.push(f229);
+function f230(x) { var y = (x * 31 + 3230) % 1000003; return y ^ (x >>> 7); }
+fns.push(f230);
+function f231(x) { var y = (x * 31 + 3231) % 1000003; return y ^ (x >>> 1); }
+fns.push(f231);
+function f232(x) { var y = (x * 31 + 3232) % 1000003; return y ^ (x >>> 2); }
+fns.push(f232);
+function f233(x) { var y = (x * 31 + 3233) % 1000003; return y ^ (x >>> 3); }
+fns.push(f233);
+function f234(x) { var y = (x * 31 + 3234) % 1000003; return y ^ (x >>> 4); }
+fns.push(f234);
+function f235(x) { var y = (x * 31 + 3235) % 1000003; return y ^ (x >>> 5); }
+fns.push(f235);
+function f236(x) { var y = (x * 31 + 3236) % 1000003; return y ^ (x >>> 6); }
+fns.push(f236);
+function f237(x) { var y = (x * 31 + 3237) % 1000003; return y ^ (x >>> 7); }
+fns.push(f237);
+function f238(x) { var y = (x * 31 + 3238) % 1000003; return y ^ (x >>> 1); }
+fns.push(f238);
+function f239(x) { var y = (x * 31 + 3239) % 1000003; return y ^ (x >>> 2); }
+fns.push(f239);
+function f240(x) { var y = (x * 31 + 3240) % 1000003; return y ^ (x >>> 3); }
+fns.push(f240);
+function f241(x) { var y = (x * 31 + 3241) % 1000003; return y ^ (x >>> 4); }
+fns.push(f241);
+function f242(x) { var y = (x * 31 + 3242) % 1000003; return y ^ (x >>> 5); }
+fns.push(f242);
+function f243(x) { var y = (x * 31 + 3243) % 1000003; return y ^ (x >>> 6); }
+fns.push(f243);
+function f244(x) { var y = (x * 31 + 3244) % 1000003; return y ^ (x >>> 7); }
+fns.push(f244);
+function f245(x) { var y = (x * 31 + 3245) % 1000003; return y ^ (x >>> 1); }
+fns.push(f245);
+function f246(x) { var y = (x * 31 + 3246) % 1000003; return y ^ (x >>> 2); }
+fns.push(f246);
+function f247(x) { var y = (x * 31 + 3247) % 1000003; return y ^ (x >>> 3); }
+fns.push(f247);
+function f248(x) { var y = (x * 31 + 3248) % 1000003; return y ^ (x >>> 4); }
+fns.push(f248);
+function f249(x) { var y = (x * 31 + 3249) % 1000003; return y ^ (x >>> 5); }
+fns.push(f249);
+function f250(x) { var y = (x * 31 + 3250) % 1000003; return y ^ (x >>> 6); }
+fns.push(f250);
+function f251(x) { var y = (x * 31 + 3251) % 1000003; return y ^ (x >>> 7); }
+fns.push(f251);
+function f252(x) { var y = (x * 31 + 3252) % 1000003; return y ^ (x >>> 1); }
+fns.push(f252);
+function f253(x) { var y = (x * 31 + 3253) % 1000003; return y ^ (x >>> 2); }
+fns.push(f253);
+function f254(x) { var y = (x * 31 + 3254) % 1000003; return y ^ (x >>> 3); }
+fns.push(f254);
+function f255(x) { var y = (x * 31 + 3255) % 1000003; return y ^ (x >>> 4); }
+fns.push(f255);
+function f256(x) { var y = (x * 31 + 3256) % 1000003; return y ^ (x >>> 5); }
+fns.push(f256);
+function f257(x) { var y = (x * 31 + 3257) % 1000003; return y ^ (x >>> 6); }
+fns.push(f257);
+function f258(x) { var y = (x * 31 + 3258) % 1000003; return y ^ (x >>> 7); }
+fns.push(f258);
+function f259(x) { var y = (x * 31 + 3259) % 1000003; return y ^ (x >>> 1); }
+fns.push(f259);
+function f260(x) { var y = (x * 31 + 3260) % 1000003; return y ^ (x >>> 2); }
+fns.push(f260);
+function f261(x) { var y = (x * 31 + 3261) % 1000003; return y ^ (x >>> 3); }
+fns.push(f261);
+function f262(x) { var y = (x * 31 + 3262) % 1000003; return y ^ (x >>> 4); }
+fns.push(f262);
+function f263(x) { var y = (x * 31 + 3263) % 1000003; return y ^ (x >>> 5); }
+fns.push(f263);
+function f264(x) { var y = (x * 31 + 3264) % 1000003; return y ^ (x >>> 6); }
+fns.push(f264);
+function f265(x) { var y = (x * 31 + 3265) % 1000003; return y ^ (x >>> 7); }
+fns.push(f265);
+function f266(x) { var y = (x * 31 + 3266) % 1000003; return y ^ (x >>> 1); }
+fns.push(f266);
+function f267(x) { var y = (x * 31 + 3267) % 1000003; return y ^ (x >>> 2); }
+fns.push(f267);
+function f268(x) { var y = (x * 31 + 3268) % 1000003; return y ^ (x >>> 3); }
+fns.push(f268);
+function f269(x) { var y = (x * 31 + 3269) % 1000003; return y ^ (x >>> 4); }
+fns.push(f269);
+function f270(x) { var y = (x * 31 + 3270) % 1000003; return y ^ (x >>> 5); }
+fns.push(f270);
+function f271(x) { var y = (x * 31 + 3271) % 1000003; return y ^ (x >>> 6); }
+fns.push(f271);
+function f272(x) { var y = (x * 31 + 3272) % 1000003; return y ^ (x >>> 7); }
+fns.push(f272);
+function f273(x) { var y = (x * 31 + 3273) % 1000003; return y ^ (x >>> 1); }
+fns.push(f273);
+function f274(x) { var y = (x * 31 + 3274) % 1000003; return y ^ (x >>> 2); }
+fns.push(f274);
+function f275(x) { var y = (x * 31 + 3275) % 1000003; return y ^ (x >>> 3); }
+fns.push(f275);
+function f276(x) { var y = (x * 31 + 3276) % 1000003; return y ^ (x >>> 4); }
+fns.push(f276);
+function f277(x) { var y = (x * 31 + 3277) % 1000003; return y ^ (x >>> 5); }
+fns.push(f277);
+function f278(x) { var y = (x * 31 + 3278) % 1000003; return y ^ (x >>> 6); }
+fns.push(f278);
+function f279(x) { var y = (x * 31 + 3279) % 1000003; return y ^ (x >>> 7); }
+fns.push(f279);
+function f280(x) { var y = (x * 31 + 3280) % 1000003; return y ^ (x >>> 1); }
+fns.push(f280);
+function f281(x) { var y = (x * 31 + 3281) % 1000003; return y ^ (x >>> 2); }
+fns.push(f281);
+function f282(x) { var y = (x * 31 + 3282) % 1000003; return y ^ (x >>> 3); }
+fns.push(f282);
+function f283(x) { var y = (x * 31 + 3283) % 1000003; return y ^ (x >>> 4); }
+fns.push(f283);
+function f284(x) { var y = (x * 31 + 3284) % 1000003; return y ^ (x >>> 5); }
+fns.push(f284);
+function f285(x) { var y = (x * 31 + 3285) % 1000003; return y ^ (x >>> 6); }
+fns.push(f285);
+function f286(x) { var y = (x * 31 + 3286) % 1000003; return y ^ (x >>> 7); }
+fns.push(f286);
+function f287(x) { var y = (x * 31 + 3287) % 1000003; return y ^ (x >>> 1); }
+fns.push(f287);
+function f288(x) { var y = (x * 31 + 3288) % 1000003; return y ^ (x >>> 2); }
+fns.push(f288);
+function f289(x) { var y = (x * 31 + 3289) % 1000003; return y ^ (x >>> 3); }
+fns.push(f289);
+function f290(x) { var y = (x * 31 + 3290) % 1000003; return y ^ (x >>> 4); }
+fns.push(f290);
+function f291(x) { var y = (x * 31 + 3291) % 1000003; return y ^ (x >>> 5); }
+fns.push(f291);
+function f292(x) { var y = (x * 31 + 3292) % 1000003; return y ^ (x >>> 6); }
+fns.push(f292);
+function f293(x) { var y = (x * 31 + 3293) % 1000003; return y ^ (x >>> 7); }
+fns.push(f293);
+function f294(x) { var y = (x * 31 + 3294) % 1000003; return y ^ (x >>> 1); }
+fns.push(f294);
+function f295(x) { var y = (x * 31 + 3295) % 1000003; return y ^ (x >>> 2); }
+fns.push(f295);
+function f296(x) { var y = (x * 31 + 3296) % 1000003; return y ^ (x >>> 3); }
+fns.push(f296);
+function f297(x) { var y = (x * 31 + 3297) % 1000003; return y ^ (x >>> 4); }
+fns.push(f297);
+function f298(x) { var y = (x * 31 + 3298) % 1000003; return y ^ (x >>> 5); }
+fns.push(f298);
+function f299(x) { var y = (x * 31 + 3299) % 1000003; return y ^ (x >>> 6); }
+fns.push(f299);
+
+exports.name = 'modD';
+exports.value = fns.reduce(function (acc, f) { return f(acc); }, 10);

--- a/TestRunner/app/tests/concurrentStartup/modE.js
+++ b/TestRunner/app/tests/concurrentStartup/modE.js
@@ -1,0 +1,608 @@
+// Fixture for WorkerConcurrentStartupTests: many small functions so the
+// module's code cache is large enough that several workers consuming it
+// at once overlap in time. `value` folds every function over a seed, so a
+// corrupted load changes it or throws.
+var fns = [];
+function f0(x) { var y = (x * 31 + 4000) % 1000003; return y ^ (x >>> 1); }
+fns.push(f0);
+function f1(x) { var y = (x * 31 + 4001) % 1000003; return y ^ (x >>> 2); }
+fns.push(f1);
+function f2(x) { var y = (x * 31 + 4002) % 1000003; return y ^ (x >>> 3); }
+fns.push(f2);
+function f3(x) { var y = (x * 31 + 4003) % 1000003; return y ^ (x >>> 4); }
+fns.push(f3);
+function f4(x) { var y = (x * 31 + 4004) % 1000003; return y ^ (x >>> 5); }
+fns.push(f4);
+function f5(x) { var y = (x * 31 + 4005) % 1000003; return y ^ (x >>> 6); }
+fns.push(f5);
+function f6(x) { var y = (x * 31 + 4006) % 1000003; return y ^ (x >>> 7); }
+fns.push(f6);
+function f7(x) { var y = (x * 31 + 4007) % 1000003; return y ^ (x >>> 1); }
+fns.push(f7);
+function f8(x) { var y = (x * 31 + 4008) % 1000003; return y ^ (x >>> 2); }
+fns.push(f8);
+function f9(x) { var y = (x * 31 + 4009) % 1000003; return y ^ (x >>> 3); }
+fns.push(f9);
+function f10(x) { var y = (x * 31 + 4010) % 1000003; return y ^ (x >>> 4); }
+fns.push(f10);
+function f11(x) { var y = (x * 31 + 4011) % 1000003; return y ^ (x >>> 5); }
+fns.push(f11);
+function f12(x) { var y = (x * 31 + 4012) % 1000003; return y ^ (x >>> 6); }
+fns.push(f12);
+function f13(x) { var y = (x * 31 + 4013) % 1000003; return y ^ (x >>> 7); }
+fns.push(f13);
+function f14(x) { var y = (x * 31 + 4014) % 1000003; return y ^ (x >>> 1); }
+fns.push(f14);
+function f15(x) { var y = (x * 31 + 4015) % 1000003; return y ^ (x >>> 2); }
+fns.push(f15);
+function f16(x) { var y = (x * 31 + 4016) % 1000003; return y ^ (x >>> 3); }
+fns.push(f16);
+function f17(x) { var y = (x * 31 + 4017) % 1000003; return y ^ (x >>> 4); }
+fns.push(f17);
+function f18(x) { var y = (x * 31 + 4018) % 1000003; return y ^ (x >>> 5); }
+fns.push(f18);
+function f19(x) { var y = (x * 31 + 4019) % 1000003; return y ^ (x >>> 6); }
+fns.push(f19);
+function f20(x) { var y = (x * 31 + 4020) % 1000003; return y ^ (x >>> 7); }
+fns.push(f20);
+function f21(x) { var y = (x * 31 + 4021) % 1000003; return y ^ (x >>> 1); }
+fns.push(f21);
+function f22(x) { var y = (x * 31 + 4022) % 1000003; return y ^ (x >>> 2); }
+fns.push(f22);
+function f23(x) { var y = (x * 31 + 4023) % 1000003; return y ^ (x >>> 3); }
+fns.push(f23);
+function f24(x) { var y = (x * 31 + 4024) % 1000003; return y ^ (x >>> 4); }
+fns.push(f24);
+function f25(x) { var y = (x * 31 + 4025) % 1000003; return y ^ (x >>> 5); }
+fns.push(f25);
+function f26(x) { var y = (x * 31 + 4026) % 1000003; return y ^ (x >>> 6); }
+fns.push(f26);
+function f27(x) { var y = (x * 31 + 4027) % 1000003; return y ^ (x >>> 7); }
+fns.push(f27);
+function f28(x) { var y = (x * 31 + 4028) % 1000003; return y ^ (x >>> 1); }
+fns.push(f28);
+function f29(x) { var y = (x * 31 + 4029) % 1000003; return y ^ (x >>> 2); }
+fns.push(f29);
+function f30(x) { var y = (x * 31 + 4030) % 1000003; return y ^ (x >>> 3); }
+fns.push(f30);
+function f31(x) { var y = (x * 31 + 4031) % 1000003; return y ^ (x >>> 4); }
+fns.push(f31);
+function f32(x) { var y = (x * 31 + 4032) % 1000003; return y ^ (x >>> 5); }
+fns.push(f32);
+function f33(x) { var y = (x * 31 + 4033) % 1000003; return y ^ (x >>> 6); }
+fns.push(f33);
+function f34(x) { var y = (x * 31 + 4034) % 1000003; return y ^ (x >>> 7); }
+fns.push(f34);
+function f35(x) { var y = (x * 31 + 4035) % 1000003; return y ^ (x >>> 1); }
+fns.push(f35);
+function f36(x) { var y = (x * 31 + 4036) % 1000003; return y ^ (x >>> 2); }
+fns.push(f36);
+function f37(x) { var y = (x * 31 + 4037) % 1000003; return y ^ (x >>> 3); }
+fns.push(f37);
+function f38(x) { var y = (x * 31 + 4038) % 1000003; return y ^ (x >>> 4); }
+fns.push(f38);
+function f39(x) { var y = (x * 31 + 4039) % 1000003; return y ^ (x >>> 5); }
+fns.push(f39);
+function f40(x) { var y = (x * 31 + 4040) % 1000003; return y ^ (x >>> 6); }
+fns.push(f40);
+function f41(x) { var y = (x * 31 + 4041) % 1000003; return y ^ (x >>> 7); }
+fns.push(f41);
+function f42(x) { var y = (x * 31 + 4042) % 1000003; return y ^ (x >>> 1); }
+fns.push(f42);
+function f43(x) { var y = (x * 31 + 4043) % 1000003; return y ^ (x >>> 2); }
+fns.push(f43);
+function f44(x) { var y = (x * 31 + 4044) % 1000003; return y ^ (x >>> 3); }
+fns.push(f44);
+function f45(x) { var y = (x * 31 + 4045) % 1000003; return y ^ (x >>> 4); }
+fns.push(f45);
+function f46(x) { var y = (x * 31 + 4046) % 1000003; return y ^ (x >>> 5); }
+fns.push(f46);
+function f47(x) { var y = (x * 31 + 4047) % 1000003; return y ^ (x >>> 6); }
+fns.push(f47);
+function f48(x) { var y = (x * 31 + 4048) % 1000003; return y ^ (x >>> 7); }
+fns.push(f48);
+function f49(x) { var y = (x * 31 + 4049) % 1000003; return y ^ (x >>> 1); }
+fns.push(f49);
+function f50(x) { var y = (x * 31 + 4050) % 1000003; return y ^ (x >>> 2); }
+fns.push(f50);
+function f51(x) { var y = (x * 31 + 4051) % 1000003; return y ^ (x >>> 3); }
+fns.push(f51);
+function f52(x) { var y = (x * 31 + 4052) % 1000003; return y ^ (x >>> 4); }
+fns.push(f52);
+function f53(x) { var y = (x * 31 + 4053) % 1000003; return y ^ (x >>> 5); }
+fns.push(f53);
+function f54(x) { var y = (x * 31 + 4054) % 1000003; return y ^ (x >>> 6); }
+fns.push(f54);
+function f55(x) { var y = (x * 31 + 4055) % 1000003; return y ^ (x >>> 7); }
+fns.push(f55);
+function f56(x) { var y = (x * 31 + 4056) % 1000003; return y ^ (x >>> 1); }
+fns.push(f56);
+function f57(x) { var y = (x * 31 + 4057) % 1000003; return y ^ (x >>> 2); }
+fns.push(f57);
+function f58(x) { var y = (x * 31 + 4058) % 1000003; return y ^ (x >>> 3); }
+fns.push(f58);
+function f59(x) { var y = (x * 31 + 4059) % 1000003; return y ^ (x >>> 4); }
+fns.push(f59);
+function f60(x) { var y = (x * 31 + 4060) % 1000003; return y ^ (x >>> 5); }
+fns.push(f60);
+function f61(x) { var y = (x * 31 + 4061) % 1000003; return y ^ (x >>> 6); }
+fns.push(f61);
+function f62(x) { var y = (x * 31 + 4062) % 1000003; return y ^ (x >>> 7); }
+fns.push(f62);
+function f63(x) { var y = (x * 31 + 4063) % 1000003; return y ^ (x >>> 1); }
+fns.push(f63);
+function f64(x) { var y = (x * 31 + 4064) % 1000003; return y ^ (x >>> 2); }
+fns.push(f64);
+function f65(x) { var y = (x * 31 + 4065) % 1000003; return y ^ (x >>> 3); }
+fns.push(f65);
+function f66(x) { var y = (x * 31 + 4066) % 1000003; return y ^ (x >>> 4); }
+fns.push(f66);
+function f67(x) { var y = (x * 31 + 4067) % 1000003; return y ^ (x >>> 5); }
+fns.push(f67);
+function f68(x) { var y = (x * 31 + 4068) % 1000003; return y ^ (x >>> 6); }
+fns.push(f68);
+function f69(x) { var y = (x * 31 + 4069) % 1000003; return y ^ (x >>> 7); }
+fns.push(f69);
+function f70(x) { var y = (x * 31 + 4070) % 1000003; return y ^ (x >>> 1); }
+fns.push(f70);
+function f71(x) { var y = (x * 31 + 4071) % 1000003; return y ^ (x >>> 2); }
+fns.push(f71);
+function f72(x) { var y = (x * 31 + 4072) % 1000003; return y ^ (x >>> 3); }
+fns.push(f72);
+function f73(x) { var y = (x * 31 + 4073) % 1000003; return y ^ (x >>> 4); }
+fns.push(f73);
+function f74(x) { var y = (x * 31 + 4074) % 1000003; return y ^ (x >>> 5); }
+fns.push(f74);
+function f75(x) { var y = (x * 31 + 4075) % 1000003; return y ^ (x >>> 6); }
+fns.push(f75);
+function f76(x) { var y = (x * 31 + 4076) % 1000003; return y ^ (x >>> 7); }
+fns.push(f76);
+function f77(x) { var y = (x * 31 + 4077) % 1000003; return y ^ (x >>> 1); }
+fns.push(f77);
+function f78(x) { var y = (x * 31 + 4078) % 1000003; return y ^ (x >>> 2); }
+fns.push(f78);
+function f79(x) { var y = (x * 31 + 4079) % 1000003; return y ^ (x >>> 3); }
+fns.push(f79);
+function f80(x) { var y = (x * 31 + 4080) % 1000003; return y ^ (x >>> 4); }
+fns.push(f80);
+function f81(x) { var y = (x * 31 + 4081) % 1000003; return y ^ (x >>> 5); }
+fns.push(f81);
+function f82(x) { var y = (x * 31 + 4082) % 1000003; return y ^ (x >>> 6); }
+fns.push(f82);
+function f83(x) { var y = (x * 31 + 4083) % 1000003; return y ^ (x >>> 7); }
+fns.push(f83);
+function f84(x) { var y = (x * 31 + 4084) % 1000003; return y ^ (x >>> 1); }
+fns.push(f84);
+function f85(x) { var y = (x * 31 + 4085) % 1000003; return y ^ (x >>> 2); }
+fns.push(f85);
+function f86(x) { var y = (x * 31 + 4086) % 1000003; return y ^ (x >>> 3); }
+fns.push(f86);
+function f87(x) { var y = (x * 31 + 4087) % 1000003; return y ^ (x >>> 4); }
+fns.push(f87);
+function f88(x) { var y = (x * 31 + 4088) % 1000003; return y ^ (x >>> 5); }
+fns.push(f88);
+function f89(x) { var y = (x * 31 + 4089) % 1000003; return y ^ (x >>> 6); }
+fns.push(f89);
+function f90(x) { var y = (x * 31 + 4090) % 1000003; return y ^ (x >>> 7); }
+fns.push(f90);
+function f91(x) { var y = (x * 31 + 4091) % 1000003; return y ^ (x >>> 1); }
+fns.push(f91);
+function f92(x) { var y = (x * 31 + 4092) % 1000003; return y ^ (x >>> 2); }
+fns.push(f92);
+function f93(x) { var y = (x * 31 + 4093) % 1000003; return y ^ (x >>> 3); }
+fns.push(f93);
+function f94(x) { var y = (x * 31 + 4094) % 1000003; return y ^ (x >>> 4); }
+fns.push(f94);
+function f95(x) { var y = (x * 31 + 4095) % 1000003; return y ^ (x >>> 5); }
+fns.push(f95);
+function f96(x) { var y = (x * 31 + 4096) % 1000003; return y ^ (x >>> 6); }
+fns.push(f96);
+function f97(x) { var y = (x * 31 + 4097) % 1000003; return y ^ (x >>> 7); }
+fns.push(f97);
+function f98(x) { var y = (x * 31 + 4098) % 1000003; return y ^ (x >>> 1); }
+fns.push(f98);
+function f99(x) { var y = (x * 31 + 4099) % 1000003; return y ^ (x >>> 2); }
+fns.push(f99);
+function f100(x) { var y = (x * 31 + 4100) % 1000003; return y ^ (x >>> 3); }
+fns.push(f100);
+function f101(x) { var y = (x * 31 + 4101) % 1000003; return y ^ (x >>> 4); }
+fns.push(f101);
+function f102(x) { var y = (x * 31 + 4102) % 1000003; return y ^ (x >>> 5); }
+fns.push(f102);
+function f103(x) { var y = (x * 31 + 4103) % 1000003; return y ^ (x >>> 6); }
+fns.push(f103);
+function f104(x) { var y = (x * 31 + 4104) % 1000003; return y ^ (x >>> 7); }
+fns.push(f104);
+function f105(x) { var y = (x * 31 + 4105) % 1000003; return y ^ (x >>> 1); }
+fns.push(f105);
+function f106(x) { var y = (x * 31 + 4106) % 1000003; return y ^ (x >>> 2); }
+fns.push(f106);
+function f107(x) { var y = (x * 31 + 4107) % 1000003; return y ^ (x >>> 3); }
+fns.push(f107);
+function f108(x) { var y = (x * 31 + 4108) % 1000003; return y ^ (x >>> 4); }
+fns.push(f108);
+function f109(x) { var y = (x * 31 + 4109) % 1000003; return y ^ (x >>> 5); }
+fns.push(f109);
+function f110(x) { var y = (x * 31 + 4110) % 1000003; return y ^ (x >>> 6); }
+fns.push(f110);
+function f111(x) { var y = (x * 31 + 4111) % 1000003; return y ^ (x >>> 7); }
+fns.push(f111);
+function f112(x) { var y = (x * 31 + 4112) % 1000003; return y ^ (x >>> 1); }
+fns.push(f112);
+function f113(x) { var y = (x * 31 + 4113) % 1000003; return y ^ (x >>> 2); }
+fns.push(f113);
+function f114(x) { var y = (x * 31 + 4114) % 1000003; return y ^ (x >>> 3); }
+fns.push(f114);
+function f115(x) { var y = (x * 31 + 4115) % 1000003; return y ^ (x >>> 4); }
+fns.push(f115);
+function f116(x) { var y = (x * 31 + 4116) % 1000003; return y ^ (x >>> 5); }
+fns.push(f116);
+function f117(x) { var y = (x * 31 + 4117) % 1000003; return y ^ (x >>> 6); }
+fns.push(f117);
+function f118(x) { var y = (x * 31 + 4118) % 1000003; return y ^ (x >>> 7); }
+fns.push(f118);
+function f119(x) { var y = (x * 31 + 4119) % 1000003; return y ^ (x >>> 1); }
+fns.push(f119);
+function f120(x) { var y = (x * 31 + 4120) % 1000003; return y ^ (x >>> 2); }
+fns.push(f120);
+function f121(x) { var y = (x * 31 + 4121) % 1000003; return y ^ (x >>> 3); }
+fns.push(f121);
+function f122(x) { var y = (x * 31 + 4122) % 1000003; return y ^ (x >>> 4); }
+fns.push(f122);
+function f123(x) { var y = (x * 31 + 4123) % 1000003; return y ^ (x >>> 5); }
+fns.push(f123);
+function f124(x) { var y = (x * 31 + 4124) % 1000003; return y ^ (x >>> 6); }
+fns.push(f124);
+function f125(x) { var y = (x * 31 + 4125) % 1000003; return y ^ (x >>> 7); }
+fns.push(f125);
+function f126(x) { var y = (x * 31 + 4126) % 1000003; return y ^ (x >>> 1); }
+fns.push(f126);
+function f127(x) { var y = (x * 31 + 4127) % 1000003; return y ^ (x >>> 2); }
+fns.push(f127);
+function f128(x) { var y = (x * 31 + 4128) % 1000003; return y ^ (x >>> 3); }
+fns.push(f128);
+function f129(x) { var y = (x * 31 + 4129) % 1000003; return y ^ (x >>> 4); }
+fns.push(f129);
+function f130(x) { var y = (x * 31 + 4130) % 1000003; return y ^ (x >>> 5); }
+fns.push(f130);
+function f131(x) { var y = (x * 31 + 4131) % 1000003; return y ^ (x >>> 6); }
+fns.push(f131);
+function f132(x) { var y = (x * 31 + 4132) % 1000003; return y ^ (x >>> 7); }
+fns.push(f132);
+function f133(x) { var y = (x * 31 + 4133) % 1000003; return y ^ (x >>> 1); }
+fns.push(f133);
+function f134(x) { var y = (x * 31 + 4134) % 1000003; return y ^ (x >>> 2); }
+fns.push(f134);
+function f135(x) { var y = (x * 31 + 4135) % 1000003; return y ^ (x >>> 3); }
+fns.push(f135);
+function f136(x) { var y = (x * 31 + 4136) % 1000003; return y ^ (x >>> 4); }
+fns.push(f136);
+function f137(x) { var y = (x * 31 + 4137) % 1000003; return y ^ (x >>> 5); }
+fns.push(f137);
+function f138(x) { var y = (x * 31 + 4138) % 1000003; return y ^ (x >>> 6); }
+fns.push(f138);
+function f139(x) { var y = (x * 31 + 4139) % 1000003; return y ^ (x >>> 7); }
+fns.push(f139);
+function f140(x) { var y = (x * 31 + 4140) % 1000003; return y ^ (x >>> 1); }
+fns.push(f140);
+function f141(x) { var y = (x * 31 + 4141) % 1000003; return y ^ (x >>> 2); }
+fns.push(f141);
+function f142(x) { var y = (x * 31 + 4142) % 1000003; return y ^ (x >>> 3); }
+fns.push(f142);
+function f143(x) { var y = (x * 31 + 4143) % 1000003; return y ^ (x >>> 4); }
+fns.push(f143);
+function f144(x) { var y = (x * 31 + 4144) % 1000003; return y ^ (x >>> 5); }
+fns.push(f144);
+function f145(x) { var y = (x * 31 + 4145) % 1000003; return y ^ (x >>> 6); }
+fns.push(f145);
+function f146(x) { var y = (x * 31 + 4146) % 1000003; return y ^ (x >>> 7); }
+fns.push(f146);
+function f147(x) { var y = (x * 31 + 4147) % 1000003; return y ^ (x >>> 1); }
+fns.push(f147);
+function f148(x) { var y = (x * 31 + 4148) % 1000003; return y ^ (x >>> 2); }
+fns.push(f148);
+function f149(x) { var y = (x * 31 + 4149) % 1000003; return y ^ (x >>> 3); }
+fns.push(f149);
+function f150(x) { var y = (x * 31 + 4150) % 1000003; return y ^ (x >>> 4); }
+fns.push(f150);
+function f151(x) { var y = (x * 31 + 4151) % 1000003; return y ^ (x >>> 5); }
+fns.push(f151);
+function f152(x) { var y = (x * 31 + 4152) % 1000003; return y ^ (x >>> 6); }
+fns.push(f152);
+function f153(x) { var y = (x * 31 + 4153) % 1000003; return y ^ (x >>> 7); }
+fns.push(f153);
+function f154(x) { var y = (x * 31 + 4154) % 1000003; return y ^ (x >>> 1); }
+fns.push(f154);
+function f155(x) { var y = (x * 31 + 4155) % 1000003; return y ^ (x >>> 2); }
+fns.push(f155);
+function f156(x) { var y = (x * 31 + 4156) % 1000003; return y ^ (x >>> 3); }
+fns.push(f156);
+function f157(x) { var y = (x * 31 + 4157) % 1000003; return y ^ (x >>> 4); }
+fns.push(f157);
+function f158(x) { var y = (x * 31 + 4158) % 1000003; return y ^ (x >>> 5); }
+fns.push(f158);
+function f159(x) { var y = (x * 31 + 4159) % 1000003; return y ^ (x >>> 6); }
+fns.push(f159);
+function f160(x) { var y = (x * 31 + 4160) % 1000003; return y ^ (x >>> 7); }
+fns.push(f160);
+function f161(x) { var y = (x * 31 + 4161) % 1000003; return y ^ (x >>> 1); }
+fns.push(f161);
+function f162(x) { var y = (x * 31 + 4162) % 1000003; return y ^ (x >>> 2); }
+fns.push(f162);
+function f163(x) { var y = (x * 31 + 4163) % 1000003; return y ^ (x >>> 3); }
+fns.push(f163);
+function f164(x) { var y = (x * 31 + 4164) % 1000003; return y ^ (x >>> 4); }
+fns.push(f164);
+function f165(x) { var y = (x * 31 + 4165) % 1000003; return y ^ (x >>> 5); }
+fns.push(f165);
+function f166(x) { var y = (x * 31 + 4166) % 1000003; return y ^ (x >>> 6); }
+fns.push(f166);
+function f167(x) { var y = (x * 31 + 4167) % 1000003; return y ^ (x >>> 7); }
+fns.push(f167);
+function f168(x) { var y = (x * 31 + 4168) % 1000003; return y ^ (x >>> 1); }
+fns.push(f168);
+function f169(x) { var y = (x * 31 + 4169) % 1000003; return y ^ (x >>> 2); }
+fns.push(f169);
+function f170(x) { var y = (x * 31 + 4170) % 1000003; return y ^ (x >>> 3); }
+fns.push(f170);
+function f171(x) { var y = (x * 31 + 4171) % 1000003; return y ^ (x >>> 4); }
+fns.push(f171);
+function f172(x) { var y = (x * 31 + 4172) % 1000003; return y ^ (x >>> 5); }
+fns.push(f172);
+function f173(x) { var y = (x * 31 + 4173) % 1000003; return y ^ (x >>> 6); }
+fns.push(f173);
+function f174(x) { var y = (x * 31 + 4174) % 1000003; return y ^ (x >>> 7); }
+fns.push(f174);
+function f175(x) { var y = (x * 31 + 4175) % 1000003; return y ^ (x >>> 1); }
+fns.push(f175);
+function f176(x) { var y = (x * 31 + 4176) % 1000003; return y ^ (x >>> 2); }
+fns.push(f176);
+function f177(x) { var y = (x * 31 + 4177) % 1000003; return y ^ (x >>> 3); }
+fns.push(f177);
+function f178(x) { var y = (x * 31 + 4178) % 1000003; return y ^ (x >>> 4); }
+fns.push(f178);
+function f179(x) { var y = (x * 31 + 4179) % 1000003; return y ^ (x >>> 5); }
+fns.push(f179);
+function f180(x) { var y = (x * 31 + 4180) % 1000003; return y ^ (x >>> 6); }
+fns.push(f180);
+function f181(x) { var y = (x * 31 + 4181) % 1000003; return y ^ (x >>> 7); }
+fns.push(f181);
+function f182(x) { var y = (x * 31 + 4182) % 1000003; return y ^ (x >>> 1); }
+fns.push(f182);
+function f183(x) { var y = (x * 31 + 4183) % 1000003; return y ^ (x >>> 2); }
+fns.push(f183);
+function f184(x) { var y = (x * 31 + 4184) % 1000003; return y ^ (x >>> 3); }
+fns.push(f184);
+function f185(x) { var y = (x * 31 + 4185) % 1000003; return y ^ (x >>> 4); }
+fns.push(f185);
+function f186(x) { var y = (x * 31 + 4186) % 1000003; return y ^ (x >>> 5); }
+fns.push(f186);
+function f187(x) { var y = (x * 31 + 4187) % 1000003; return y ^ (x >>> 6); }
+fns.push(f187);
+function f188(x) { var y = (x * 31 + 4188) % 1000003; return y ^ (x >>> 7); }
+fns.push(f188);
+function f189(x) { var y = (x * 31 + 4189) % 1000003; return y ^ (x >>> 1); }
+fns.push(f189);
+function f190(x) { var y = (x * 31 + 4190) % 1000003; return y ^ (x >>> 2); }
+fns.push(f190);
+function f191(x) { var y = (x * 31 + 4191) % 1000003; return y ^ (x >>> 3); }
+fns.push(f191);
+function f192(x) { var y = (x * 31 + 4192) % 1000003; return y ^ (x >>> 4); }
+fns.push(f192);
+function f193(x) { var y = (x * 31 + 4193) % 1000003; return y ^ (x >>> 5); }
+fns.push(f193);
+function f194(x) { var y = (x * 31 + 4194) % 1000003; return y ^ (x >>> 6); }
+fns.push(f194);
+function f195(x) { var y = (x * 31 + 4195) % 1000003; return y ^ (x >>> 7); }
+fns.push(f195);
+function f196(x) { var y = (x * 31 + 4196) % 1000003; return y ^ (x >>> 1); }
+fns.push(f196);
+function f197(x) { var y = (x * 31 + 4197) % 1000003; return y ^ (x >>> 2); }
+fns.push(f197);
+function f198(x) { var y = (x * 31 + 4198) % 1000003; return y ^ (x >>> 3); }
+fns.push(f198);
+function f199(x) { var y = (x * 31 + 4199) % 1000003; return y ^ (x >>> 4); }
+fns.push(f199);
+function f200(x) { var y = (x * 31 + 4200) % 1000003; return y ^ (x >>> 5); }
+fns.push(f200);
+function f201(x) { var y = (x * 31 + 4201) % 1000003; return y ^ (x >>> 6); }
+fns.push(f201);
+function f202(x) { var y = (x * 31 + 4202) % 1000003; return y ^ (x >>> 7); }
+fns.push(f202);
+function f203(x) { var y = (x * 31 + 4203) % 1000003; return y ^ (x >>> 1); }
+fns.push(f203);
+function f204(x) { var y = (x * 31 + 4204) % 1000003; return y ^ (x >>> 2); }
+fns.push(f204);
+function f205(x) { var y = (x * 31 + 4205) % 1000003; return y ^ (x >>> 3); }
+fns.push(f205);
+function f206(x) { var y = (x * 31 + 4206) % 1000003; return y ^ (x >>> 4); }
+fns.push(f206);
+function f207(x) { var y = (x * 31 + 4207) % 1000003; return y ^ (x >>> 5); }
+fns.push(f207);
+function f208(x) { var y = (x * 31 + 4208) % 1000003; return y ^ (x >>> 6); }
+fns.push(f208);
+function f209(x) { var y = (x * 31 + 4209) % 1000003; return y ^ (x >>> 7); }
+fns.push(f209);
+function f210(x) { var y = (x * 31 + 4210) % 1000003; return y ^ (x >>> 1); }
+fns.push(f210);
+function f211(x) { var y = (x * 31 + 4211) % 1000003; return y ^ (x >>> 2); }
+fns.push(f211);
+function f212(x) { var y = (x * 31 + 4212) % 1000003; return y ^ (x >>> 3); }
+fns.push(f212);
+function f213(x) { var y = (x * 31 + 4213) % 1000003; return y ^ (x >>> 4); }
+fns.push(f213);
+function f214(x) { var y = (x * 31 + 4214) % 1000003; return y ^ (x >>> 5); }
+fns.push(f214);
+function f215(x) { var y = (x * 31 + 4215) % 1000003; return y ^ (x >>> 6); }
+fns.push(f215);
+function f216(x) { var y = (x * 31 + 4216) % 1000003; return y ^ (x >>> 7); }
+fns.push(f216);
+function f217(x) { var y = (x * 31 + 4217) % 1000003; return y ^ (x >>> 1); }
+fns.push(f217);
+function f218(x) { var y = (x * 31 + 4218) % 1000003; return y ^ (x >>> 2); }
+fns.push(f218);
+function f219(x) { var y = (x * 31 + 4219) % 1000003; return y ^ (x >>> 3); }
+fns.push(f219);
+function f220(x) { var y = (x * 31 + 4220) % 1000003; return y ^ (x >>> 4); }
+fns.push(f220);
+function f221(x) { var y = (x * 31 + 4221) % 1000003; return y ^ (x >>> 5); }
+fns.push(f221);
+function f222(x) { var y = (x * 31 + 4222) % 1000003; return y ^ (x >>> 6); }
+fns.push(f222);
+function f223(x) { var y = (x * 31 + 4223) % 1000003; return y ^ (x >>> 7); }
+fns.push(f223);
+function f224(x) { var y = (x * 31 + 4224) % 1000003; return y ^ (x >>> 1); }
+fns.push(f224);
+function f225(x) { var y = (x * 31 + 4225) % 1000003; return y ^ (x >>> 2); }
+fns.push(f225);
+function f226(x) { var y = (x * 31 + 4226) % 1000003; return y ^ (x >>> 3); }
+fns.push(f226);
+function f227(x) { var y = (x * 31 + 4227) % 1000003; return y ^ (x >>> 4); }
+fns.push(f227);
+function f228(x) { var y = (x * 31 + 4228) % 1000003; return y ^ (x >>> 5); }
+fns.push(f228);
+function f229(x) { var y = (x * 31 + 4229) % 1000003; return y ^ (x >>> 6); }
+fns.push(f229);
+function f230(x) { var y = (x * 31 + 4230) % 1000003; return y ^ (x >>> 7); }
+fns.push(f230);
+function f231(x) { var y = (x * 31 + 4231) % 1000003; return y ^ (x >>> 1); }
+fns.push(f231);
+function f232(x) { var y = (x * 31 + 4232) % 1000003; return y ^ (x >>> 2); }
+fns.push(f232);
+function f233(x) { var y = (x * 31 + 4233) % 1000003; return y ^ (x >>> 3); }
+fns.push(f233);
+function f234(x) { var y = (x * 31 + 4234) % 1000003; return y ^ (x >>> 4); }
+fns.push(f234);
+function f235(x) { var y = (x * 31 + 4235) % 1000003; return y ^ (x >>> 5); }
+fns.push(f235);
+function f236(x) { var y = (x * 31 + 4236) % 1000003; return y ^ (x >>> 6); }
+fns.push(f236);
+function f237(x) { var y = (x * 31 + 4237) % 1000003; return y ^ (x >>> 7); }
+fns.push(f237);
+function f238(x) { var y = (x * 31 + 4238) % 1000003; return y ^ (x >>> 1); }
+fns.push(f238);
+function f239(x) { var y = (x * 31 + 4239) % 1000003; return y ^ (x >>> 2); }
+fns.push(f239);
+function f240(x) { var y = (x * 31 + 4240) % 1000003; return y ^ (x >>> 3); }
+fns.push(f240);
+function f241(x) { var y = (x * 31 + 4241) % 1000003; return y ^ (x >>> 4); }
+fns.push(f241);
+function f242(x) { var y = (x * 31 + 4242) % 1000003; return y ^ (x >>> 5); }
+fns.push(f242);
+function f243(x) { var y = (x * 31 + 4243) % 1000003; return y ^ (x >>> 6); }
+fns.push(f243);
+function f244(x) { var y = (x * 31 + 4244) % 1000003; return y ^ (x >>> 7); }
+fns.push(f244);
+function f245(x) { var y = (x * 31 + 4245) % 1000003; return y ^ (x >>> 1); }
+fns.push(f245);
+function f246(x) { var y = (x * 31 + 4246) % 1000003; return y ^ (x >>> 2); }
+fns.push(f246);
+function f247(x) { var y = (x * 31 + 4247) % 1000003; return y ^ (x >>> 3); }
+fns.push(f247);
+function f248(x) { var y = (x * 31 + 4248) % 1000003; return y ^ (x >>> 4); }
+fns.push(f248);
+function f249(x) { var y = (x * 31 + 4249) % 1000003; return y ^ (x >>> 5); }
+fns.push(f249);
+function f250(x) { var y = (x * 31 + 4250) % 1000003; return y ^ (x >>> 6); }
+fns.push(f250);
+function f251(x) { var y = (x * 31 + 4251) % 1000003; return y ^ (x >>> 7); }
+fns.push(f251);
+function f252(x) { var y = (x * 31 + 4252) % 1000003; return y ^ (x >>> 1); }
+fns.push(f252);
+function f253(x) { var y = (x * 31 + 4253) % 1000003; return y ^ (x >>> 2); }
+fns.push(f253);
+function f254(x) { var y = (x * 31 + 4254) % 1000003; return y ^ (x >>> 3); }
+fns.push(f254);
+function f255(x) { var y = (x * 31 + 4255) % 1000003; return y ^ (x >>> 4); }
+fns.push(f255);
+function f256(x) { var y = (x * 31 + 4256) % 1000003; return y ^ (x >>> 5); }
+fns.push(f256);
+function f257(x) { var y = (x * 31 + 4257) % 1000003; return y ^ (x >>> 6); }
+fns.push(f257);
+function f258(x) { var y = (x * 31 + 4258) % 1000003; return y ^ (x >>> 7); }
+fns.push(f258);
+function f259(x) { var y = (x * 31 + 4259) % 1000003; return y ^ (x >>> 1); }
+fns.push(f259);
+function f260(x) { var y = (x * 31 + 4260) % 1000003; return y ^ (x >>> 2); }
+fns.push(f260);
+function f261(x) { var y = (x * 31 + 4261) % 1000003; return y ^ (x >>> 3); }
+fns.push(f261);
+function f262(x) { var y = (x * 31 + 4262) % 1000003; return y ^ (x >>> 4); }
+fns.push(f262);
+function f263(x) { var y = (x * 31 + 4263) % 1000003; return y ^ (x >>> 5); }
+fns.push(f263);
+function f264(x) { var y = (x * 31 + 4264) % 1000003; return y ^ (x >>> 6); }
+fns.push(f264);
+function f265(x) { var y = (x * 31 + 4265) % 1000003; return y ^ (x >>> 7); }
+fns.push(f265);
+function f266(x) { var y = (x * 31 + 4266) % 1000003; return y ^ (x >>> 1); }
+fns.push(f266);
+function f267(x) { var y = (x * 31 + 4267) % 1000003; return y ^ (x >>> 2); }
+fns.push(f267);
+function f268(x) { var y = (x * 31 + 4268) % 1000003; return y ^ (x >>> 3); }
+fns.push(f268);
+function f269(x) { var y = (x * 31 + 4269) % 1000003; return y ^ (x >>> 4); }
+fns.push(f269);
+function f270(x) { var y = (x * 31 + 4270) % 1000003; return y ^ (x >>> 5); }
+fns.push(f270);
+function f271(x) { var y = (x * 31 + 4271) % 1000003; return y ^ (x >>> 6); }
+fns.push(f271);
+function f272(x) { var y = (x * 31 + 4272) % 1000003; return y ^ (x >>> 7); }
+fns.push(f272);
+function f273(x) { var y = (x * 31 + 4273) % 1000003; return y ^ (x >>> 1); }
+fns.push(f273);
+function f274(x) { var y = (x * 31 + 4274) % 1000003; return y ^ (x >>> 2); }
+fns.push(f274);
+function f275(x) { var y = (x * 31 + 4275) % 1000003; return y ^ (x >>> 3); }
+fns.push(f275);
+function f276(x) { var y = (x * 31 + 4276) % 1000003; return y ^ (x >>> 4); }
+fns.push(f276);
+function f277(x) { var y = (x * 31 + 4277) % 1000003; return y ^ (x >>> 5); }
+fns.push(f277);
+function f278(x) { var y = (x * 31 + 4278) % 1000003; return y ^ (x >>> 6); }
+fns.push(f278);
+function f279(x) { var y = (x * 31 + 4279) % 1000003; return y ^ (x >>> 7); }
+fns.push(f279);
+function f280(x) { var y = (x * 31 + 4280) % 1000003; return y ^ (x >>> 1); }
+fns.push(f280);
+function f281(x) { var y = (x * 31 + 4281) % 1000003; return y ^ (x >>> 2); }
+fns.push(f281);
+function f282(x) { var y = (x * 31 + 4282) % 1000003; return y ^ (x >>> 3); }
+fns.push(f282);
+function f283(x) { var y = (x * 31 + 4283) % 1000003; return y ^ (x >>> 4); }
+fns.push(f283);
+function f284(x) { var y = (x * 31 + 4284) % 1000003; return y ^ (x >>> 5); }
+fns.push(f284);
+function f285(x) { var y = (x * 31 + 4285) % 1000003; return y ^ (x >>> 6); }
+fns.push(f285);
+function f286(x) { var y = (x * 31 + 4286) % 1000003; return y ^ (x >>> 7); }
+fns.push(f286);
+function f287(x) { var y = (x * 31 + 4287) % 1000003; return y ^ (x >>> 1); }
+fns.push(f287);
+function f288(x) { var y = (x * 31 + 4288) % 1000003; return y ^ (x >>> 2); }
+fns.push(f288);
+function f289(x) { var y = (x * 31 + 4289) % 1000003; return y ^ (x >>> 3); }
+fns.push(f289);
+function f290(x) { var y = (x * 31 + 4290) % 1000003; return y ^ (x >>> 4); }
+fns.push(f290);
+function f291(x) { var y = (x * 31 + 4291) % 1000003; return y ^ (x >>> 5); }
+fns.push(f291);
+function f292(x) { var y = (x * 31 + 4292) % 1000003; return y ^ (x >>> 6); }
+fns.push(f292);
+function f293(x) { var y = (x * 31 + 4293) % 1000003; return y ^ (x >>> 7); }
+fns.push(f293);
+function f294(x) { var y = (x * 31 + 4294) % 1000003; return y ^ (x >>> 1); }
+fns.push(f294);
+function f295(x) { var y = (x * 31 + 4295) % 1000003; return y ^ (x >>> 2); }
+fns.push(f295);
+function f296(x) { var y = (x * 31 + 4296) % 1000003; return y ^ (x >>> 3); }
+fns.push(f296);
+function f297(x) { var y = (x * 31 + 4297) % 1000003; return y ^ (x >>> 4); }
+fns.push(f297);
+function f298(x) { var y = (x * 31 + 4298) % 1000003; return y ^ (x >>> 5); }
+fns.push(f298);
+function f299(x) { var y = (x * 31 + 4299) % 1000003; return y ^ (x >>> 6); }
+fns.push(f299);
+
+exports.name = 'modE';
+exports.value = fns.reduce(function (acc, f) { return f(acc); }, 11);

--- a/TestRunner/app/tests/concurrentStartup/modF.js
+++ b/TestRunner/app/tests/concurrentStartup/modF.js
@@ -1,0 +1,608 @@
+// Fixture for WorkerConcurrentStartupTests: many small functions so the
+// module's code cache is large enough that several workers consuming it
+// at once overlap in time. `value` folds every function over a seed, so a
+// corrupted load changes it or throws.
+var fns = [];
+function f0(x) { var y = (x * 31 + 5000) % 1000003; return y ^ (x >>> 1); }
+fns.push(f0);
+function f1(x) { var y = (x * 31 + 5001) % 1000003; return y ^ (x >>> 2); }
+fns.push(f1);
+function f2(x) { var y = (x * 31 + 5002) % 1000003; return y ^ (x >>> 3); }
+fns.push(f2);
+function f3(x) { var y = (x * 31 + 5003) % 1000003; return y ^ (x >>> 4); }
+fns.push(f3);
+function f4(x) { var y = (x * 31 + 5004) % 1000003; return y ^ (x >>> 5); }
+fns.push(f4);
+function f5(x) { var y = (x * 31 + 5005) % 1000003; return y ^ (x >>> 6); }
+fns.push(f5);
+function f6(x) { var y = (x * 31 + 5006) % 1000003; return y ^ (x >>> 7); }
+fns.push(f6);
+function f7(x) { var y = (x * 31 + 5007) % 1000003; return y ^ (x >>> 1); }
+fns.push(f7);
+function f8(x) { var y = (x * 31 + 5008) % 1000003; return y ^ (x >>> 2); }
+fns.push(f8);
+function f9(x) { var y = (x * 31 + 5009) % 1000003; return y ^ (x >>> 3); }
+fns.push(f9);
+function f10(x) { var y = (x * 31 + 5010) % 1000003; return y ^ (x >>> 4); }
+fns.push(f10);
+function f11(x) { var y = (x * 31 + 5011) % 1000003; return y ^ (x >>> 5); }
+fns.push(f11);
+function f12(x) { var y = (x * 31 + 5012) % 1000003; return y ^ (x >>> 6); }
+fns.push(f12);
+function f13(x) { var y = (x * 31 + 5013) % 1000003; return y ^ (x >>> 7); }
+fns.push(f13);
+function f14(x) { var y = (x * 31 + 5014) % 1000003; return y ^ (x >>> 1); }
+fns.push(f14);
+function f15(x) { var y = (x * 31 + 5015) % 1000003; return y ^ (x >>> 2); }
+fns.push(f15);
+function f16(x) { var y = (x * 31 + 5016) % 1000003; return y ^ (x >>> 3); }
+fns.push(f16);
+function f17(x) { var y = (x * 31 + 5017) % 1000003; return y ^ (x >>> 4); }
+fns.push(f17);
+function f18(x) { var y = (x * 31 + 5018) % 1000003; return y ^ (x >>> 5); }
+fns.push(f18);
+function f19(x) { var y = (x * 31 + 5019) % 1000003; return y ^ (x >>> 6); }
+fns.push(f19);
+function f20(x) { var y = (x * 31 + 5020) % 1000003; return y ^ (x >>> 7); }
+fns.push(f20);
+function f21(x) { var y = (x * 31 + 5021) % 1000003; return y ^ (x >>> 1); }
+fns.push(f21);
+function f22(x) { var y = (x * 31 + 5022) % 1000003; return y ^ (x >>> 2); }
+fns.push(f22);
+function f23(x) { var y = (x * 31 + 5023) % 1000003; return y ^ (x >>> 3); }
+fns.push(f23);
+function f24(x) { var y = (x * 31 + 5024) % 1000003; return y ^ (x >>> 4); }
+fns.push(f24);
+function f25(x) { var y = (x * 31 + 5025) % 1000003; return y ^ (x >>> 5); }
+fns.push(f25);
+function f26(x) { var y = (x * 31 + 5026) % 1000003; return y ^ (x >>> 6); }
+fns.push(f26);
+function f27(x) { var y = (x * 31 + 5027) % 1000003; return y ^ (x >>> 7); }
+fns.push(f27);
+function f28(x) { var y = (x * 31 + 5028) % 1000003; return y ^ (x >>> 1); }
+fns.push(f28);
+function f29(x) { var y = (x * 31 + 5029) % 1000003; return y ^ (x >>> 2); }
+fns.push(f29);
+function f30(x) { var y = (x * 31 + 5030) % 1000003; return y ^ (x >>> 3); }
+fns.push(f30);
+function f31(x) { var y = (x * 31 + 5031) % 1000003; return y ^ (x >>> 4); }
+fns.push(f31);
+function f32(x) { var y = (x * 31 + 5032) % 1000003; return y ^ (x >>> 5); }
+fns.push(f32);
+function f33(x) { var y = (x * 31 + 5033) % 1000003; return y ^ (x >>> 6); }
+fns.push(f33);
+function f34(x) { var y = (x * 31 + 5034) % 1000003; return y ^ (x >>> 7); }
+fns.push(f34);
+function f35(x) { var y = (x * 31 + 5035) % 1000003; return y ^ (x >>> 1); }
+fns.push(f35);
+function f36(x) { var y = (x * 31 + 5036) % 1000003; return y ^ (x >>> 2); }
+fns.push(f36);
+function f37(x) { var y = (x * 31 + 5037) % 1000003; return y ^ (x >>> 3); }
+fns.push(f37);
+function f38(x) { var y = (x * 31 + 5038) % 1000003; return y ^ (x >>> 4); }
+fns.push(f38);
+function f39(x) { var y = (x * 31 + 5039) % 1000003; return y ^ (x >>> 5); }
+fns.push(f39);
+function f40(x) { var y = (x * 31 + 5040) % 1000003; return y ^ (x >>> 6); }
+fns.push(f40);
+function f41(x) { var y = (x * 31 + 5041) % 1000003; return y ^ (x >>> 7); }
+fns.push(f41);
+function f42(x) { var y = (x * 31 + 5042) % 1000003; return y ^ (x >>> 1); }
+fns.push(f42);
+function f43(x) { var y = (x * 31 + 5043) % 1000003; return y ^ (x >>> 2); }
+fns.push(f43);
+function f44(x) { var y = (x * 31 + 5044) % 1000003; return y ^ (x >>> 3); }
+fns.push(f44);
+function f45(x) { var y = (x * 31 + 5045) % 1000003; return y ^ (x >>> 4); }
+fns.push(f45);
+function f46(x) { var y = (x * 31 + 5046) % 1000003; return y ^ (x >>> 5); }
+fns.push(f46);
+function f47(x) { var y = (x * 31 + 5047) % 1000003; return y ^ (x >>> 6); }
+fns.push(f47);
+function f48(x) { var y = (x * 31 + 5048) % 1000003; return y ^ (x >>> 7); }
+fns.push(f48);
+function f49(x) { var y = (x * 31 + 5049) % 1000003; return y ^ (x >>> 1); }
+fns.push(f49);
+function f50(x) { var y = (x * 31 + 5050) % 1000003; return y ^ (x >>> 2); }
+fns.push(f50);
+function f51(x) { var y = (x * 31 + 5051) % 1000003; return y ^ (x >>> 3); }
+fns.push(f51);
+function f52(x) { var y = (x * 31 + 5052) % 1000003; return y ^ (x >>> 4); }
+fns.push(f52);
+function f53(x) { var y = (x * 31 + 5053) % 1000003; return y ^ (x >>> 5); }
+fns.push(f53);
+function f54(x) { var y = (x * 31 + 5054) % 1000003; return y ^ (x >>> 6); }
+fns.push(f54);
+function f55(x) { var y = (x * 31 + 5055) % 1000003; return y ^ (x >>> 7); }
+fns.push(f55);
+function f56(x) { var y = (x * 31 + 5056) % 1000003; return y ^ (x >>> 1); }
+fns.push(f56);
+function f57(x) { var y = (x * 31 + 5057) % 1000003; return y ^ (x >>> 2); }
+fns.push(f57);
+function f58(x) { var y = (x * 31 + 5058) % 1000003; return y ^ (x >>> 3); }
+fns.push(f58);
+function f59(x) { var y = (x * 31 + 5059) % 1000003; return y ^ (x >>> 4); }
+fns.push(f59);
+function f60(x) { var y = (x * 31 + 5060) % 1000003; return y ^ (x >>> 5); }
+fns.push(f60);
+function f61(x) { var y = (x * 31 + 5061) % 1000003; return y ^ (x >>> 6); }
+fns.push(f61);
+function f62(x) { var y = (x * 31 + 5062) % 1000003; return y ^ (x >>> 7); }
+fns.push(f62);
+function f63(x) { var y = (x * 31 + 5063) % 1000003; return y ^ (x >>> 1); }
+fns.push(f63);
+function f64(x) { var y = (x * 31 + 5064) % 1000003; return y ^ (x >>> 2); }
+fns.push(f64);
+function f65(x) { var y = (x * 31 + 5065) % 1000003; return y ^ (x >>> 3); }
+fns.push(f65);
+function f66(x) { var y = (x * 31 + 5066) % 1000003; return y ^ (x >>> 4); }
+fns.push(f66);
+function f67(x) { var y = (x * 31 + 5067) % 1000003; return y ^ (x >>> 5); }
+fns.push(f67);
+function f68(x) { var y = (x * 31 + 5068) % 1000003; return y ^ (x >>> 6); }
+fns.push(f68);
+function f69(x) { var y = (x * 31 + 5069) % 1000003; return y ^ (x >>> 7); }
+fns.push(f69);
+function f70(x) { var y = (x * 31 + 5070) % 1000003; return y ^ (x >>> 1); }
+fns.push(f70);
+function f71(x) { var y = (x * 31 + 5071) % 1000003; return y ^ (x >>> 2); }
+fns.push(f71);
+function f72(x) { var y = (x * 31 + 5072) % 1000003; return y ^ (x >>> 3); }
+fns.push(f72);
+function f73(x) { var y = (x * 31 + 5073) % 1000003; return y ^ (x >>> 4); }
+fns.push(f73);
+function f74(x) { var y = (x * 31 + 5074) % 1000003; return y ^ (x >>> 5); }
+fns.push(f74);
+function f75(x) { var y = (x * 31 + 5075) % 1000003; return y ^ (x >>> 6); }
+fns.push(f75);
+function f76(x) { var y = (x * 31 + 5076) % 1000003; return y ^ (x >>> 7); }
+fns.push(f76);
+function f77(x) { var y = (x * 31 + 5077) % 1000003; return y ^ (x >>> 1); }
+fns.push(f77);
+function f78(x) { var y = (x * 31 + 5078) % 1000003; return y ^ (x >>> 2); }
+fns.push(f78);
+function f79(x) { var y = (x * 31 + 5079) % 1000003; return y ^ (x >>> 3); }
+fns.push(f79);
+function f80(x) { var y = (x * 31 + 5080) % 1000003; return y ^ (x >>> 4); }
+fns.push(f80);
+function f81(x) { var y = (x * 31 + 5081) % 1000003; return y ^ (x >>> 5); }
+fns.push(f81);
+function f82(x) { var y = (x * 31 + 5082) % 1000003; return y ^ (x >>> 6); }
+fns.push(f82);
+function f83(x) { var y = (x * 31 + 5083) % 1000003; return y ^ (x >>> 7); }
+fns.push(f83);
+function f84(x) { var y = (x * 31 + 5084) % 1000003; return y ^ (x >>> 1); }
+fns.push(f84);
+function f85(x) { var y = (x * 31 + 5085) % 1000003; return y ^ (x >>> 2); }
+fns.push(f85);
+function f86(x) { var y = (x * 31 + 5086) % 1000003; return y ^ (x >>> 3); }
+fns.push(f86);
+function f87(x) { var y = (x * 31 + 5087) % 1000003; return y ^ (x >>> 4); }
+fns.push(f87);
+function f88(x) { var y = (x * 31 + 5088) % 1000003; return y ^ (x >>> 5); }
+fns.push(f88);
+function f89(x) { var y = (x * 31 + 5089) % 1000003; return y ^ (x >>> 6); }
+fns.push(f89);
+function f90(x) { var y = (x * 31 + 5090) % 1000003; return y ^ (x >>> 7); }
+fns.push(f90);
+function f91(x) { var y = (x * 31 + 5091) % 1000003; return y ^ (x >>> 1); }
+fns.push(f91);
+function f92(x) { var y = (x * 31 + 5092) % 1000003; return y ^ (x >>> 2); }
+fns.push(f92);
+function f93(x) { var y = (x * 31 + 5093) % 1000003; return y ^ (x >>> 3); }
+fns.push(f93);
+function f94(x) { var y = (x * 31 + 5094) % 1000003; return y ^ (x >>> 4); }
+fns.push(f94);
+function f95(x) { var y = (x * 31 + 5095) % 1000003; return y ^ (x >>> 5); }
+fns.push(f95);
+function f96(x) { var y = (x * 31 + 5096) % 1000003; return y ^ (x >>> 6); }
+fns.push(f96);
+function f97(x) { var y = (x * 31 + 5097) % 1000003; return y ^ (x >>> 7); }
+fns.push(f97);
+function f98(x) { var y = (x * 31 + 5098) % 1000003; return y ^ (x >>> 1); }
+fns.push(f98);
+function f99(x) { var y = (x * 31 + 5099) % 1000003; return y ^ (x >>> 2); }
+fns.push(f99);
+function f100(x) { var y = (x * 31 + 5100) % 1000003; return y ^ (x >>> 3); }
+fns.push(f100);
+function f101(x) { var y = (x * 31 + 5101) % 1000003; return y ^ (x >>> 4); }
+fns.push(f101);
+function f102(x) { var y = (x * 31 + 5102) % 1000003; return y ^ (x >>> 5); }
+fns.push(f102);
+function f103(x) { var y = (x * 31 + 5103) % 1000003; return y ^ (x >>> 6); }
+fns.push(f103);
+function f104(x) { var y = (x * 31 + 5104) % 1000003; return y ^ (x >>> 7); }
+fns.push(f104);
+function f105(x) { var y = (x * 31 + 5105) % 1000003; return y ^ (x >>> 1); }
+fns.push(f105);
+function f106(x) { var y = (x * 31 + 5106) % 1000003; return y ^ (x >>> 2); }
+fns.push(f106);
+function f107(x) { var y = (x * 31 + 5107) % 1000003; return y ^ (x >>> 3); }
+fns.push(f107);
+function f108(x) { var y = (x * 31 + 5108) % 1000003; return y ^ (x >>> 4); }
+fns.push(f108);
+function f109(x) { var y = (x * 31 + 5109) % 1000003; return y ^ (x >>> 5); }
+fns.push(f109);
+function f110(x) { var y = (x * 31 + 5110) % 1000003; return y ^ (x >>> 6); }
+fns.push(f110);
+function f111(x) { var y = (x * 31 + 5111) % 1000003; return y ^ (x >>> 7); }
+fns.push(f111);
+function f112(x) { var y = (x * 31 + 5112) % 1000003; return y ^ (x >>> 1); }
+fns.push(f112);
+function f113(x) { var y = (x * 31 + 5113) % 1000003; return y ^ (x >>> 2); }
+fns.push(f113);
+function f114(x) { var y = (x * 31 + 5114) % 1000003; return y ^ (x >>> 3); }
+fns.push(f114);
+function f115(x) { var y = (x * 31 + 5115) % 1000003; return y ^ (x >>> 4); }
+fns.push(f115);
+function f116(x) { var y = (x * 31 + 5116) % 1000003; return y ^ (x >>> 5); }
+fns.push(f116);
+function f117(x) { var y = (x * 31 + 5117) % 1000003; return y ^ (x >>> 6); }
+fns.push(f117);
+function f118(x) { var y = (x * 31 + 5118) % 1000003; return y ^ (x >>> 7); }
+fns.push(f118);
+function f119(x) { var y = (x * 31 + 5119) % 1000003; return y ^ (x >>> 1); }
+fns.push(f119);
+function f120(x) { var y = (x * 31 + 5120) % 1000003; return y ^ (x >>> 2); }
+fns.push(f120);
+function f121(x) { var y = (x * 31 + 5121) % 1000003; return y ^ (x >>> 3); }
+fns.push(f121);
+function f122(x) { var y = (x * 31 + 5122) % 1000003; return y ^ (x >>> 4); }
+fns.push(f122);
+function f123(x) { var y = (x * 31 + 5123) % 1000003; return y ^ (x >>> 5); }
+fns.push(f123);
+function f124(x) { var y = (x * 31 + 5124) % 1000003; return y ^ (x >>> 6); }
+fns.push(f124);
+function f125(x) { var y = (x * 31 + 5125) % 1000003; return y ^ (x >>> 7); }
+fns.push(f125);
+function f126(x) { var y = (x * 31 + 5126) % 1000003; return y ^ (x >>> 1); }
+fns.push(f126);
+function f127(x) { var y = (x * 31 + 5127) % 1000003; return y ^ (x >>> 2); }
+fns.push(f127);
+function f128(x) { var y = (x * 31 + 5128) % 1000003; return y ^ (x >>> 3); }
+fns.push(f128);
+function f129(x) { var y = (x * 31 + 5129) % 1000003; return y ^ (x >>> 4); }
+fns.push(f129);
+function f130(x) { var y = (x * 31 + 5130) % 1000003; return y ^ (x >>> 5); }
+fns.push(f130);
+function f131(x) { var y = (x * 31 + 5131) % 1000003; return y ^ (x >>> 6); }
+fns.push(f131);
+function f132(x) { var y = (x * 31 + 5132) % 1000003; return y ^ (x >>> 7); }
+fns.push(f132);
+function f133(x) { var y = (x * 31 + 5133) % 1000003; return y ^ (x >>> 1); }
+fns.push(f133);
+function f134(x) { var y = (x * 31 + 5134) % 1000003; return y ^ (x >>> 2); }
+fns.push(f134);
+function f135(x) { var y = (x * 31 + 5135) % 1000003; return y ^ (x >>> 3); }
+fns.push(f135);
+function f136(x) { var y = (x * 31 + 5136) % 1000003; return y ^ (x >>> 4); }
+fns.push(f136);
+function f137(x) { var y = (x * 31 + 5137) % 1000003; return y ^ (x >>> 5); }
+fns.push(f137);
+function f138(x) { var y = (x * 31 + 5138) % 1000003; return y ^ (x >>> 6); }
+fns.push(f138);
+function f139(x) { var y = (x * 31 + 5139) % 1000003; return y ^ (x >>> 7); }
+fns.push(f139);
+function f140(x) { var y = (x * 31 + 5140) % 1000003; return y ^ (x >>> 1); }
+fns.push(f140);
+function f141(x) { var y = (x * 31 + 5141) % 1000003; return y ^ (x >>> 2); }
+fns.push(f141);
+function f142(x) { var y = (x * 31 + 5142) % 1000003; return y ^ (x >>> 3); }
+fns.push(f142);
+function f143(x) { var y = (x * 31 + 5143) % 1000003; return y ^ (x >>> 4); }
+fns.push(f143);
+function f144(x) { var y = (x * 31 + 5144) % 1000003; return y ^ (x >>> 5); }
+fns.push(f144);
+function f145(x) { var y = (x * 31 + 5145) % 1000003; return y ^ (x >>> 6); }
+fns.push(f145);
+function f146(x) { var y = (x * 31 + 5146) % 1000003; return y ^ (x >>> 7); }
+fns.push(f146);
+function f147(x) { var y = (x * 31 + 5147) % 1000003; return y ^ (x >>> 1); }
+fns.push(f147);
+function f148(x) { var y = (x * 31 + 5148) % 1000003; return y ^ (x >>> 2); }
+fns.push(f148);
+function f149(x) { var y = (x * 31 + 5149) % 1000003; return y ^ (x >>> 3); }
+fns.push(f149);
+function f150(x) { var y = (x * 31 + 5150) % 1000003; return y ^ (x >>> 4); }
+fns.push(f150);
+function f151(x) { var y = (x * 31 + 5151) % 1000003; return y ^ (x >>> 5); }
+fns.push(f151);
+function f152(x) { var y = (x * 31 + 5152) % 1000003; return y ^ (x >>> 6); }
+fns.push(f152);
+function f153(x) { var y = (x * 31 + 5153) % 1000003; return y ^ (x >>> 7); }
+fns.push(f153);
+function f154(x) { var y = (x * 31 + 5154) % 1000003; return y ^ (x >>> 1); }
+fns.push(f154);
+function f155(x) { var y = (x * 31 + 5155) % 1000003; return y ^ (x >>> 2); }
+fns.push(f155);
+function f156(x) { var y = (x * 31 + 5156) % 1000003; return y ^ (x >>> 3); }
+fns.push(f156);
+function f157(x) { var y = (x * 31 + 5157) % 1000003; return y ^ (x >>> 4); }
+fns.push(f157);
+function f158(x) { var y = (x * 31 + 5158) % 1000003; return y ^ (x >>> 5); }
+fns.push(f158);
+function f159(x) { var y = (x * 31 + 5159) % 1000003; return y ^ (x >>> 6); }
+fns.push(f159);
+function f160(x) { var y = (x * 31 + 5160) % 1000003; return y ^ (x >>> 7); }
+fns.push(f160);
+function f161(x) { var y = (x * 31 + 5161) % 1000003; return y ^ (x >>> 1); }
+fns.push(f161);
+function f162(x) { var y = (x * 31 + 5162) % 1000003; return y ^ (x >>> 2); }
+fns.push(f162);
+function f163(x) { var y = (x * 31 + 5163) % 1000003; return y ^ (x >>> 3); }
+fns.push(f163);
+function f164(x) { var y = (x * 31 + 5164) % 1000003; return y ^ (x >>> 4); }
+fns.push(f164);
+function f165(x) { var y = (x * 31 + 5165) % 1000003; return y ^ (x >>> 5); }
+fns.push(f165);
+function f166(x) { var y = (x * 31 + 5166) % 1000003; return y ^ (x >>> 6); }
+fns.push(f166);
+function f167(x) { var y = (x * 31 + 5167) % 1000003; return y ^ (x >>> 7); }
+fns.push(f167);
+function f168(x) { var y = (x * 31 + 5168) % 1000003; return y ^ (x >>> 1); }
+fns.push(f168);
+function f169(x) { var y = (x * 31 + 5169) % 1000003; return y ^ (x >>> 2); }
+fns.push(f169);
+function f170(x) { var y = (x * 31 + 5170) % 1000003; return y ^ (x >>> 3); }
+fns.push(f170);
+function f171(x) { var y = (x * 31 + 5171) % 1000003; return y ^ (x >>> 4); }
+fns.push(f171);
+function f172(x) { var y = (x * 31 + 5172) % 1000003; return y ^ (x >>> 5); }
+fns.push(f172);
+function f173(x) { var y = (x * 31 + 5173) % 1000003; return y ^ (x >>> 6); }
+fns.push(f173);
+function f174(x) { var y = (x * 31 + 5174) % 1000003; return y ^ (x >>> 7); }
+fns.push(f174);
+function f175(x) { var y = (x * 31 + 5175) % 1000003; return y ^ (x >>> 1); }
+fns.push(f175);
+function f176(x) { var y = (x * 31 + 5176) % 1000003; return y ^ (x >>> 2); }
+fns.push(f176);
+function f177(x) { var y = (x * 31 + 5177) % 1000003; return y ^ (x >>> 3); }
+fns.push(f177);
+function f178(x) { var y = (x * 31 + 5178) % 1000003; return y ^ (x >>> 4); }
+fns.push(f178);
+function f179(x) { var y = (x * 31 + 5179) % 1000003; return y ^ (x >>> 5); }
+fns.push(f179);
+function f180(x) { var y = (x * 31 + 5180) % 1000003; return y ^ (x >>> 6); }
+fns.push(f180);
+function f181(x) { var y = (x * 31 + 5181) % 1000003; return y ^ (x >>> 7); }
+fns.push(f181);
+function f182(x) { var y = (x * 31 + 5182) % 1000003; return y ^ (x >>> 1); }
+fns.push(f182);
+function f183(x) { var y = (x * 31 + 5183) % 1000003; return y ^ (x >>> 2); }
+fns.push(f183);
+function f184(x) { var y = (x * 31 + 5184) % 1000003; return y ^ (x >>> 3); }
+fns.push(f184);
+function f185(x) { var y = (x * 31 + 5185) % 1000003; return y ^ (x >>> 4); }
+fns.push(f185);
+function f186(x) { var y = (x * 31 + 5186) % 1000003; return y ^ (x >>> 5); }
+fns.push(f186);
+function f187(x) { var y = (x * 31 + 5187) % 1000003; return y ^ (x >>> 6); }
+fns.push(f187);
+function f188(x) { var y = (x * 31 + 5188) % 1000003; return y ^ (x >>> 7); }
+fns.push(f188);
+function f189(x) { var y = (x * 31 + 5189) % 1000003; return y ^ (x >>> 1); }
+fns.push(f189);
+function f190(x) { var y = (x * 31 + 5190) % 1000003; return y ^ (x >>> 2); }
+fns.push(f190);
+function f191(x) { var y = (x * 31 + 5191) % 1000003; return y ^ (x >>> 3); }
+fns.push(f191);
+function f192(x) { var y = (x * 31 + 5192) % 1000003; return y ^ (x >>> 4); }
+fns.push(f192);
+function f193(x) { var y = (x * 31 + 5193) % 1000003; return y ^ (x >>> 5); }
+fns.push(f193);
+function f194(x) { var y = (x * 31 + 5194) % 1000003; return y ^ (x >>> 6); }
+fns.push(f194);
+function f195(x) { var y = (x * 31 + 5195) % 1000003; return y ^ (x >>> 7); }
+fns.push(f195);
+function f196(x) { var y = (x * 31 + 5196) % 1000003; return y ^ (x >>> 1); }
+fns.push(f196);
+function f197(x) { var y = (x * 31 + 5197) % 1000003; return y ^ (x >>> 2); }
+fns.push(f197);
+function f198(x) { var y = (x * 31 + 5198) % 1000003; return y ^ (x >>> 3); }
+fns.push(f198);
+function f199(x) { var y = (x * 31 + 5199) % 1000003; return y ^ (x >>> 4); }
+fns.push(f199);
+function f200(x) { var y = (x * 31 + 5200) % 1000003; return y ^ (x >>> 5); }
+fns.push(f200);
+function f201(x) { var y = (x * 31 + 5201) % 1000003; return y ^ (x >>> 6); }
+fns.push(f201);
+function f202(x) { var y = (x * 31 + 5202) % 1000003; return y ^ (x >>> 7); }
+fns.push(f202);
+function f203(x) { var y = (x * 31 + 5203) % 1000003; return y ^ (x >>> 1); }
+fns.push(f203);
+function f204(x) { var y = (x * 31 + 5204) % 1000003; return y ^ (x >>> 2); }
+fns.push(f204);
+function f205(x) { var y = (x * 31 + 5205) % 1000003; return y ^ (x >>> 3); }
+fns.push(f205);
+function f206(x) { var y = (x * 31 + 5206) % 1000003; return y ^ (x >>> 4); }
+fns.push(f206);
+function f207(x) { var y = (x * 31 + 5207) % 1000003; return y ^ (x >>> 5); }
+fns.push(f207);
+function f208(x) { var y = (x * 31 + 5208) % 1000003; return y ^ (x >>> 6); }
+fns.push(f208);
+function f209(x) { var y = (x * 31 + 5209) % 1000003; return y ^ (x >>> 7); }
+fns.push(f209);
+function f210(x) { var y = (x * 31 + 5210) % 1000003; return y ^ (x >>> 1); }
+fns.push(f210);
+function f211(x) { var y = (x * 31 + 5211) % 1000003; return y ^ (x >>> 2); }
+fns.push(f211);
+function f212(x) { var y = (x * 31 + 5212) % 1000003; return y ^ (x >>> 3); }
+fns.push(f212);
+function f213(x) { var y = (x * 31 + 5213) % 1000003; return y ^ (x >>> 4); }
+fns.push(f213);
+function f214(x) { var y = (x * 31 + 5214) % 1000003; return y ^ (x >>> 5); }
+fns.push(f214);
+function f215(x) { var y = (x * 31 + 5215) % 1000003; return y ^ (x >>> 6); }
+fns.push(f215);
+function f216(x) { var y = (x * 31 + 5216) % 1000003; return y ^ (x >>> 7); }
+fns.push(f216);
+function f217(x) { var y = (x * 31 + 5217) % 1000003; return y ^ (x >>> 1); }
+fns.push(f217);
+function f218(x) { var y = (x * 31 + 5218) % 1000003; return y ^ (x >>> 2); }
+fns.push(f218);
+function f219(x) { var y = (x * 31 + 5219) % 1000003; return y ^ (x >>> 3); }
+fns.push(f219);
+function f220(x) { var y = (x * 31 + 5220) % 1000003; return y ^ (x >>> 4); }
+fns.push(f220);
+function f221(x) { var y = (x * 31 + 5221) % 1000003; return y ^ (x >>> 5); }
+fns.push(f221);
+function f222(x) { var y = (x * 31 + 5222) % 1000003; return y ^ (x >>> 6); }
+fns.push(f222);
+function f223(x) { var y = (x * 31 + 5223) % 1000003; return y ^ (x >>> 7); }
+fns.push(f223);
+function f224(x) { var y = (x * 31 + 5224) % 1000003; return y ^ (x >>> 1); }
+fns.push(f224);
+function f225(x) { var y = (x * 31 + 5225) % 1000003; return y ^ (x >>> 2); }
+fns.push(f225);
+function f226(x) { var y = (x * 31 + 5226) % 1000003; return y ^ (x >>> 3); }
+fns.push(f226);
+function f227(x) { var y = (x * 31 + 5227) % 1000003; return y ^ (x >>> 4); }
+fns.push(f227);
+function f228(x) { var y = (x * 31 + 5228) % 1000003; return y ^ (x >>> 5); }
+fns.push(f228);
+function f229(x) { var y = (x * 31 + 5229) % 1000003; return y ^ (x >>> 6); }
+fns.push(f229);
+function f230(x) { var y = (x * 31 + 5230) % 1000003; return y ^ (x >>> 7); }
+fns.push(f230);
+function f231(x) { var y = (x * 31 + 5231) % 1000003; return y ^ (x >>> 1); }
+fns.push(f231);
+function f232(x) { var y = (x * 31 + 5232) % 1000003; return y ^ (x >>> 2); }
+fns.push(f232);
+function f233(x) { var y = (x * 31 + 5233) % 1000003; return y ^ (x >>> 3); }
+fns.push(f233);
+function f234(x) { var y = (x * 31 + 5234) % 1000003; return y ^ (x >>> 4); }
+fns.push(f234);
+function f235(x) { var y = (x * 31 + 5235) % 1000003; return y ^ (x >>> 5); }
+fns.push(f235);
+function f236(x) { var y = (x * 31 + 5236) % 1000003; return y ^ (x >>> 6); }
+fns.push(f236);
+function f237(x) { var y = (x * 31 + 5237) % 1000003; return y ^ (x >>> 7); }
+fns.push(f237);
+function f238(x) { var y = (x * 31 + 5238) % 1000003; return y ^ (x >>> 1); }
+fns.push(f238);
+function f239(x) { var y = (x * 31 + 5239) % 1000003; return y ^ (x >>> 2); }
+fns.push(f239);
+function f240(x) { var y = (x * 31 + 5240) % 1000003; return y ^ (x >>> 3); }
+fns.push(f240);
+function f241(x) { var y = (x * 31 + 5241) % 1000003; return y ^ (x >>> 4); }
+fns.push(f241);
+function f242(x) { var y = (x * 31 + 5242) % 1000003; return y ^ (x >>> 5); }
+fns.push(f242);
+function f243(x) { var y = (x * 31 + 5243) % 1000003; return y ^ (x >>> 6); }
+fns.push(f243);
+function f244(x) { var y = (x * 31 + 5244) % 1000003; return y ^ (x >>> 7); }
+fns.push(f244);
+function f245(x) { var y = (x * 31 + 5245) % 1000003; return y ^ (x >>> 1); }
+fns.push(f245);
+function f246(x) { var y = (x * 31 + 5246) % 1000003; return y ^ (x >>> 2); }
+fns.push(f246);
+function f247(x) { var y = (x * 31 + 5247) % 1000003; return y ^ (x >>> 3); }
+fns.push(f247);
+function f248(x) { var y = (x * 31 + 5248) % 1000003; return y ^ (x >>> 4); }
+fns.push(f248);
+function f249(x) { var y = (x * 31 + 5249) % 1000003; return y ^ (x >>> 5); }
+fns.push(f249);
+function f250(x) { var y = (x * 31 + 5250) % 1000003; return y ^ (x >>> 6); }
+fns.push(f250);
+function f251(x) { var y = (x * 31 + 5251) % 1000003; return y ^ (x >>> 7); }
+fns.push(f251);
+function f252(x) { var y = (x * 31 + 5252) % 1000003; return y ^ (x >>> 1); }
+fns.push(f252);
+function f253(x) { var y = (x * 31 + 5253) % 1000003; return y ^ (x >>> 2); }
+fns.push(f253);
+function f254(x) { var y = (x * 31 + 5254) % 1000003; return y ^ (x >>> 3); }
+fns.push(f254);
+function f255(x) { var y = (x * 31 + 5255) % 1000003; return y ^ (x >>> 4); }
+fns.push(f255);
+function f256(x) { var y = (x * 31 + 5256) % 1000003; return y ^ (x >>> 5); }
+fns.push(f256);
+function f257(x) { var y = (x * 31 + 5257) % 1000003; return y ^ (x >>> 6); }
+fns.push(f257);
+function f258(x) { var y = (x * 31 + 5258) % 1000003; return y ^ (x >>> 7); }
+fns.push(f258);
+function f259(x) { var y = (x * 31 + 5259) % 1000003; return y ^ (x >>> 1); }
+fns.push(f259);
+function f260(x) { var y = (x * 31 + 5260) % 1000003; return y ^ (x >>> 2); }
+fns.push(f260);
+function f261(x) { var y = (x * 31 + 5261) % 1000003; return y ^ (x >>> 3); }
+fns.push(f261);
+function f262(x) { var y = (x * 31 + 5262) % 1000003; return y ^ (x >>> 4); }
+fns.push(f262);
+function f263(x) { var y = (x * 31 + 5263) % 1000003; return y ^ (x >>> 5); }
+fns.push(f263);
+function f264(x) { var y = (x * 31 + 5264) % 1000003; return y ^ (x >>> 6); }
+fns.push(f264);
+function f265(x) { var y = (x * 31 + 5265) % 1000003; return y ^ (x >>> 7); }
+fns.push(f265);
+function f266(x) { var y = (x * 31 + 5266) % 1000003; return y ^ (x >>> 1); }
+fns.push(f266);
+function f267(x) { var y = (x * 31 + 5267) % 1000003; return y ^ (x >>> 2); }
+fns.push(f267);
+function f268(x) { var y = (x * 31 + 5268) % 1000003; return y ^ (x >>> 3); }
+fns.push(f268);
+function f269(x) { var y = (x * 31 + 5269) % 1000003; return y ^ (x >>> 4); }
+fns.push(f269);
+function f270(x) { var y = (x * 31 + 5270) % 1000003; return y ^ (x >>> 5); }
+fns.push(f270);
+function f271(x) { var y = (x * 31 + 5271) % 1000003; return y ^ (x >>> 6); }
+fns.push(f271);
+function f272(x) { var y = (x * 31 + 5272) % 1000003; return y ^ (x >>> 7); }
+fns.push(f272);
+function f273(x) { var y = (x * 31 + 5273) % 1000003; return y ^ (x >>> 1); }
+fns.push(f273);
+function f274(x) { var y = (x * 31 + 5274) % 1000003; return y ^ (x >>> 2); }
+fns.push(f274);
+function f275(x) { var y = (x * 31 + 5275) % 1000003; return y ^ (x >>> 3); }
+fns.push(f275);
+function f276(x) { var y = (x * 31 + 5276) % 1000003; return y ^ (x >>> 4); }
+fns.push(f276);
+function f277(x) { var y = (x * 31 + 5277) % 1000003; return y ^ (x >>> 5); }
+fns.push(f277);
+function f278(x) { var y = (x * 31 + 5278) % 1000003; return y ^ (x >>> 6); }
+fns.push(f278);
+function f279(x) { var y = (x * 31 + 5279) % 1000003; return y ^ (x >>> 7); }
+fns.push(f279);
+function f280(x) { var y = (x * 31 + 5280) % 1000003; return y ^ (x >>> 1); }
+fns.push(f280);
+function f281(x) { var y = (x * 31 + 5281) % 1000003; return y ^ (x >>> 2); }
+fns.push(f281);
+function f282(x) { var y = (x * 31 + 5282) % 1000003; return y ^ (x >>> 3); }
+fns.push(f282);
+function f283(x) { var y = (x * 31 + 5283) % 1000003; return y ^ (x >>> 4); }
+fns.push(f283);
+function f284(x) { var y = (x * 31 + 5284) % 1000003; return y ^ (x >>> 5); }
+fns.push(f284);
+function f285(x) { var y = (x * 31 + 5285) % 1000003; return y ^ (x >>> 6); }
+fns.push(f285);
+function f286(x) { var y = (x * 31 + 5286) % 1000003; return y ^ (x >>> 7); }
+fns.push(f286);
+function f287(x) { var y = (x * 31 + 5287) % 1000003; return y ^ (x >>> 1); }
+fns.push(f287);
+function f288(x) { var y = (x * 31 + 5288) % 1000003; return y ^ (x >>> 2); }
+fns.push(f288);
+function f289(x) { var y = (x * 31 + 5289) % 1000003; return y ^ (x >>> 3); }
+fns.push(f289);
+function f290(x) { var y = (x * 31 + 5290) % 1000003; return y ^ (x >>> 4); }
+fns.push(f290);
+function f291(x) { var y = (x * 31 + 5291) % 1000003; return y ^ (x >>> 5); }
+fns.push(f291);
+function f292(x) { var y = (x * 31 + 5292) % 1000003; return y ^ (x >>> 6); }
+fns.push(f292);
+function f293(x) { var y = (x * 31 + 5293) % 1000003; return y ^ (x >>> 7); }
+fns.push(f293);
+function f294(x) { var y = (x * 31 + 5294) % 1000003; return y ^ (x >>> 1); }
+fns.push(f294);
+function f295(x) { var y = (x * 31 + 5295) % 1000003; return y ^ (x >>> 2); }
+fns.push(f295);
+function f296(x) { var y = (x * 31 + 5296) % 1000003; return y ^ (x >>> 3); }
+fns.push(f296);
+function f297(x) { var y = (x * 31 + 5297) % 1000003; return y ^ (x >>> 4); }
+fns.push(f297);
+function f298(x) { var y = (x * 31 + 5298) % 1000003; return y ^ (x >>> 5); }
+fns.push(f298);
+function f299(x) { var y = (x * 31 + 5299) % 1000003; return y ^ (x >>> 6); }
+fns.push(f299);
+
+exports.name = 'modF';
+exports.value = fns.reduce(function (acc, f) { return f(acc); }, 12);

--- a/TestRunner/app/tests/concurrentStartup/worker0.js
+++ b/TestRunner/app/tests/concurrentStartup/worker0.js
@@ -1,0 +1,13 @@
+// Entry for WorkerConcurrentStartupTests: loads the fixture modules the
+// parent already compiled (so their code caches are warm) and reports the
+// values it observed, keyed by module name. Each entry uses a different
+// load order so workers starting together read different files at once.
+var values = {};
+values.modA = require("./modA").value;
+values.modB = require("./modB").value;
+values.modC = require("./modC").value;
+values.modD = require("./modD").value;
+values.modE = require("./modE").value;
+values.modF = require("./modF").value;
+
+postMessage({ values: values });

--- a/TestRunner/app/tests/concurrentStartup/worker1.js
+++ b/TestRunner/app/tests/concurrentStartup/worker1.js
@@ -1,0 +1,13 @@
+// Entry for WorkerConcurrentStartupTests: loads the fixture modules the
+// parent already compiled (so their code caches are warm) and reports the
+// values it observed, keyed by module name. Each entry uses a different
+// load order so workers starting together read different files at once.
+var values = {};
+values.modB = require("./modB").value;
+values.modC = require("./modC").value;
+values.modD = require("./modD").value;
+values.modE = require("./modE").value;
+values.modF = require("./modF").value;
+values.modA = require("./modA").value;
+
+postMessage({ values: values });

--- a/TestRunner/app/tests/concurrentStartup/worker2.js
+++ b/TestRunner/app/tests/concurrentStartup/worker2.js
@@ -1,0 +1,13 @@
+// Entry for WorkerConcurrentStartupTests: loads the fixture modules the
+// parent already compiled (so their code caches are warm) and reports the
+// values it observed, keyed by module name. Each entry uses a different
+// load order so workers starting together read different files at once.
+var values = {};
+values.modC = require("./modC").value;
+values.modD = require("./modD").value;
+values.modE = require("./modE").value;
+values.modF = require("./modF").value;
+values.modA = require("./modA").value;
+values.modB = require("./modB").value;
+
+postMessage({ values: values });

--- a/TestRunner/app/tests/concurrentStartup/worker3.js
+++ b/TestRunner/app/tests/concurrentStartup/worker3.js
@@ -1,0 +1,13 @@
+// Entry for WorkerConcurrentStartupTests: loads the fixture modules the
+// parent already compiled (so their code caches are warm) and reports the
+// values it observed, keyed by module name. Each entry uses a different
+// load order so workers starting together read different files at once.
+var values = {};
+values.modD = require("./modD").value;
+values.modE = require("./modE").value;
+values.modF = require("./modF").value;
+values.modA = require("./modA").value;
+values.modB = require("./modB").value;
+values.modC = require("./modC").value;
+
+postMessage({ values: values });

--- a/TestRunner/app/tests/concurrentStartup/worker4.js
+++ b/TestRunner/app/tests/concurrentStartup/worker4.js
@@ -1,0 +1,13 @@
+// Entry for WorkerConcurrentStartupTests: loads the fixture modules the
+// parent already compiled (so their code caches are warm) and reports the
+// values it observed, keyed by module name. Each entry uses a different
+// load order so workers starting together read different files at once.
+var values = {};
+values.modE = require("./modE").value;
+values.modF = require("./modF").value;
+values.modA = require("./modA").value;
+values.modB = require("./modB").value;
+values.modC = require("./modC").value;
+values.modD = require("./modD").value;
+
+postMessage({ values: values });

--- a/TestRunner/app/tests/concurrentStartup/worker5.js
+++ b/TestRunner/app/tests/concurrentStartup/worker5.js
@@ -1,0 +1,13 @@
+// Entry for WorkerConcurrentStartupTests: loads the fixture modules the
+// parent already compiled (so their code caches are warm) and reports the
+// values it observed, keyed by module name. Each entry uses a different
+// load order so workers starting together read different files at once.
+var values = {};
+values.modF = require("./modF").value;
+values.modA = require("./modA").value;
+values.modB = require("./modB").value;
+values.modC = require("./modC").value;
+values.modD = require("./modD").value;
+values.modE = require("./modE").value;
+
+postMessage({ values: values });

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -130,6 +130,7 @@ require("./MetadataTests");
 require("./ApiTests");
 require("./NsRuntimeTests");
 require("./GCFinalizerTests");
+require("./WorkerConcurrentStartupTests");
 require("./DeclarationConflicts");
 //
 require("./Promises");


### PR DESCRIPTION
## Crash

Production crash reports from an app that starts several Workers at launch (every event within ~5s of app start):

```
EXC_BAD_ACCESS (null dereference)
v8::internal::Deserializer<T>::ReadObject
  ← v8::internal::CodeSerializer::Deserialize
  ← v8::ScriptCompiler::Compile (kConsumeCodeCache)
  ← tns::ModuleInternal::LoadClassicScript
  ← require() chain from a Worker entry
  ← tns::Worker::ConstructorCallback lambda (worker looper thread)
```

In every event a **second** worker thread is in the exact same frame at the same moment: also starting, also inside `LoadClassicScript` consuming a code cache. The app spins up several workers at launch, and each one `require`s shared chunks.

## Root cause

`tns::ReadBinary` (and the 3-arg `tns::ReadText`) served every file up to 1 MiB out of a **process-global static buffer**:

```cpp
uint8_t* BinBuffer = new uint8_t[BUFFER_SIZE];
...
fread(BinBuffer, 1, length, file);
return BinBuffer;   // BufferNotOwned
```

`LoadScriptCache` handed that pointer to V8 as `CachedData(BufferNotOwned)`, and V8 reads it for the whole duration of `CodeSerializer::Deserialize`. Two worker threads starting concurrently both `fread` their code caches into the same buffer, so one thread's deserializer walks bytes that the other thread is overwriting with a different file. Release V8 does not checksum code caches (only the header is sanity-checked), so the corrupted payload is deserialized until a bad pointer is followed.

Every worker thread and the main thread share this buffer; the race only needs two module loads to overlap, which launching workers together guarantees.

## Fix

- **`ReadBinary` / `ReadText`** always read into storage private to the call. `ReadBinary` returns a caller-owned heap buffer and `LoadScriptCache` uses `BufferOwned`, so V8 frees it with the `Source`. The 3-arg `ReadText` overload (same shared `Buffer`) is removed; the `std::string` overload reads directly into the string.
- **`WriteBinary`** writes through a `mkstemp` temp file in the cache directory and `rename`s over the target, and stamps the source's mtime on the temp file before publishing. A reader on another thread now sees either the previous complete cache or the new one, never a half-written file, and two workers compiling the same module for the first time no longer interleave writes into one file. Both `SaveScriptCache` overloads share one helper for this.

## Test

`WorkerConcurrentStartupTests` (TestRunner): the parent compiles six ~28 KB fixture modules (warming their caches), six worker entries that `require` those modules in rotated orders are each run once to warm their own caches, then 12 workers (two per entry) start together and every one must report the same fixture values. The rotation matters: workers loading the same files in the same order write identical bytes into the shared buffer and never corrupt each other, which is why the first draft of the spec passed on unfixed code.

The regular suite builds Debug, where `IsDebug` disables code caches, so the spec cannot bite there; it was verified with a Release build of TestRunner on the simulator:

| Build | Runtime | Result |
| --- | --- | --- |
| Release | main (unfixed) | spec **fails**: 11 of 12 batch workers report wrong values, several with one module evaluating to *another module's* value (the deserializer consumed the bytes another thread had just read into the shared buffer); 1 worker never reports |
| Release | this PR | spec **passes**; 1511 specs, only the 20 Release-inherent HTTP ESM loader failures remain (same set as on unfixed main) |
| Debug | this PR | 1513 / 0 failures / 0 errors (TestRunner, iOS Simulator) |

(The 20 HTTP ESM loader specs fail in any Release run because remote module loading is disabled outside dev builds; they are unrelated and identical with and without this change.)

## Notes

- The same `BinBuffer` path also served ES-module caches (`.mcache`) and any other future `ReadBinary` caller; all are covered.
- Not in scope: `ReadModule` (the common CommonJS wrap path) already allocated per call and was never affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved binary file handling for incomplete, empty, or missing data.
  - File updates are now written atomically, reducing the risk of corrupted files.
  - Preserved file modification times when generating cached script data.
  - Improved reliability when loading and saving script cache data.

- **Tests**
  - Added coverage for concurrently starting multiple workers.
  - Added validation that modules load correctly and produce consistent results during concurrent startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
