### PR TITLE
feat(worker): accept platform options under ios, deprecate iosPriority

### DIFF
--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <thread>
 
 #include "Common.h"
@@ -548,7 +549,8 @@ class WorkerWrapper : public BaseDataWrapper {
   void DestroyInspector();
 
   void Start(std::shared_ptr<v8::Persistent<v8::Value>> poWorker,
-             std::function<v8::Isolate*()> func, int qualityOfService = -1);
+             std::function<v8::Isolate*()> func,
+             std::optional<int> qualityOfService = std::nullopt);
   void CallOnErrorHandlers(v8::TryCatch& tc);
   // Reports a rejected entry-evaluation promise. A rejection carries a reason
   // rather than a TryCatch, so it cannot go through CallOnErrorHandlers, but it

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -1,6 +1,8 @@
 #include "Worker.h"
 #include <pthread.h>
 #include <functional>
+#include <mutex>
+#include <optional>
 #include "Caches.h"
 #include "Constants.h"
 #include "Helpers.h"
@@ -16,6 +18,85 @@ using namespace v8;
 namespace tns {
 
 std::vector<std::string> Worker::GlobalFunctions = {"postMessage", "close"};
+
+namespace {
+
+// The five names below are the whole public priority surface; anything else is
+// a caller error under `ios.priority` and ignored under the deprecated
+// `iosPriority`.
+bool MapPriorityName(const std::string& name, int& qos) {
+  if (name == "userInteractive") {
+    qos = NSQualityOfServiceUserInteractive;
+  } else if (name == "userInitiated") {
+    qos = NSQualityOfServiceUserInitiated;
+  } else if (name == "default") {
+    qos = NSQualityOfServiceDefault;
+  } else if (name == "utility") {
+    qos = NSQualityOfServiceUtility;
+  } else if (name == "background") {
+    qos = NSQualityOfServiceBackground;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+// Carries a real TypeError instance so `catch (e) { e instanceof TypeError }`
+// holds in JS; the constructor's catch block rethrows it unchanged.
+[[noreturn]] void ThrowOptionTypeError(Isolate* isolate, const std::string& message) {
+  Local<Value> error = Exception::TypeError(tns::ToV8String(isolate, message));
+  throw NativeScriptException(isolate, error, message);
+}
+
+// Returns the quality of service the caller asked for, or nullopt to leave the
+// worker thread at the operation queue's own default.
+std::optional<int> ParseQualityOfService(Isolate* isolate, Local<Context> context,
+                                         Local<Object> options) {
+  std::optional<int> qos;
+
+  Local<Value> iosVal;
+  if (options->Get(context, tns::ToV8String(isolate, "ios")).ToLocal(&iosVal) &&
+      !iosVal->IsUndefined()) {
+    if (!iosVal->IsObject()) {
+      ThrowOptionTypeError(isolate, "Worker option \"ios\" must be an object.");
+    }
+
+    Local<Value> priorityVal;
+    if (iosVal.As<Object>()
+            ->Get(context, tns::ToV8String(isolate, "priority"))
+            .ToLocal(&priorityVal) &&
+        !priorityVal->IsUndefined()) {
+      int mapped;
+      if (!IsString(priorityVal) || !MapPriorityName(ToString(isolate, priorityVal), mapped)) {
+        ThrowOptionTypeError(isolate,
+                             "Worker option \"ios.priority\" must be one of \"userInteractive\", "
+                             "\"userInitiated\", \"default\", \"utility\" or \"background\".");
+      }
+      qos = mapped;
+    }
+  }
+
+  Local<Value> legacyVal;
+  if (options->Get(context, tns::ToV8String(isolate, "iosPriority")).ToLocal(&legacyVal) &&
+      !legacyVal->IsUndefined()) {
+    static std::once_flag warnedDeprecated;
+    std::call_once(warnedDeprecated, []() {
+      Log(@"NativeScript: the Worker option \"iosPriority\" is deprecated. Use "
+          @"\"ios\": { \"priority\": ... } instead.");
+    });
+
+    int mapped;
+    // Lenient by contract: an unusable legacy value is ignored, never fatal.
+    if (!qos.has_value() && IsString(legacyVal) &&
+        MapPriorityName(ToString(isolate, legacyVal), mapped)) {
+      qos = mapped;
+    }
+  }
+
+  return qos;
+}
+
+}  // namespace
 
 void Worker::Init(Isolate* isolate, Local<ObjectTemplate> globalTemplate) {
   Worker::Init(isolate, globalTemplate, Caches::Get(isolate)->isWorker);
@@ -148,25 +229,9 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
       }
     }
 
-    int qos = -1;
+    std::optional<int> qos;
     if (info.Length() >= 2 && info[1]->IsObject()) {
-      Local<Object> options = info[1].As<Object>();
-      Local<Value> iosPriorityVal;
-      if (options->Get(context, tns::ToV8String(isolate, "iosPriority")).ToLocal(&iosPriorityVal) &&
-          IsString(iosPriorityVal)) {
-        std::string priority = ToString(isolate, iosPriorityVal);
-        if (priority == "userInteractive") {
-          qos = NSQualityOfServiceUserInteractive;
-        } else if (priority == "userInitiated") {
-          qos = NSQualityOfServiceUserInitiated;
-        } else if (priority == "default") {
-          qos = NSQualityOfServiceDefault;
-        } else if (priority == "utility") {
-          qos = NSQualityOfServiceUtility;
-        } else if (priority == "background") {
-          qos = NSQualityOfServiceBackground;
-        }
-      }
+      qos = ParseQualityOfService(isolate, context, info[1].As<Object>());
     }
 
     WorkerWrapper* worker = new WorkerWrapper(isolate, Worker::OnMessageCallback);

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -48,24 +48,33 @@ bool MapPriorityName(const std::string& name, int& qos) {
   throw NativeScriptException(isolate, error, message);
 }
 
-// Returns the quality of service the caller asked for, or nullopt to leave the
-// worker thread at the operation queue's own default.
-std::optional<int> ParseQualityOfService(Isolate* isolate, Local<Context> context,
-                                         Local<Object> options) {
-  std::optional<int> qos;
+// Reads `key` from `object`. A false return means the getter threw: the
+// exception is already pending on the isolate and construction must stop
+// without running anything else on it.
+bool ReadOption(Isolate* isolate, Local<Context> context, Local<Object> object, const char* key,
+                Local<Value>& out) {
+  return object->Get(context, tns::ToV8String(isolate, key)).ToLocal(&out);
+}
 
+// Fills `qos` with the quality of service the caller asked for, or leaves it
+// empty for the operation queue's own default. Returns false when a getter
+// threw (see ReadOption).
+bool ParseQualityOfService(Isolate* isolate, Local<Context> context, Local<Object> options,
+                           std::optional<int>& qos) {
   Local<Value> iosVal;
-  if (options->Get(context, tns::ToV8String(isolate, "ios")).ToLocal(&iosVal) &&
-      !iosVal->IsNullOrUndefined()) {
+  if (!ReadOption(isolate, context, options, "ios", iosVal)) {
+    return false;
+  }
+  if (!iosVal->IsNullOrUndefined()) {
     if (!iosVal->IsObject()) {
       ThrowOptionTypeError(isolate, "Worker option \"ios\" must be an object.");
     }
 
     Local<Value> priorityVal;
-    if (iosVal.As<Object>()
-            ->Get(context, tns::ToV8String(isolate, "priority"))
-            .ToLocal(&priorityVal) &&
-        !priorityVal->IsUndefined()) {
+    if (!ReadOption(isolate, context, iosVal.As<Object>(), "priority", priorityVal)) {
+      return false;
+    }
+    if (!priorityVal->IsUndefined()) {
       int mapped;
       if (!IsString(priorityVal) || !MapPriorityName(ToString(isolate, priorityVal), mapped)) {
         ThrowOptionTypeError(isolate,
@@ -77,8 +86,10 @@ std::optional<int> ParseQualityOfService(Isolate* isolate, Local<Context> contex
   }
 
   Local<Value> legacyVal;
-  if (options->Get(context, tns::ToV8String(isolate, "iosPriority")).ToLocal(&legacyVal) &&
-      !legacyVal->IsUndefined()) {
+  if (!ReadOption(isolate, context, options, "iosPriority", legacyVal)) {
+    return false;
+  }
+  if (!legacyVal->IsUndefined()) {
     static std::once_flag warnedDeprecated;
     std::call_once(warnedDeprecated, []() {
       Log(@"NativeScript: the Worker option \"iosPriority\" is deprecated. Use "
@@ -93,7 +104,7 @@ std::optional<int> ParseQualityOfService(Isolate* isolate, Local<Context> contex
     }
   }
 
-  return qos;
+  return true;
 }
 
 }  // namespace
@@ -231,7 +242,9 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
 
     std::optional<int> qos;
     if (info.Length() >= 2 && info[1]->IsObject()) {
-      qos = ParseQualityOfService(isolate, context, info[1].As<Object>());
+      if (!ParseQualityOfService(isolate, context, info[1].As<Object>(), qos)) {
+        return;
+      }
     }
 
     WorkerWrapper* worker = new WorkerWrapper(isolate, Worker::OnMessageCallback);

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -56,7 +56,7 @@ std::optional<int> ParseQualityOfService(Isolate* isolate, Local<Context> contex
 
   Local<Value> iosVal;
   if (options->Get(context, tns::ToV8String(isolate, "ios")).ToLocal(&iosVal) &&
-      !iosVal->IsUndefined()) {
+      !iosVal->IsNullOrUndefined()) {
     if (!iosVal->IsObject()) {
       ThrowOptionTypeError(isolate, "Worker option \"ios\" must be an object.");
     }

--- a/NativeScript/runtime/WorkerWrapper.mm
+++ b/NativeScript/runtime/WorkerWrapper.mm
@@ -73,7 +73,7 @@ void WorkerWrapper::PostMessage(std::shared_ptr<worker::Message> message) {
 }
 
 void WorkerWrapper::Start(std::shared_ptr<Persistent<Value>> poWorker,
-                          std::function<Isolate*()> func, int qualityOfService) {
+                          std::function<Isolate*()> func, std::optional<int> qualityOfService) {
   this->poWorker_ = poWorker;
   this->workerId_ = nextId_.fetch_add(1, std::memory_order_relaxed) + 1;
 
@@ -81,8 +81,8 @@ void WorkerWrapper::Start(std::shared_ptr<Persistent<Value>> poWorker,
     this->BackgroundLooper(func);
   }];
 
-  if (qualityOfService >= 0) {
-    op.qualityOfService = static_cast<NSQualityOfService>(qualityOfService);
+  if (qualityOfService.has_value()) {
+    op.qualityOfService = static_cast<NSQualityOfService>(*qualityOfService);
   }
 
   [workers_ addOperation:op];

--- a/TestRunner/app/tests/WorkerOptionsTests.js
+++ b/TestRunner/app/tests/WorkerOptionsTests.js
@@ -2,11 +2,13 @@ describe("Worker platform options", function () {
     var entry = "./workerOptions/qosWorker.js";
 
     // Jasmine arms a spec's async timeout before calling it, so the interval
-    // has to be raised ahead of the spec, not inside it.
+    // has to be raised ahead of the spec, not inside it. A utility or
+    // background thread boots a whole isolate under throttled CPU and I/O, and
+    // on a contended CI host that alone has taken over 30 s.
     var originalTimeout;
     beforeEach(function () {
         originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
     });
     afterEach(function () {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;

--- a/TestRunner/app/tests/WorkerOptionsTests.js
+++ b/TestRunner/app/tests/WorkerOptionsTests.js
@@ -2,9 +2,9 @@ describe("Worker platform options", function () {
     var entry = "./workerOptions/qosWorker.js";
 
     // Jasmine arms a spec's async timeout before calling it, so the interval
-    // has to be raised ahead of the spec, not inside it. A utility or
-    // background thread boots a whole isolate under throttled CPU and I/O, and
-    // on a contended CI host that alone has taken over 30 s.
+    // has to be raised ahead of the spec, not inside it. A utility thread boots
+    // a whole isolate under throttled CPU and I/O; on a contended host that has
+    // taken well over 10 s.
     var originalTimeout;
     beforeEach(function () {
         originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -35,12 +35,15 @@ describe("Worker platform options", function () {
         };
     };
 
+    // Background is deliberately absent: the system defines that class as work
+    // that may take minutes, and on a loaded host a background thread has not
+    // finished booting an isolate within two minutes. It is covered below
+    // without waiting on it.
     var priorities = [
         ["userInteractive", NSQualityOfService.UserInteractive],
         ["userInitiated", NSQualityOfService.UserInitiated],
         ["default", NSQualityOfService.Default],
-        ["utility", NSQualityOfService.Utility],
-        ["background", NSQualityOfService.Background]
+        ["utility", NSQualityOfService.Utility]
     ];
 
     priorities.forEach(function (pair) {
@@ -49,6 +52,14 @@ describe("Worker platform options", function () {
                 expect(qos).toBe(pair[1]);
             });
         });
+    });
+
+    it("accepts background priority", function () {
+        var worker;
+        expect(function () {
+            worker = new Worker(entry, { ios: { priority: "background" } });
+        }).not.toThrow();
+        worker.terminate();
     });
 
     it("still honors the deprecated iosPriority option", function (done) {
@@ -76,8 +87,8 @@ describe("Worker platform options", function () {
     });
 
     it("treats ios: null like an absent ios", function (done) {
-        reportQos({ ios: null, iosPriority: "background" }, done, function (qos) {
-            expect(qos).toBe(NSQualityOfService.Background);
+        reportQos({ ios: null, iosPriority: "utility" }, done, function (qos) {
+            expect(qos).toBe(NSQualityOfService.Utility);
         });
     });
 

--- a/TestRunner/app/tests/WorkerOptionsTests.js
+++ b/TestRunner/app/tests/WorkerOptionsTests.js
@@ -73,6 +73,12 @@ describe("Worker platform options", function () {
         });
     });
 
+    it("treats ios: null like an absent ios", function (done) {
+        reportQos({ ios: null, iosPriority: "background" }, done, function (qos) {
+            expect(qos).toBe(NSQualityOfService.Background);
+        });
+    });
+
     it("throws a TypeError when ios is not an object", function () {
         expect(function () {
             new Worker(entry, { ios: 42 });

--- a/TestRunner/app/tests/WorkerOptionsTests.js
+++ b/TestRunner/app/tests/WorkerOptionsTests.js
@@ -25,13 +25,21 @@ describe("Worker platform options", function () {
             worker.terminate();
             done();
         };
+        // A throw inside either handler must still settle the spec and
+        // terminate the worker; Jasmine only guards the spec body itself.
         worker.onmessage = function (msg) {
-            check(msg.data.qos);
-            finish();
+            try {
+                check(msg.data.qos);
+            } finally {
+                finish();
+            }
         };
         worker.onerror = function (e) {
-            expect(String(e && e.message ? e.message : e)).toBe("<no worker error>");
-            finish();
+            try {
+                expect(String(e && e.message ? e.message : e)).toBe("<no worker error>");
+            } finally {
+                finish();
+            }
         };
     };
 
@@ -90,6 +98,25 @@ describe("Worker platform options", function () {
         reportQos({ ios: null, iosPriority: "utility" }, done, function (qos) {
             expect(qos).toBe(NSQualityOfService.Utility);
         });
+    });
+
+    it("propagates the error thrown by an option getter", function () {
+        var boom = new Error("boom");
+        var options = new Proxy({}, {
+            get: function (target, key) {
+                if (key === "ios") {
+                    throw boom;
+                }
+                return undefined;
+            }
+        });
+        var thrown;
+        try {
+            new Worker(entry, options);
+        } catch (e) {
+            thrown = e;
+        }
+        expect(thrown).toBe(boom);
     });
 
     it("throws a TypeError when ios is not an object", function () {

--- a/TestRunner/app/tests/WorkerOptionsTests.js
+++ b/TestRunner/app/tests/WorkerOptionsTests.js
@@ -1,0 +1,93 @@
+describe("Worker platform options", function () {
+    var entry = "./workerOptions/qosWorker.js";
+
+    // Jasmine arms a spec's async timeout before calling it, so the interval
+    // has to be raised ahead of the spec, not inside it.
+    var originalTimeout;
+    beforeEach(function () {
+        originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+    });
+    afterEach(function () {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+    });
+
+    var reportQos = function (options, done, check) {
+        var worker = options === undefined ? new Worker(entry) : new Worker(entry, options);
+        var settled = false;
+        var finish = function () {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            worker.terminate();
+            done();
+        };
+        worker.onmessage = function (msg) {
+            check(msg.data.qos);
+            finish();
+        };
+        worker.onerror = function (e) {
+            expect(String(e && e.message ? e.message : e)).toBe("<no worker error>");
+            finish();
+        };
+    };
+
+    var priorities = [
+        ["userInteractive", NSQualityOfService.UserInteractive],
+        ["userInitiated", NSQualityOfService.UserInitiated],
+        ["default", NSQualityOfService.Default],
+        ["utility", NSQualityOfService.Utility],
+        ["background", NSQualityOfService.Background]
+    ];
+
+    priorities.forEach(function (pair) {
+        it("runs the worker thread at " + pair[0] + " quality of service", function (done) {
+            reportQos({ ios: { priority: pair[0] } }, done, function (qos) {
+                expect(qos).toBe(pair[1]);
+            });
+        });
+    });
+
+    it("still honors the deprecated iosPriority option", function (done) {
+        reportQos({ iosPriority: "utility" }, done, function (qos) {
+            expect(qos).toBe(NSQualityOfService.Utility);
+        });
+    });
+
+    it("prefers ios.priority over iosPriority when both are given", function (done) {
+        reportQos({ ios: { priority: "userInteractive" }, iosPriority: "background" }, done, function (qos) {
+            expect(qos).toBe(NSQualityOfService.UserInteractive);
+        });
+    });
+
+    it("ignores unknown keys inside ios", function (done) {
+        reportQos({ ios: { priority: "utility", somethingElse: 42 } }, done, function (qos) {
+            expect(qos).toBe(NSQualityOfService.Utility);
+        });
+    });
+
+    it("starts a worker given no options at all", function (done) {
+        reportQos(undefined, done, function (qos) {
+            expect(typeof qos).toBe("number");
+        });
+    });
+
+    it("throws a TypeError when ios is not an object", function () {
+        expect(function () {
+            new Worker(entry, { ios: 42 });
+        }).toThrowError(TypeError, /"ios"/);
+    });
+
+    it("throws a TypeError for an unknown ios.priority", function () {
+        expect(function () {
+            new Worker(entry, { ios: { priority: "highest" } });
+        }).toThrowError(TypeError, /"ios\.priority"/);
+    });
+
+    it("throws a TypeError for a non-string ios.priority", function () {
+        expect(function () {
+            new Worker(entry, { ios: { priority: 3 } });
+        }).toThrowError(TypeError, /"ios\.priority"/);
+    });
+});

--- a/TestRunner/app/tests/index.js
+++ b/TestRunner/app/tests/index.js
@@ -131,6 +131,7 @@ require("./ApiTests");
 require("./NsRuntimeTests");
 require("./GCFinalizerTests");
 require("./WorkerConcurrentStartupTests");
+require("./WorkerOptionsTests");
 require("./DeclarationConflicts");
 //
 require("./Promises");

--- a/TestRunner/app/tests/workerOptions/qosWorker.js
+++ b/TestRunner/app/tests/workerOptions/qosWorker.js
@@ -1,0 +1,4 @@
+// Entry for WorkerOptionsTests: reports the quality of service the runtime
+// gave this worker's thread, which is the only observable effect of the
+// `ios.priority` option.
+postMessage({ qos: NSThread.currentThread.qualityOfService });


### PR DESCRIPTION
## What changed

`new Worker(url, options)` now takes its iOS-specific settings under an `ios`
namespace object, so future platform options have a place to live instead of
accumulating as `iosSomething` keys on the top level.

```js
const worker = new Worker("./worker.js", {
  ios: { priority: "userInitiated" },
});
```

`ios.priority` accepts exactly `"userInteractive"`, `"userInitiated"`,
`"default"`, `"utility"` and `"background"`, and maps to the matching
`NSQualityOfService` on the worker thread.

## Deprecation

`options.iosPriority` keeps working unchanged, including its lenient handling of
unrecognized values (they are ignored, not fatal). Passing it logs a one-time
per-process warning pointing at `ios.priority`. When both keys are present,
`ios.priority` wins.

## Validation

| Input | Result |
| --- | --- |
| `ios` present and not an object (`null` counts as absent, as for a WebIDL dictionary) | `TypeError` |
| `ios.priority` not a string | `TypeError` naming `"ios.priority"` |
| `ios.priority` an unknown string | `TypeError` naming `"ios.priority"` |
| unknown keys inside `ios` | ignored (forward compatibility) |
| `iosPriority` with an unknown value | ignored (unchanged) |

The thrown value is a genuine `TypeError` instance, so `e instanceof TypeError`
holds in JS.

Along the way, `"default"` now actually reaches the thread: the quality of
service was carried as an `int` whose "unset" sentinel was `-1`, which is also
the value of `NSQualityOfServiceDefault`, so an explicit `"default"` was
indistinguishable from passing no option at all. It is now a
`std::optional<int>`.

## Verification

TestRunner suite, Debug, iOS Simulator.

| Metric | Count |
| --- | --- |
| tests | 1526 |
| failures | 0 |
| errors | 0 |
| skipped | 11 |

That is the 1513-test baseline plus the 12 specs added here; the skips are unchanged.

## Follow-ups

- `@nativescript/core` typings for `WorkerOptions` need `ios?: { priority?: "userInteractive" | "userInitiated" | "default" | "utility" | "background" }`, with `iosPriority` marked `@deprecated`.
- A stacked PR adds `resourceLimits`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring iOS worker thread quality of service through `ios.priority`.
  - Supports standard priority values, including background execution.
  - Continues to support the deprecated `iosPriority` option, with `ios.priority` taking precedence.

- **Bug Fixes**
  - Added validation for invalid priority configurations, including clear type errors.
  - Worker option getter errors are now propagated correctly.

- **Tests**
  - Added coverage for priority mapping, compatibility behavior, missing or null options, unknown properties, and invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->