### PR TITLE
fix(worker): lifecycle fixes for workers that fail during startup

### DIFF
--- a/NativeScript/runtime/DataWrapper.h
+++ b/NativeScript/runtime/DataWrapper.h
@@ -652,11 +652,9 @@ class WorkerWrapper : public BaseDataWrapper {
                                  const std::string& source,
                                  const std::string& stackTrace, int lineNumber,
                                  bool async);
-  v8::Local<v8::Object> ConstructErrorObject(v8::Local<v8::Context> context,
-                                             std::string message,
-                                             std::string source,
-                                             std::string stackTrace,
-                                             int lineNumber);
+  static v8::Local<v8::Object> ConstructErrorObject(
+      v8::Local<v8::Context> context, std::string message, std::string source,
+      std::string stackTrace, int lineNumber);
 };
 
 }  // namespace tns

--- a/NativeScript/runtime/Runtime.mm
+++ b/NativeScript/runtime/Runtime.mm
@@ -285,11 +285,12 @@ Runtime::~Runtime() {
     IsolateTracked::SweepAll(isolate_);
 
     if (IsRuntimeWorker()) {
-      auto currentWorker =
-          static_cast<WorkerWrapper*>(Caches::Workers->Get(this->workerId_)->UserData());
+      std::shared_ptr<Caches::WorkerState> workerState = Caches::Workers->Get(this->workerId_);
+      WorkerWrapper* currentWorker =
+          workerState == nullptr ? nullptr : static_cast<WorkerWrapper*>(workerState->UserData());
       Caches::Workers->Remove(this->workerId_);
       // if the parent isolate is dead then deleting the wrapper is our responsibility
-      if (currentWorker->IsWeak()) {
+      if (currentWorker != nullptr && currentWorker->IsWeak()) {
         delete currentWorker;
       }
     }

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -550,12 +550,15 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
       return isolate;
     });
 
-    worker->Start(poWorker, func, qos);
-
+    // The registry entry has to exist before the worker can run: the worker
+    // removes it from its own thread when its runtime is deleted, and a worker
+    // that closes or hits its heap limit inside its entry script reaches that
+    // teardown without waiting for anyone.
     std::shared_ptr<Caches::WorkerState> state =
         std::make_shared<Caches::WorkerState>(isolate, poWorker, worker);
-    int workerId = worker->Id();
-    Caches::Workers->Insert(workerId, state);
+    Caches::Workers->Insert(worker->Id(), state);
+
+    worker->Start(poWorker, func, qos);
   } catch (NativeScriptException& ex) {
     ex.ReThrowToV8(isolate);
   }

--- a/NativeScript/runtime/Worker.mm
+++ b/NativeScript/runtime/Worker.mm
@@ -436,7 +436,9 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
       TryCatch tc(isolate);
 
       // If the script can be determined missing up-front, report it through
-      // worker.onerror instead of running (and let the caller terminate us).
+      // worker.onerror instead of running, and stop the worker: there is
+      // nothing left for it to do, so it does not park in its runloop waiting
+      // for the parent to call terminate().
       if (!resolvedPath.empty() && resolvedPath[0] == '/' && !tns::Exists(resolvedPath.c_str())) {
         NSString* path = [NSString stringWithUTF8String:resolvedPath.c_str()];
         if (!tns::Exists([[path stringByAppendingPathExtension:@"js"] fileSystemRepresentation]) &&
@@ -444,6 +446,7 @@ void Worker::ConstructorCallback(const FunctionCallbackInfo<Value>& info) {
                 [[path stringByAppendingPathComponent:@"index.js"] fileSystemRepresentation])) {
           worker->PassUncaughtExceptionFromWorkerToMain(
               "Worker script does not exist: " + resolvedPath, resolvedPath, "", 1, true);
+          worker->Terminate();
           return isolate;
         }
       }

--- a/NativeScript/runtime/WorkerWrapper.mm
+++ b/NativeScript/runtime/WorkerWrapper.mm
@@ -54,7 +54,8 @@ WorkerWrapper::WorkerWrapper(
       isDisposed_(false),
       isWeak_(false),
       messagesEnabled_(false),
-      onMessage_(onMessage) {}
+      onMessage_(onMessage),
+      workerId_(nextId_.fetch_add(1, std::memory_order_relaxed) + 1) {}
 
 const WrapperType WorkerWrapper::Type() { return WrapperType::Worker; }
 
@@ -75,7 +76,10 @@ void WorkerWrapper::PostMessage(std::shared_ptr<worker::Message> message) {
 void WorkerWrapper::Start(std::shared_ptr<Persistent<Value>> poWorker,
                           std::function<Isolate*()> func, std::optional<int> qualityOfService) {
   this->poWorker_ = poWorker;
-  this->workerId_ = nextId_.fetch_add(1, std::memory_order_relaxed) + 1;
+  // Set before the operation is queued: a worker that terminates inside its
+  // entry script clears this flag from its own thread, and a store made after
+  // queueing could land on top of that.
+  this->isRunning_ = true;
 
   NSBlockOperation* op = [NSBlockOperation blockOperationWithBlock:^{
     this->BackgroundLooper(func);
@@ -86,8 +90,6 @@ void WorkerWrapper::Start(std::shared_ptr<Persistent<Value>> poWorker,
   }
 
   [workers_ addOperation:op];
-
-  this->isRunning_ = true;
 }
 
 void WorkerWrapper::DrainPendingTasks() {

--- a/NativeScript/runtime/WorkerWrapper.mm
+++ b/NativeScript/runtime/WorkerWrapper.mm
@@ -448,41 +448,7 @@ void WorkerWrapper::PassUncaughtExceptionFromWorkerToMain(Local<Context> context
     }
   }
 
-  auto runtime = static_cast<Runtime*>(mainIsolate_->GetData(Constants::RUNTIME_SLOT));
-  if (runtime == nullptr) {
-    return;
-  }
-  PostToRuntimeLoop(
-      runtime,
-      [this, message, src, stackTrace, lineNumber]() {
-        v8::Locker locker(this->mainIsolate_);
-        Isolate::Scope isolate_scope(this->mainIsolate_);
-        HandleScope handle_scope(this->mainIsolate_);
-        Local<Object> worker = this->poWorker_->Get(this->mainIsolate_).As<Object>();
-        Local<Context> context = Caches::Get(this->mainIsolate_)->GetContext();
-
-        Local<Value> onErrorVal;
-        bool success = worker->Get(context, tns::ToV8String(this->mainIsolate_, "onerror"))
-                           .ToLocal(&onErrorVal);
-        tns::Assert(success, this->mainIsolate_);
-
-        if (!onErrorVal.IsEmpty() && onErrorVal->IsFunction()) {
-          Local<v8::Function> onErrorFunc = onErrorVal.As<v8::Function>();
-          Local<Object> arg =
-              this->ConstructErrorObject(context, message, src, stackTrace, lineNumber);
-          Local<Value> args[1] = {arg};
-          Local<Value> result;
-          TryCatch tc(this->mainIsolate_);
-          bool success = onErrorFunc->Call(context, v8::Undefined(this->mainIsolate_), 1, args)
-                             .ToLocal(&result);
-          if (!success && tc.HasCaught()) {
-            Local<Value> error = tc.Exception();
-            Log(@"%s", tns::ToString(this->mainIsolate_, error).c_str());
-            this->mainIsolate_->ThrowException(error);
-          }
-        }
-      },
-      async);
+  this->ForwardErrorPayloadToMain(message, src, stackTrace, lineNumber, async);
 }
 
 void WorkerWrapper::PassUncaughtExceptionFromWorkerToMain(const std::string& message,
@@ -509,33 +475,45 @@ void WorkerWrapper::ForwardErrorPayloadToMain(const std::string& message, const 
   if (runtime == nullptr) {
     return;
   }
+  // The task runs later, on the parent's loop, and this wrapper may be gone by
+  // then: a worker that reports and terminates is disposed on its own thread,
+  // after which the parent's finalizer deletes the wrapper as soon as the
+  // Worker object is collected. So the task captures what it needs by value.
+  // The shared_ptr keeps the persistent itself alive; an emptied handle means
+  // the Worker object is gone and there is nothing left to report to.
+  Isolate* mainIsolate = mainIsolate_;
+  std::shared_ptr<Persistent<Value>> poWorker = poWorker_;
   PostToRuntimeLoop(
       runtime,
-      [this, message, source, stackTrace, lineNumber]() {
-        v8::Locker locker(this->mainIsolate_);
-        Isolate::Scope isolate_scope(this->mainIsolate_);
-        HandleScope handle_scope(this->mainIsolate_);
-        Local<Context> context = Caches::Get(this->mainIsolate_)->GetContext();
-        Local<Object> worker = this->poWorker_->Get(this->mainIsolate_).As<Object>();
+      [mainIsolate, poWorker, message, source, stackTrace, lineNumber]() {
+        v8::Locker locker(mainIsolate);
+        Isolate::Scope isolate_scope(mainIsolate);
+        HandleScope handle_scope(mainIsolate);
+        Local<Context> context = Caches::Get(mainIsolate)->GetContext();
+        Local<Value> workerValue = poWorker->Get(mainIsolate);
+        if (workerValue.IsEmpty() || !workerValue->IsObject()) {
+          return;
+        }
+        Local<Object> worker = workerValue.As<Object>();
 
         Local<Value> onErrorVal;
-        bool success = worker->Get(context, tns::ToV8String(this->mainIsolate_, "onerror"))
-                           .ToLocal(&onErrorVal);
-        tns::Assert(success, this->mainIsolate_);
+        bool success =
+            worker->Get(context, tns::ToV8String(mainIsolate, "onerror")).ToLocal(&onErrorVal);
+        tns::Assert(success, mainIsolate);
 
         if (!onErrorVal.IsEmpty() && onErrorVal->IsFunction()) {
           Local<v8::Function> onErrorFunc = onErrorVal.As<v8::Function>();
           Local<Object> arg =
-              this->ConstructErrorObject(context, message, source, stackTrace, lineNumber);
+              ConstructErrorObject(context, message, source, stackTrace, lineNumber);
           Local<Value> args[1] = {arg};
           Local<Value> result;
-          TryCatch tc(this->mainIsolate_);
-          bool success = onErrorFunc->Call(context, v8::Undefined(this->mainIsolate_), 1, args)
-                             .ToLocal(&result);
+          TryCatch tc(mainIsolate);
+          bool success =
+              onErrorFunc->Call(context, v8::Undefined(mainIsolate), 1, args).ToLocal(&result);
           if (!success && tc.HasCaught()) {
             Local<Value> error = tc.Exception();
-            Log(@"%s", tns::ToString(this->mainIsolate_, error).c_str());
-            this->mainIsolate_->ThrowException(error);
+            Log(@"%s", tns::ToString(mainIsolate, error).c_str());
+            mainIsolate->ThrowException(error);
           }
         }
       },


### PR DESCRIPTION
A worker that fails while starting can leave things behind in three ways.

A worker whose entry script does not exist reports the error but keeps running: the startup callback returns without terminating, so the looper enters its runloop and the thread and its isolate stay alive until the parent calls `terminate()`. A parent that only logs the error keeps the worker forever. The worker now terminates itself right after reporting, the way a worker whose entry throws already does.

The worker's registry entry is inserted only after `Start()` has queued the startup operation, because the wrapper takes its id inside `Start()`. A worker whose entry calls `close()` or exhausts its heap right away can delete its runtime before the entry exists: `~Runtime` dereferences the lookup unchecked, and the constructor then publishes an entry for a wrapper that is already disposed. The id is now taken in the wrapper's constructor and the entry is inserted before `Start()`. `isRunning_` is set before the operation is queued for the same reason, so a worker that already terminated is not flipped back to running, and `~Runtime` tolerates an absent entry.

Errors forwarded to `worker.onerror` are posted to the parent's loop as a task that captures the wrapper and reads its main isolate and persistent when it runs. A worker whose entry throws reports, terminates and is disposed on its own thread, after which the parent's finalizer deletes the wrapper the next time the Worker object is collected, so a worker nobody holds a reference to can lose its wrapper before the report runs. The task now captures the isolate and the persistent by value and returns when the handle is empty. The `TryCatch` overload carried a copy of the same task and shares the one path.

No new tests: the first case is covered by the existing missing-script test, where the `terminate()` in the handler becomes a no-op, and the other two depend on thread and GC timing. TestRunner passes on an iPhone 17 simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker startup and shutdown reliability.
  * Prevented crashes when worker state is unavailable during teardown.
  * Worker scripts that cannot be found now report an error and terminate correctly instead of remaining active.
  * Improved error handling for asynchronous worker operations, including cases where a worker has already been destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->