### PR TITLE
fix(runtime): re-check isolate liveness under the Locker in ObjC-to-JS callbacks

### DIFF
--- a/NativeScript/runtime/ArgConverter.mm
+++ b/NativeScript/runtime/ArgConverter.mm
@@ -306,6 +306,15 @@ void ArgConverter::MethodCallback(ffi_cif* cif, void* retValue, void** argValues
 
   {
     v8::Locker locker(isolate);
+    // Checked again with the isolate locked: a runtime being destroyed holds
+    // this lock while it removes its caches, so the check above can pass and
+    // the lock then be granted only once the context is gone. ~Runtime drops
+    // the isolate from the live registry before it takes the lock, which is
+    // what makes this second look reliable.
+    if (!data->isolateWrapper_.IsValid()) {
+      memset(retValue, 0, cif->rtype->size);
+      return;
+    }
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     std::shared_ptr<Caches> cache = Caches::Get(isolate);

--- a/NativeScript/runtime/Interop.mm
+++ b/NativeScript/runtime/Interop.mm
@@ -47,22 +47,26 @@ Interop::JSBlock::JSBlockDescriptor Interop::JSBlock::kJSBlockDescriptor = {
             if (wrapper->isolateWrapper_.IsValid()) {
               Isolate* isolate = wrapper->isolateWrapper_.Isolate();
               v8::Locker locker(isolate);
-              Isolate::Scope isolate_scope(isolate);
-              HandleScope handle_scope(isolate);
-              Local<Value> callback = wrapper->callback_->Get(isolate);
-              if (!callback.IsEmpty() && callback->IsObject()) {
-                // The callback's slot is the cache's owner, so only a wrapper
-                // still sitting in it is ours to free.
-                if (tns::GetValue(isolate, callback) == blockWrapper) {
-                  tns::DeleteValue(isolate, callback);
-                } else {
-                  blockWrapper = nullptr;
+              // Re-checked under the lock: ~Runtime holds it while it tears the
+              // isolate's caches down, so the check above can predate that.
+              if (wrapper->isolateWrapper_.IsValid()) {
+                Isolate::Scope isolate_scope(isolate);
+                HandleScope handle_scope(isolate);
+                Local<Value> callback = wrapper->callback_->Get(isolate);
+                if (!callback.IsEmpty() && callback->IsObject()) {
+                  // The callback's slot is the cache's owner, so only a wrapper
+                  // still sitting in it is ours to free.
+                  if (tns::GetValue(isolate, callback) == blockWrapper) {
+                    tns::DeleteValue(isolate, callback);
+                  } else {
+                    blockWrapper = nullptr;
+                  }
                 }
+                // Unconditional: an already-detached callback still owns its
+                // node, and dropping the persistent without a reset would leave
+                // that node rooted forever.
+                wrapper->callback_->Reset();
               }
-              // Unconditional: an already-detached callback still owns its
-              // node, and dropping the persistent without a reset would leave
-              // that node rooted forever.
-              wrapper->callback_->Reset();
             }
             // Outside the isolate guard: once the isolate is gone the cache
             // slot is unreachable and nothing else can free the wrapper.


### PR DESCRIPTION
An Objective-C callback implemented in JS (an exposed method on an extended class, or a JS block) can be invoked on any thread while the isolate that owns it is being torn down. Both entry points checked the isolate was alive before taking its `Locker`, but `~Runtime` holds that lock while it removes the isolate's caches and clears the context. The pre-lock check could therefore pass, the lock be granted only after the caches were gone, and the callback continue with the dummy cache `Caches::Get` hands out for a disposed isolate, whose context persistent is empty: `Caches::GetContext` then dereferences null.

Seen on the shared spec `Should not crash if the worker registers a notification`, where the worker registers an `NSNotificationCenter` observer, the parent terminates it and posts the notification straight away: the main thread's post raced the worker thread's `~Runtime`, and the crash report shows the observer's `MethodCallback` on the main thread with the worker in `DisposeIsolateWhenPossible`.

Both `ArgConverter::MethodCallback` and the `JSBlock` dispose helper now re-check `IsolateWrapper::IsValid()` once the `Locker` is held. `~Runtime` erases the isolate from the live registry before it takes the lock, which is what makes the second look reliable; a caller that lost the race returns a zeroed result (or skips the persistent reset) instead of touching the dead isolate.

One window stays open and is out of scope here: a `Locker` taken on an isolate between the destructor's unlock and `Isolate::Dispose`. Closing it needs the registry mutex held across the check and the lock acquisition.

Suite: 1543 / 0 locally on top of main (19b880cb).
