### PR TITLE
fix(runtime): keep the V8 platform and main Runtime alive through exit()

### DIFF
--- a/NativeScript/NativeScript.mm
+++ b/NativeScript/NativeScript.mm
@@ -45,9 +45,11 @@ extern char defaultStartOfMetadataSection __asm("section$start$__DATA$__TNSMetad
 // A dying process needs no teardown; shutdownRuntime is the deliberate path.
 Runtime* runtime_ = nullptr;
 
+// Cleared before ~Runtime runs so no caller sees a runtime mid-destruction.
 static void DestroyMainRuntime() {
-  delete runtime_;
+  Runtime* runtime = runtime_;
   runtime_ = nullptr;
+  delete runtime;
 }
 
 - (void)runMainApplication {

--- a/NativeScript/NativeScript.mm
+++ b/NativeScript/NativeScript.mm
@@ -39,7 +39,16 @@ extern char defaultStartOfMetadataSection __asm("section$start$__DATA$__TNSMetad
   tns::Tasks::Drain();
 }
 
-std::unique_ptr<Runtime> runtime_;
+// A raw pointer so that exit() never runs ~Runtime from a static destructor:
+// exit() can come from any thread while the main thread and every worker are
+// still live, and a teardown then races them and the other static destructors.
+// A dying process needs no teardown; shutdownRuntime is the deliberate path.
+Runtime* runtime_ = nullptr;
+
+static void DestroyMainRuntime() {
+  delete runtime_;
+  runtime_ = nullptr;
+}
 
 - (void)runMainApplication {
   runtime_->RunMainScript();
@@ -141,9 +150,7 @@ std::unique_ptr<Runtime> runtime_;
     Console::DetachInspectorClient();
   }
   tns::Tasks::ClearTasks();
-  if (runtime_ != nullptr) {
-    runtime_ = nullptr;
-  }
+  DestroyMainRuntime();
 }
 
 - (instancetype)initializeWithConfig:(Config*)config {
@@ -165,8 +172,8 @@ std::unique_ptr<Runtime> runtime_;
     RuntimeConfig.LogToSystemConsole = [config LogToSystemConsole];
 
     Runtime::Initialize();
-    runtime_ = nullptr;
-    runtime_ = std::make_unique<Runtime>();
+    DestroyMainRuntime();
+    runtime_ = new Runtime();
 
     std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
     Isolate* isolate = runtime_->CreateIsolate();
@@ -181,7 +188,7 @@ std::unique_ptr<Runtime> runtime_;
       Isolate::Scope isolate_scope(isolate);
       HandleScope handle_scope(isolate);
       v8_inspector::JsV8InspectorClient* inspectorClient =
-          new v8_inspector::JsV8InspectorClient(runtime_.get());
+          new v8_inspector::JsV8InspectorClient(runtime_);
       inspectorClient->init();
       inspectorClient->registerModules();
       inspectorClient->connect([config ArgumentsCount], [config Arguments]);

--- a/NativeScript/runtime/Runtime.h
+++ b/NativeScript/runtime/Runtime.h
@@ -100,7 +100,7 @@ class Runtime {
     return currentRuntime_->IsRuntimeWorker();
   }
 
-  static std::shared_ptr<v8::Platform> GetPlatform() { return platform_; }
+  static v8::Platform* GetPlatform() { return platform_; }
 
   static id GetAppConfigValue(std::string key);
 
@@ -119,9 +119,6 @@ class Runtime {
   static napi_env GetNapiEnvIfAlive(const Runtime* runtime);
 
   // Milliseconds since this runtime's time origin, on the monotonic clock.
-  // Not inline on purpose: an inline definition would have to reach the
-  // platform through GetPlatform(), which copies a shared_ptr on every call,
-  // while the out-of-line definition reads platform_ directly.
   double PerformanceNowMillis();
 
   // Wall-clock milliseconds since the Unix epoch at the moment the time origin
@@ -138,7 +135,10 @@ class Runtime {
 
  private:
   static thread_local Runtime* currentRuntime_;
-  static std::shared_ptr<v8::Platform> platform_;
+  // Lives until the process dies and is never deleted: V8 holds it by raw
+  // pointer for every isolate, and exit() runs static destructors while the
+  // main thread and worker threads are still tearing isolates down.
+  static v8::Platform* platform_;
   static std::vector<v8::Isolate*> isolates_;
   static SpinMutex isolatesMutex_;
   static bool v8Initialized_;

--- a/NativeScript/runtime/Runtime.h
+++ b/NativeScript/runtime/Runtime.h
@@ -171,13 +171,9 @@ class Runtime {
   CFRunLoopObserverRef rejectionObserver_ = nullptr;
   double timeOriginMonotonic_;
   double timeOriginRealtimeMs_;
-  // TODO: refactor this. This is only needed because, during program
-  // termination (UIApplicationMain not called) the Cache::Workers is released
-  // (static initialization order fiasco
-  // https://en.cppreference.com/w/cpp/language/siof) so it released the
-  // Cache::Workers shared_ptr and then releases the Runtime unique_ptr
-  // eventually we just need to refactor so that Runtime::Initialize is
-  // responsible for its initalization and lifecycle
+  // Keeps Caches::Workers alive for as long as this runtime exists: ~Runtime
+  // reads it, and a worker runtime can be deleted on its own thread while
+  // exit() is already running static destructors on another.
   std::shared_ptr<ConcurrentMap<int, std::shared_ptr<Caches::WorkerState>>>
       workerCache_;
 };

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -193,12 +193,10 @@ bool isErrorDisplayShowing = false;
 // kCFTimeZoneSystemTimeZoneDidChangeNotification, NULL);
 
 void DisposeIsolateWhenPossible(Isolate* isolate) {
-  // most of the time, this will never delay disposal
-  // occasionally this can happen when the runtime is destroyed by actions of its own isolate
-  // as an example: isolate calls exit(0), which in turn destroys the Runtime unique_ptr
-  // another scenario is when embedding nativescript, if the embedder deletes the runtime as a
-  // result of a callback from JS in the case of exit(0), the app will die before actually disposing
-  // the isolate, which isn't a problem
+  // Disposal is deferred only while the isolate is still entered, which happens
+  // when the runtime is deleted by code running inside its own isolate: an
+  // embedder calling shutdownRuntime from a JS callback. exit() never deletes a
+  // runtime, so a process that is dying leaves its isolates to the OS.
   if (isolate->IsInUse()) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_MSEC)),
                    dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -331,9 +331,9 @@ Isolate* Runtime::CreateIsolate() {
 
     // wrap the default platform so foreground tasks ride each runtime
     // thread's CFRunLoop instead of sitting in never-pumped libplatform queues
-    Runtime::platform_ = std::make_shared<NativeScriptPlatform>(platform::NewDefaultPlatform());
+    Runtime::platform_ = new NativeScriptPlatform(platform::NewDefaultPlatform());
 
-    V8::InitializePlatform(Runtime::platform_.get());
+    V8::InitializePlatform(Runtime::platform_);
     V8::Initialize();
     v8Initialized_ = true;
   }
@@ -781,7 +781,7 @@ napi_env Runtime::GetNapiEnvIfAlive(const Runtime* runtime) {
   return nullptr;
 }
 
-std::shared_ptr<Platform> Runtime::platform_;
+Platform* Runtime::platform_ = nullptr;
 std::vector<Isolate*> Runtime::isolates_;
 bool Runtime::v8Initialized_ = false;
 thread_local Runtime* Runtime::currentRuntime_ = nullptr;


### PR DESCRIPTION
## Crash

Production crash reports show `EXC_BAD_ACCESS` at `0x80` in `v8::internal::TracingCpuProfilerImpl::~TracingCpuProfilerImpl`, reached from `Isolate::Deinit` while a worker thread deletes its `Runtime`. Only seen with the app suspended, on iOS 26+.

## Root cause

Disassembling the destructor in the prebuilt `libv8_base_without_compiler.a` shows the faulting sequence: it calls `V8::GetCurrentPlatform()`, loads the returned object's vtable pointer, then loads slot `0x80` (`GetTracingController`). A fault at exactly `0x80` means the vtable word read as zero, i.e. the platform object had been freed (iOS 26+ zeroes on free).

The thread list explains the free: a BackBoard connection-invalidation handler is calling `exit()`, and `__cxa_finalize_ranges` is already inside `tns::Runtime::~Runtime` for the **main** runtime, blocked in an ObjC dealloc that waits on XPC. That is how iOS reclaims a suspended app in-process, and it runs the C++ static destructors while the main thread and every worker thread are still live.

Two file-scope globals had non-trivial destructors:

- `Runtime::platform_` (`std::shared_ptr<v8::Platform>`) freed the platform, which V8 still holds by raw pointer for every isolate.
- `runtime_` in `NativeScript.mm` (`std::unique_ptr<Runtime>`) ran `~Runtime` on the exiting thread: terminated every worker, took the main isolate's `Locker`, deallocated JS-owned ObjC objects, and disposed the main isolate under a running main thread.

Sequence: exit frees the platform, main `~Runtime` terminates the workers, a worker thread deletes its own `Runtime`, disposes its isolate, and the profiler destructor dereferences the freed platform.

## Fix

Neither object is destroyed at process exit any more.

- `Runtime::platform_` is a raw `v8::Platform*` created once and never deleted. `GetPlatform()` returns the raw pointer; its single external caller (the inspector tracing agent) is unchanged.
- `runtime_` is a raw `Runtime*` deleted only by `shutdownRuntime` and before re-initialization, so the embedding paths (`initWithConfig`, `restartWithConfig`, `shutdownRuntime`) keep their explicit, in-order teardown.

A dying process needs no teardown; the OS reclaims everything.

## Verification

| Run | Result |
| --- | --- |
| TestRunner suite, Debug, iOS Simulator, first commit | 1513 tests, 0 failures, 11 skipped (baseline) |
| Same, after the pointer-order follow-up | 1513 tests, 1 failure, 11 skipped |

The one failure in the second run is the `NSURLSession downloadTask` spec in ApiTests timing out on a 2.3 MB Wikimedia download; the same download took 5.5 s from the shell at that moment against Jasmine's 5 s default, so it is network timing, not this change.

There is no in-process reproduction for a BackBoard-initiated `exit()`, so the fix is argued from the disassembly and the thread list rather than a repro.

## Notes

- The inspector Tracing domain is not involved: the tracing agent only starts and stops tracing and never replaces the controller, and none of it runs in release builds.
- Other static-storage objects (caches, registries) are still destroyed at exit while threads run. With no runtime teardown triggered from exit the window is much smaller, but this does not make `exit()` with live JS threads fully safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime shutdown behavior to prevent crashes or undefined behavior while the application’s main thread and workers are still active.
  * Ensured existing runtimes are fully released before creating new ones.
  * Improved cleanup handling when shutting down the JavaScript runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->